### PR TITLE
⚡ Bolt: replace N+1 query loop with recursive CTE in getParentNodesFromWorkspace

### DIFF
--- a/server/workspace/context/workflowContext/db.ts
+++ b/server/workspace/context/workflowContext/db.ts
@@ -38,37 +38,46 @@ export function getParentNodesFromWorkspace(nodeId: string, workspace: string, r
   const db = new Database(dbPath, { readonly: true });
 
   try {
-    const parents: GraphNode[] = [];
-    const seen = new Set<string>();
-    let current = nodeId;
-
-    while (true) {
+    if (!recursive) {
       const edge = db
         .prepare("SELECT source FROM edges WHERE target = ? AND source != ? LIMIT 1")
-        .get(current, current) as { source?: string } | undefined;
+        .get(nodeId, nodeId) as { source?: string } | undefined;
+
       if (!edge?.source) {
-        break;
-      }
-      if (seen.has(edge.source)) {
-        break;
+        return [];
       }
 
       const row = db.prepare("SELECT * FROM nodes WHERE id = ?").get(edge.source) as NodeDbRow | undefined;
-      if (!row) {
-        break;
-      }
-
-      const node = mapNodeRow(row);
-      parents.push(node);
-      seen.add(node.id);
-
-      if (!recursive) {
-        break;
-      }
-      current = node.id;
+      return row ? [mapNodeRow(row)] : [];
     }
 
-    return parents;
+    // Optimization: Use recursive CTE to fetch ancestors in a single query
+    // instead of N+1 loop. We use a path string to detect cycles and stop.
+    // Limits traversal depth to 100 to prevent runaway queries.
+    const sql = `
+      WITH RECURSIVE lineage AS (
+        SELECT source, target, 1 as depth, '/' || target || '/' || source || '/' as path
+        FROM edges
+        WHERE target = ? AND source != target
+
+        UNION ALL
+
+        SELECT e.source, e.target, l.depth + 1, l.path || e.source || '/'
+        FROM edges e
+        JOIN lineage l ON e.target = l.source
+        WHERE e.source != e.target
+          AND l.depth < 100
+          AND l.path NOT LIKE '%/' || e.source || '/%'
+      )
+      SELECT n.*
+      FROM lineage l
+      JOIN nodes n ON n.id = l.source
+      GROUP BY n.id
+      ORDER BY min(l.depth) ASC;
+    `;
+
+    const rows = db.prepare(sql).all(nodeId) as NodeDbRow[];
+    return rows.map((row) => mapNodeRow(row));
   } finally {
     db.close();
   }


### PR DESCRIPTION
💡 **What**: Replaced the iterative database querying (`while (true) { db.prepare(...).get() }`) in `getParentNodesFromWorkspace` with a single SQL query using a `WITH RECURSIVE` Common Table Expression (CTE).

🎯 **Why**: The original implementation suffered from the classic N+1 query problem, requiring a distinct round-trip to the SQLite database for every single level of ancestry. In deep workflows, this becomes a significant bottleneck.

📊 **Impact**: Reduces database queries from `O(N)` (where N is depth of ancestry) to `O(1)` query per call. It also natively handles cycle detection and complex graph paths safely.

🔬 **Measurement**: Benchmark `getParentNodesFromWorkspace` on a deep workflow graph (e.g., 50+ nodes). The new implementation should show a reduction in CPU time and fewer database locks.

---
*PR created automatically by Jules for task [2169468191253016736](https://jules.google.com/task/2169468191253016736) started by @Andy963*