### PR TITLE
🛡️ Sentinel: [SECURITY ENHANCEMENT] Add Content-Security-Policy header

### DIFF
--- a/server/web/server/http.ts
+++ b/server/web/server/http.ts
@@ -23,6 +23,7 @@ export function setSecurityHeaders(res: http.ServerResponse): void {
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("X-Frame-Options", "DENY");
   res.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+  res.setHeader("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:; frame-ancestors 'none';");
 }
 
 export function sendJson(res: http.ServerResponse, statusCode: number, payload: unknown): void {


### PR DESCRIPTION
🚨 **Severity**: MEDIUM (Defense in Depth)
💡 **Vulnerability / Gap**: The application's HTTP responses did not previously include a `Content-Security-Policy` header. Without it, the application lacks an important defense-in-depth layer against malicious script execution (XSS) or framing attacks, leaving it reliant solely on input validation and output encoding.
🎯 **Impact**: An attacker who successfully injects an XSS payload could more easily load malicious external scripts or exfiltrate data. Additionally, missing `frame-ancestors` makes clickjacking easier if `X-Frame-Options` is somehow bypassed or unsupported by older browsers.
🔧 **Fix**: Added a robust baseline `Content-Security-Policy` header inside the `setSecurityHeaders` utility in `server/web/server/http.ts`. The policy dictates `default-src 'self'` while allowing typical single-page app patterns (websockets, inline styles/scripts, base64 images/fonts) but strictly disabling frame embedding via `frame-ancestors 'none'`.
✅ **Verification**: Code compiles cleanly via `pnpm build`. Tests were run locally and modifications to the HTTP header logic were isolated.

---
*PR created automatically by Jules for task [12940218656045986569](https://jules.google.com/task/12940218656045986569) started by @Andy963*