### PR TITLE
refactor: make safeStringify non-throwing

### DIFF
--- a/src/bootstrap/artifacts.ts
+++ b/src/bootstrap/artifacts.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { safeStringify } from "../utils/json.js";
+
 import type { BootstrapIterationOutcome, BootstrapRunResult, BootstrapRunSpec } from "./types.js";
 
 function ensureDir(dirPath: string): void {
@@ -10,14 +12,6 @@ function ensureDir(dirPath: string): void {
 function writeUtf8(filePath: string, content: string): void {
   ensureDir(path.dirname(filePath));
   fs.writeFileSync(filePath, content, "utf8");
-}
-
-function safeStringify(value: unknown): string {
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return JSON.stringify({ error: "failed to stringify value" }, null, 2);
-  }
 }
 
 export class BootstrapArtifactStore {

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -59,13 +59,21 @@ export function parseJsonWithSchema<TSchema extends z.ZodTypeAny>(
 }
 
 export function safeStringify(value: unknown, indent = 2): string {
-  return JSON.stringify(value, (_key, val) => {
-    if (val instanceof Map) {
-      return Object.fromEntries(val.entries());
-    }
-    if (val instanceof Set) {
-      return Array.from(val.values());
-    }
-    return val;
-  }, indent);
+  try {
+    return JSON.stringify(
+      value,
+      (_key, val) => {
+        if (val instanceof Map) {
+          return Object.fromEntries(val.entries());
+        }
+        if (val instanceof Set) {
+          return Array.from(val.values());
+        }
+        return val;
+      },
+      indent,
+    );
+  } catch {
+    return JSON.stringify({ error: "failed to stringify value" }, null, indent);
+  }
 }

--- a/tests/utils/json.test.ts
+++ b/tests/utils/json.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 
 import { z } from "zod";
 
-const { parseJsonWithSchema, safeParseJson, safeParseJsonFromUnknown, safeParseJsonWithSchema } = await import(
+const { parseJsonWithSchema, safeParseJson, safeParseJsonFromUnknown, safeParseJsonWithSchema, safeStringify } = await import(
   "../../src/utils/json.js"
 );
 
@@ -43,5 +43,26 @@ describe("utils/json", () => {
     assert.throws(() => parseJsonWithSchema("not-json", schema), /Invalid JSON payload/);
     assert.throws(() => parseJsonWithSchema('{"a":"1"}', schema), /Invalid JSON payload/);
   });
-});
 
+  it("safeStringify serializes Map as object", () => {
+    const payload = safeStringify(new Map([["a", 1], ["b", 2]]));
+    assert.deepEqual(JSON.parse(payload), { a: 1, b: 2 });
+  });
+
+  it("safeStringify serializes Set as array", () => {
+    const payload = safeStringify(new Set([1, 2]));
+    assert.deepEqual(JSON.parse(payload), [1, 2]);
+  });
+
+  it("safeStringify returns fallback JSON for circular references", () => {
+    const value: any = { a: 1 };
+    value.self = value;
+    const payload = safeStringify(value);
+    assert.deepEqual(JSON.parse(payload), { error: "failed to stringify value" });
+  });
+
+  it("safeStringify returns fallback JSON for bigint", () => {
+    const payload = safeStringify({ a: 1n });
+    assert.deepEqual(JSON.parse(payload), { error: "failed to stringify value" });
+  });
+});


### PR DESCRIPTION
Spec Reference:
- docs/spec/20260223-2350-project-wide-refactor-pass-5/

Changes:
- Make `safeStringify()` non-throwing with a stable fallback JSON.
- Reuse `safeStringify()` in `BootstrapArtifactStore` (remove duplicate implementation).
- Add unit tests for Map/Set/circular/bigint inputs.

Verification:
- npx tsc --noEmit
- npm run lint
- npm test
