### PR TITLE
test: fix skillAutoloadCjk test by writing missing metadata

### DIFF
--- a/tests/agents/skillAutoloadCjk.test.ts
+++ b/tests/agents/skillAutoloadCjk.test.ts
@@ -69,6 +69,11 @@ function writeSkill(workspaceRoot: string, name: string, description: string): v
   const skillFile = path.join(skillDir, "SKILL.md");
   const content = ["---", `name: ${name}`, `description: "${description}"`, "---", "", `# ${name}`, ""].join("\n");
   fs.writeFileSync(skillFile, content, "utf8");
+
+  const metadataPath = path.join(workspaceRoot, ".agent", "skills", "metadata.yaml");
+  if (!fs.existsSync(metadataPath)) {
+    fs.writeFileSync(metadataPath, "", "utf8");
+  }
 }
 
 describe("agents/orchestrator skill autoload (CJK)", () => {


### PR DESCRIPTION
During a full project review for bugs, the `npm run test` command highlighted a failure in `tests/agents/skillAutoloadCjk.test.ts`. The test `infers requested skills from CJK keywords` was failing because the mock workspace skills it created were being ignored in favor of global fallback skills (like `scheduler-compile`).

This occurred because the test environment's `.agent/skills/` directory lacked the `metadata.yaml` file, which is required by `isWorkspaceSkillsEnabled` (in `src/skills/loader.ts`) to recognize the workspace skills.

I have updated the `writeSkill` helper function in the test file to ensure `metadata.yaml` is written alongside the mock skills, allowing the test to correctly infer the intended mock skills and pass.

No other bugs were found by tests, compiler, or linter.

---
*PR created automatically by Jules for task [15887038299330000277](https://jules.google.com/task/15887038299330000277) started by @Andy963*