### PR TITLE
🎨 Palette: Close DraggableModal on Escape key press

### DIFF
--- a/web/src/__tests__/draggable-modal-drag.test.ts
+++ b/web/src/__tests__/draggable-modal-drag.test.ts
@@ -103,4 +103,24 @@ describe("DraggableModal", () => {
     expect(x).toBeLessThanOrEqual(552);
     expect(y).toBeLessThanOrEqual(402);
   });
+
+  it("emits close when Escape key is pressed", async () => {
+    const wrapper = mount(DraggableModal, {
+      props: { cardVariant: "default" },
+      slots: {
+        default: `<div>Modal Content</div>`,
+      },
+    });
+
+    await nextTick();
+
+    // Dispatch keydown event on window
+    const escapeEvent = new KeyboardEvent("keydown", { key: "Escape" });
+    window.dispatchEvent(escapeEvent);
+
+    expect(wrapper.emitted("close")).toBeTruthy();
+    expect(wrapper.emitted("close")?.length).toBe(1);
+
+    wrapper.unmount();
+  });
 });

--- a/web/src/components/DraggableModal.vue
+++ b/web/src/components/DraggableModal.vue
@@ -148,6 +148,12 @@ function onWindowResize(): void {
   updateBounds();
 }
 
+function onWindowKeydown(ev: KeyboardEvent): void {
+  if (ev.key === "Escape") {
+    emit("close");
+  }
+}
+
 function onOverlayClick(): void {
   if (suppressOverlayClick) {
     return;
@@ -158,10 +164,12 @@ function onOverlayClick(): void {
 onMounted(() => {
   updateBounds();
   window.addEventListener("resize", onWindowResize, { passive: true });
+  window.addEventListener("keydown", onWindowKeydown);
 });
 
 onBeforeUnmount(() => {
   window.removeEventListener("resize", onWindowResize);
+  window.removeEventListener("keydown", onWindowKeydown);
 });
 </script>
 


### PR DESCRIPTION
💡 What: Added functionality to close the `DraggableModal` component by pressing the Escape key.
🎯 Why: Modals should be closable via keyboard for better accessibility and user experience. Previously, users had to click the close button or outside the modal.
♿ Accessibility: Ensures keyboard users can easily dismiss modals without needing to navigate to the close button.


---
*PR created automatically by Jules for task [11224088354552612141](https://jules.google.com/task/11224088354552612141) started by @Andy963*