### PR TITLE
refactor: centralize JSON safe parsing

### DIFF
--- a/src/tasks/executor.ts
+++ b/src/tasks/executor.ts
@@ -7,6 +7,7 @@ import { runBootstrapLoop } from "../bootstrap/bootstrapLoop.js";
 import { CodexBootstrapAgentRunner } from "../bootstrap/agentRunner.js";
 import { NoopSandbox } from "../bootstrap/sandbox.js";
 import type { BootstrapProjectRef } from "../bootstrap/types.js";
+import { safeParseJson } from "../utils/json.js";
 import { mergeStreamingText } from "../utils/streamingText.js";
 
 import type { TaskStore } from "./store.js";
@@ -35,16 +36,6 @@ type WorkspacePatchFileStat = { path: string; added: number | null; removed: num
 type WorkspacePatchPayload = { files: WorkspacePatchFileStat[]; diff: string; truncated: boolean };
 type TaskWorkspacePatchArtifact = { paths: string[]; patch: WorkspacePatchPayload | null; reason?: string; createdAt: number };
 
-function safeJsonParse<T>(raw: string): T | null {
-  const trimmed = String(raw ?? "").trim();
-  if (!trimmed) return null;
-  try {
-    return JSON.parse(trimmed) as T;
-  } catch {
-    return null;
-  }
-}
-
 function getLatestContextOfType(contexts: TaskContext[], contextType: string): TaskContext | null {
   const type = String(contextType ?? "").trim();
   if (!type) return null;
@@ -57,7 +48,7 @@ function getLatestContextOfType(contexts: TaskContext[], contextType: string): T
 
 function formatWorkspacePatchArtifactForPrompt(context: TaskContext | null): string {
   if (!context) return "";
-  const parsed = safeJsonParse<TaskWorkspacePatchArtifact>(context.content);
+  const parsed = safeParseJson<TaskWorkspacePatchArtifact>(context.content);
   if (!parsed) return "";
   const paths = Array.isArray(parsed.paths) ? parsed.paths.map((p) => String(p ?? "").trim()).filter(Boolean) : [];
   const patch = parsed.patch ?? null;

--- a/src/tasks/storeImpl/normalize.ts
+++ b/src/tasks/storeImpl/normalize.ts
@@ -1,18 +1,9 @@
 import type { ConversationStatus, TaskRole, TaskStatus } from "../types.js";
 
+import { safeParseJsonFromUnknown } from "../../utils/json.js";
+
 export function parseJson<T>(raw: unknown): T | null {
-  if (typeof raw !== "string") {
-    return null;
-  }
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return null;
-  }
-  try {
-    return JSON.parse(trimmed) as T;
-  } catch {
-    return null;
-  }
+  return safeParseJsonFromUnknown<T>(raw);
 }
 
 export function normalizeTaskStatus(value: unknown): TaskStatus {

--- a/src/utils/activityTracker/text.ts
+++ b/src/utils/activityTracker/text.ts
@@ -1,9 +1,7 @@
+import { safeParseJson } from "../json.js";
+
 function safeJsonParse(value: string): unknown | null {
-  try {
-    return JSON.parse(value);
-  } catch {
-    return null;
-  }
+  return safeParseJson<unknown>(value);
 }
 
 function normalizeFirstLine(text: string): string {
@@ -47,4 +45,3 @@ function displayPath(value: string): string {
 }
 
 export { displayPath, normalizeFirstLine, safeJsonParse, truncate };
-

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -12,6 +12,17 @@ export function safeParseJson<T>(payload: string | null | undefined): T | null {
   }
 }
 
+export function safeParseJsonFromUnknown<T>(raw: unknown): T | null {
+  if (typeof raw !== "string") {
+    return null;
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return safeParseJson<T>(trimmed);
+}
+
 export function safeParseJsonWithSchema<TSchema extends z.ZodTypeAny>(
   payload: string | null | undefined,
   schema: TSchema,

--- a/src/web/server/planner/taskBundleDraftStore.ts
+++ b/src/web/server/planner/taskBundleDraftStore.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import type { Database as DatabaseType, Statement as StatementType } from "better-sqlite3";
 
 import { getStateDatabase } from "../../../state/database.js";
+import { safeParseJsonFromUnknown } from "../../../utils/json.js";
 import { taskBundleSchema, type TaskBundle } from "./taskBundle.js";
 
 type SqliteStatement = StatementType<unknown[], unknown>;
@@ -29,19 +30,8 @@ function normalizeStatus(status: unknown): TaskBundleDraftStatus {
   return "draft";
 }
 
-function safeJsonParse(raw: unknown): unknown | null {
-  if (typeof raw !== "string") return null;
-  const trimmed = raw.trim();
-  if (!trimmed) return null;
-  try {
-    return JSON.parse(trimmed) as unknown;
-  } catch {
-    return null;
-  }
-}
-
 function parseApprovedTaskIds(raw: unknown): string[] {
-  const parsed = safeJsonParse(raw);
+  const parsed = safeParseJsonFromUnknown<unknown>(raw);
   if (!Array.isArray(parsed)) return [];
   return parsed.map((id) => String(id ?? "").trim()).filter(Boolean);
 }
@@ -67,7 +57,7 @@ function mapRow(row: Record<string, unknown>): TaskBundleDraft {
 
   const approvedTaskIds = parseApprovedTaskIds(row.approved_task_ids_json);
 
-  const parsedBundle = safeJsonParse(row.bundle_json);
+  const parsedBundle = safeParseJsonFromUnknown<unknown>(row.bundle_json);
   const bundle = (() => {
     if (!parsedBundle) return null;
     const result = taskBundleSchema.safeParse(parsedBundle);

--- a/src/web/server/taskQueue/manager.ts
+++ b/src/web/server/taskQueue/manager.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import type { Logger } from "../../../utils/logger.js";
+import { safeParseJson } from "../../../utils/json.js";
 import { detectWorkspaceFrom } from "../../../workspace/detector.js";
 import { DirectoryManager } from "../../../telegram/utils/directoryManager.js";
 import { ThreadStorage } from "../../../telegram/utils/threadStorage.js";
@@ -55,16 +56,6 @@ export type TaskQueueContext = {
 type ChangedPathsContext = { paths?: unknown };
 type TaskWorkspacePatchArtifact = { paths: string[]; patch: WorkspacePatchPayload | null; reason?: string; createdAt: number };
 
-function safeJsonParse<T>(raw: string): T | null {
-  const trimmed = String(raw ?? "").trim();
-  if (!trimmed) return null;
-  try {
-    return JSON.parse(trimmed) as T;
-  } catch {
-    return null;
-  }
-}
-
 function recordTaskWorkspacePatchArtifact(ctx: TaskQueueContext, taskId: string, now = Date.now()): void {
   const id = String(taskId ?? "").trim();
   if (!id) return;
@@ -87,7 +78,7 @@ function recordTaskWorkspacePatchArtifact(ctx: TaskQueueContext, taskId: string,
     return null;
   })();
 
-  const parsed = changedCtx ? safeJsonParse<ChangedPathsContext>(changedCtx.content) : null;
+  const parsed = changedCtx ? safeParseJson<ChangedPathsContext>(changedCtx.content) : null;
   const paths = Array.isArray(parsed?.paths) ? (parsed?.paths as unknown[]).map((p) => String(p ?? "").trim()).filter(Boolean) : [];
 
   let patch: WorkspacePatchPayload | null = null;

--- a/tests/utils/json.test.ts
+++ b/tests/utils/json.test.ts
@@ -1,0 +1,47 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { z } from "zod";
+
+const { parseJsonWithSchema, safeParseJson, safeParseJsonFromUnknown, safeParseJsonWithSchema } = await import(
+  "../../src/utils/json.js"
+);
+
+describe("utils/json", () => {
+  it("safeParseJson returns parsed value for valid JSON", () => {
+    const parsed = safeParseJson<{ a: number }>('{"a":1}');
+    assert.deepEqual(parsed, { a: 1 });
+  });
+
+  it("safeParseJson returns null for empty/invalid input", () => {
+    assert.equal(safeParseJson(""), null);
+    assert.equal(safeParseJson("   "), null);
+    assert.equal(safeParseJson("not-json"), null);
+  });
+
+  it("safeParseJsonFromUnknown returns null for non-strings", () => {
+    assert.equal(safeParseJsonFromUnknown(1), null);
+    assert.equal(safeParseJsonFromUnknown(null), null);
+    assert.equal(safeParseJsonFromUnknown(undefined), null);
+    assert.equal(safeParseJsonFromUnknown({}), null);
+  });
+
+  it("safeParseJsonFromUnknown trims and parses strings", () => {
+    const parsed = safeParseJsonFromUnknown<{ a: number }>('  {"a":1}  ');
+    assert.deepEqual(parsed, { a: 1 });
+  });
+
+  it("safeParseJsonWithSchema validates payload", () => {
+    const schema = z.object({ a: z.number() });
+    assert.deepEqual(safeParseJsonWithSchema('{"a":1}', schema), { a: 1 });
+    assert.equal(safeParseJsonWithSchema('{"a":"1"}', schema), null);
+    assert.equal(safeParseJsonWithSchema("not-json", schema), null);
+  });
+
+  it("parseJsonWithSchema throws on invalid payloads", () => {
+    const schema = z.object({ a: z.number() });
+    assert.throws(() => parseJsonWithSchema("not-json", schema), /Invalid JSON payload/);
+    assert.throws(() => parseJsonWithSchema('{"a":"1"}', schema), /Invalid JSON payload/);
+  });
+});
+


### PR DESCRIPTION
Summary:\n- Add safeParseJsonFromUnknown() to centralize defensive JSON parsing for unknown/sqlite fields.\n- Replace duplicated safeJsonParse()/parseJson() helpers in task executor, web task queue manager, planner draft store, and activity tracker text.\n- Add unit tests for utils/json.\n\nVerification:\n- npx tsc --noEmit\n- npm run lint\n- npm test\n