### PR TITLE
refactor: dedupe flag parsing

### DIFF
--- a/.agent/skills/metadata.yaml
+++ b/.agent/skills/metadata.yaml
@@ -7,3 +7,9 @@ skills:
   gemini-transcribe:
     provides: [audio.transcribe]
     priority: 200
+  gemini-tts:
+    provides: [audio.tts]
+    priority: 200
+  openai-tts:
+    provides: [audio.tts]
+    priority: 100

--- a/.agent/skills/scheduler-compile/SKILL.md
+++ b/.agent/skills/scheduler-compile/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scheduler-compile
-description: "Compile a natural-language scheduled job into a deterministic ScheduleSpec JSON for compile-on-create scheduling."
+description: "Compile a natural-language scheduled job into a deterministic ScheduleSpec JSON for compile-on-create scheduling. Use when user asks 定时任务/cron/schedule/提醒/每天几点做什么."
 ---
 
 # Scheduler Compile

--- a/src/scheduler/compiler.ts
+++ b/src/scheduler/compiler.ts
@@ -1,19 +1,13 @@
 import crypto from "node:crypto";
 
 import { SessionManager } from "../telegram/utils/sessionManager.js";
+import { parsePositiveIntFlag } from "../utils/flags.js";
 
 import { ScheduleSpecSchema, type ScheduleSpec } from "./scheduleSpec.js";
 import { parseSupportedCron, validateTimeZone } from "./cron.js";
 
 export interface ScheduleCompiler {
   compile(options: { workspaceRoot: string; instruction: string; signal?: AbortSignal }): Promise<ScheduleSpec>;
-}
-
-function parsePositiveInt(value: string | undefined, fallback: number): number {
-  if (!value) return fallback;
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
-  return parsed;
 }
 
 function extractSingleFencedJsonBlock(text: string): string {
@@ -94,11 +88,11 @@ export class AgentScheduleCompiler implements ScheduleCompiler {
     const timeoutMs =
       typeof options?.timeoutMs === "number" && Number.isFinite(options.timeoutMs) && options.timeoutMs > 0
         ? Math.floor(options.timeoutMs)
-        : parsePositiveInt(process.env.ADS_SCHEDULER_COMPILE_TIMEOUT_MS, 120_000);
+        : parsePositiveIntFlag(process.env.ADS_SCHEDULER_COMPILE_TIMEOUT_MS, 120_000);
     const maxAttempts =
       typeof options?.maxAttempts === "number" && Number.isFinite(options.maxAttempts) && options.maxAttempts > 0
         ? Math.floor(options.maxAttempts)
-        : parsePositiveInt(process.env.ADS_SCHEDULER_COMPILE_MAX_ATTEMPTS, 2);
+        : parsePositiveIntFlag(process.env.ADS_SCHEDULER_COMPILE_MAX_ATTEMPTS, 2);
     const model = String(options?.model ?? process.env.ADS_SCHEDULER_COMPILE_MODEL ?? "").trim() || undefined;
 
     this.timeoutMs = timeoutMs;
@@ -204,4 +198,3 @@ export class AgentScheduleCompiler implements ScheduleCompiler {
     }
   }
 }
-

--- a/src/scheduler/runtime.ts
+++ b/src/scheduler/runtime.ts
@@ -1,25 +1,11 @@
 import crypto from "node:crypto";
 
 import { TaskStore } from "../tasks/store.js";
+import { parseBooleanFlag, parsePositiveIntFlag } from "../utils/flags.js";
 
 import { computeNextCronRunAt } from "./cron.js";
 import { ScheduleStore } from "./store.js";
 import type { StoredSchedule } from "./store.js";
-
-function parseBooleanEnv(raw: string | undefined, defaultValue: boolean): boolean {
-  if (raw === undefined) return defaultValue;
-  const normalized = raw.trim().toLowerCase();
-  if (["1", "true", "yes", "on"].includes(normalized)) return true;
-  if (["0", "false", "no", "off"].includes(normalized)) return false;
-  return defaultValue;
-}
-
-function parsePositiveInt(raw: string | undefined, fallback: number): number {
-  if (!raw) return fallback;
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
-  return parsed;
-}
 
 function renderIdempotencyKey(template: string, scheduleId: string, runAtIso: string): string {
   const t = String(template ?? "").trim();
@@ -57,11 +43,11 @@ export class SchedulerRuntime {
     reconcileLimit?: number;
     ownerId?: string;
   }) {
-    this.enabled = options?.enabled ?? parseBooleanEnv(process.env.ADS_SCHEDULER_ENABLED, true);
-    this.tickMs = options?.tickMs ?? parsePositiveInt(process.env.ADS_SCHEDULER_TICK_MS, 5000);
-    this.leaseTtlMs = options?.leaseTtlMs ?? parsePositiveInt(process.env.ADS_SCHEDULER_LEASE_TTL_MS, 30_000);
-    this.dueLimit = options?.dueLimit ?? parsePositiveInt(process.env.ADS_SCHEDULER_DUE_LIMIT, 20);
-    this.reconcileLimit = options?.reconcileLimit ?? parsePositiveInt(process.env.ADS_SCHEDULER_RECONCILE_LIMIT, 200);
+    this.enabled = options?.enabled ?? parseBooleanFlag(process.env.ADS_SCHEDULER_ENABLED, true);
+    this.tickMs = options?.tickMs ?? parsePositiveIntFlag(process.env.ADS_SCHEDULER_TICK_MS, 5000);
+    this.leaseTtlMs = options?.leaseTtlMs ?? parsePositiveIntFlag(process.env.ADS_SCHEDULER_LEASE_TTL_MS, 30_000);
+    this.dueLimit = options?.dueLimit ?? parsePositiveIntFlag(process.env.ADS_SCHEDULER_DUE_LIMIT, 20);
+    this.reconcileLimit = options?.reconcileLimit ?? parsePositiveIntFlag(process.env.ADS_SCHEDULER_RECONCILE_LIMIT, 200);
     this.ownerId = options?.ownerId ?? crypto.randomUUID();
   }
 

--- a/src/scheduler/store.ts
+++ b/src/scheduler/store.ts
@@ -35,7 +35,7 @@ export type StoredScheduleRun = {
   updatedAt: number;
 };
 
-function parseBooleanFlag(value: unknown): boolean {
+function parseSqliteBoolean(value: unknown): boolean {
   if (typeof value === "number") {
     return value !== 0;
   }
@@ -78,7 +78,7 @@ function parseScheduleRow(row: Record<string, unknown>): StoredSchedule {
     id,
     instruction,
     spec: specParsed.data,
-    enabled: parseBooleanFlag(row.enabled),
+    enabled: parseSqliteBoolean(row.enabled),
     nextRunAt: parseOptionalInt(row.next_run_at),
     leaseOwner: row.lease_owner == null ? null : String(row.lease_owner ?? "").trim() || null,
     leaseUntil: parseOptionalInt(row.lease_until),
@@ -422,4 +422,3 @@ export class ScheduleStore {
     return updated;
   }
 }
-

--- a/src/telegram/utils/transcriptCorrection.ts
+++ b/src/telegram/utils/transcriptCorrection.ts
@@ -1,21 +1,9 @@
 import { resolveGroqBaseUrl, resolveGroqKey } from "../../utils/groq.js";
+import { parseBooleanFlag } from "../../utils/flags.js";
 
 export type TranscriptCorrectionResult =
   | { ok: true; text: string; corrected: boolean }
   | { ok: false; error: string };
-
-function parseBooleanFlag(value: string | undefined, fallback: boolean): boolean {
-  if (value === undefined) {
-    return fallback;
-  }
-  const normalized = String(value).trim().toLowerCase();
-  if (!normalized) {
-    return fallback;
-  }
-  if (["1", "true", "yes", "on"].includes(normalized)) return true;
-  if (["0", "false", "no", "off"].includes(normalized)) return false;
-  return fallback;
-}
 
 function resolveCorrectionEnabled(): boolean {
   return parseBooleanFlag(process.env.ADS_TELEGRAM_VOICE_CORRECTION_ENABLED, true);


### PR DESCRIPTION
Summary:\n- Scheduler: reuse src/utils/flags.ts for env flag parsing (compiler/runtime)\n- Scheduler store: rename sqlite boolean helper to avoid name collisions\n- Telegram: reuse src/utils/flags.ts for transcript correction enabled flag\n- Skills: register audio.tts skills in .agent/skills/metadata.yaml and enrich scheduler-compile description for autoload\n\nNotes:\n- Local refactor tracker/spec updates were written under docs/, but docs/ is gitignored by repo policy.