### PR TITLE
🎨 Palette: Actionable Empty State in TaskBoard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-18 - Actionable Empty States
+**Learning:** Users often get stuck when a dashboard or list is completely empty, as static text doesn't provide a clear next step. Making empty state text an actionable button directly connected to the primary action reduces friction.
+**Action:** Whenever implementing a zero-data empty state, wrap the hint in a button (styled subtly like a link) that opens the creation form or initiates the primary workflow.

--- a/client/src/components/TaskBoard.css
+++ b/client/src/components/TaskBoard.css
@@ -75,9 +75,26 @@
   min-height: 0;
 }
 
-.hint {
+.hintBtn {
+  background: transparent;
+  border: none;
   color: #94a3b8;
   font-size: 12px;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: color 0.15s ease;
+}
+
+.hintBtn:hover {
+  color: #64748b;
+}
+
+.hintBtn:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.4);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 .list {

--- a/client/src/components/TaskBoard.vue
+++ b/client/src/components/TaskBoard.vue
@@ -872,7 +872,7 @@ function toggleQueue(): void {
 
     <div v-if="totalVisibleTasks === 0" class="empty">
       <span>暂无任务</span>
-      <span class="hint">点击 + 新建任务</span>
+      <button class="hintBtn" type="button" @click.stop="emit('create')">点击 + 新建任务</button>
     </div>
 
     <div v-else class="list">


### PR DESCRIPTION
🎨 Palette: Actionable Empty States

💡 **What:** 
Turned the static text hint in `TaskBoard.vue` ("点击 + 新建任务") into an actionable `<button>` that directly triggers the task creation process (`emit('create')`).

🎯 **Why:** 
Users encountering an empty state should be immediately empowered to take the next step. Having a static text hint that tells them what to do ("click +") introduces unnecessary friction. Making the hint itself the primary call-to-action reduces cognitive load and path-to-value.

📸 **Before/After:**
*(Visual changes verified locally via Playwright headless screenshot testing - empty state hint now appears as a clickable button with standard interaction states.)*

♿ **Accessibility:**
- Changed semantic element from `<span>` to `<button>` to ensure correct screen reader announcement.
- Added `:hover` state for mouse interactions.
- Added `:focus-visible` outline to ensure keyboard navigation visibility.

---
*PR created automatically by Jules for task [3830640752227198569](https://jules.google.com/task/3830640752227198569) started by @Andy963*