### PR TITLE
feat(security): add HTTP security headers and sanitize API errors

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-16 - Raw Error Message Leak
+**Vulnerability:** The HTTP server (`src/web/server/httpServer.ts`) was catching API errors and sending the raw `error.message` to the client in a 500 response. This could leak sensitive internal details (stack traces, SQL errors, file paths) to attackers.
+**Learning:** The error handling was too simplistic, prioritizing debugging convenience over security. It assumed `error.message` was safe for public consumption.
+**Prevention:** Always sanitize error messages sent to the client. Log the full error server-side, but return a generic "Internal Server Error" message to the user.

--- a/src/web/server/httpServer.ts
+++ b/src/web/server/httpServer.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 
 import { sendJson } from "./http.js";
 
+interface Logger {
+  error(message: string, ...args: unknown[]): void;
+}
+
 function serveFile(res: http.ServerResponse, filePath: string): boolean {
   const contentTypeFor = (resolvedPath: string): string => {
     const ext = path.extname(resolvedPath).toLowerCase();
@@ -52,6 +56,7 @@ function serveFile(res: http.ServerResponse, filePath: string): boolean {
 
 export function createHttpServer(options: {
   handleApiRequest?: (req: http.IncomingMessage, res: http.ServerResponse) => Promise<boolean>;
+  logger?: Logger;
 }): http.Server {
   const distWebDir = path.join(process.cwd(), "dist", "web");
 
@@ -89,6 +94,11 @@ export function createHttpServer(options: {
   };
 
   const server = http.createServer((req, res) => {
+    // Add security headers
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("X-Frame-Options", "SAMEORIGIN");
+    res.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+
     const url = req.url ?? "";
     if (url.startsWith("/api/")) {
       const handler = options.handleApiRequest;
@@ -97,9 +107,15 @@ export function createHttpServer(options: {
         return;
       }
       void handler(req, res).catch((error) => {
-        const message = error instanceof Error ? error.message : String(error);
+        // Log the full error, but sanitize the response
+        if (options.logger) {
+          options.logger.error("API Error", error);
+        } else {
+          console.error("API Error", error);
+        }
+
         if (!res.headersSent) {
-          sendJson(res, 500, { error: message });
+          sendJson(res, 500, { error: "Internal Server Error" });
         } else {
           try {
             res.end();

--- a/src/web/server/startWebServer.ts
+++ b/src/web/server/startWebServer.ts
@@ -300,7 +300,7 @@ export async function startWebServer(): Promise<void> {
     scheduleWorkspacePurge: (ctx) => purgeScheduler.schedule(ctx),
   });
 
-  const server = createHttpServer({ handleApiRequest: apiHandler });
+  const server = createHttpServer({ handleApiRequest: apiHandler, logger });
 
   attachWebSocketServer({
     server,

--- a/tests/web/security.test.ts
+++ b/tests/web/security.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { createHttpServer } from "../../src/web/server/httpServer.js";
+
+describe("web/server/security", () => {
+  let server: http.Server;
+  let port: number;
+
+  beforeEach(async () => {
+    // Pass a dummy logger if needed
+    // The logger is optional in my planned implementation
+    server = createHttpServer({
+      handleApiRequest: async (req, res) => {
+        if (req.url === "/api/test") {
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: true }));
+            return true;
+        }
+        if (req.url === "/api/error") {
+            throw new Error("Sensitive info leak");
+        }
+        return false;
+      },
+      logger: {
+        error: () => {},
+        info: () => {},
+        warn: () => {},
+        debug: () => {},
+        log: () => {},
+        child: () => ({ error: () => {}, info: () => {}, warn: () => {}, debug: () => {}, log: () => {} } as any),
+        setLevel: () => {}
+      } as any
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        if (addr && typeof addr === "object") {
+            port = addr.port;
+        }
+        resolve();
+      });
+    });
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  it("sets security headers on API responses", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/api/test`);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("X-Content-Type-Options"), "nosniff");
+    assert.equal(res.headers.get("X-Frame-Options"), "SAMEORIGIN");
+    assert.equal(res.headers.get("Referrer-Policy"), "strict-origin-when-cross-origin");
+  });
+
+  it("does not leak stack traces on error", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/api/error`);
+    assert.equal(res.status, 500);
+    const body = await res.json() as { error: string };
+    assert.equal(body.error, "Internal Server Error");
+    // Ensure "Sensitive info leak" is NOT in the response body
+    // Although fetching as json already verified error property
+    // let's double check content
+  });
+});


### PR DESCRIPTION
This change enhances the security of the web server by adding standard security headers (X-Content-Type-Options, X-Frame-Options, Referrer-Policy) to all HTTP responses. It also sanitizes API error responses to prevent leaking sensitive information (stack traces, internal error messages) to the client, while ensuring full errors are logged server-side for debugging. A new test file `tests/web/security.test.ts` was added to verify these improvements.

---
*PR created automatically by Jules for task [12603652615835143576](https://jules.google.com/task/12603652615835143576) started by @Andy963*