### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Error Stack Trace Leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-21 - [Leaking Error Stack Traces in Prompt Handlers]
+**Vulnerability:** The application was logging the error stack trace (`error.stack`) to the `sessionLogger` in `server/web/server/ws/handlePrompt.ts` and `server/telegram/adapters/codex.ts`. This exposed internal implementation details, dependency versions, and file paths.
+**Learning:** This existed because the error handling logic was trying to be too helpful for debugging purposes, but inadvertently exposed sensitive stack trace data in production or user-facing logs.
+**Prevention:** Always fall back to `error.message` for logging user-facing or session-facing errors. Never expose `error.stack` outside of strictly controlled, internal server logs.

--- a/server/telegram/adapters/codex.ts
+++ b/server/telegram/adapters/codex.ts
@@ -97,7 +97,7 @@ export async function handleCodexMessage(
     const timestamp = new Date().toISOString();
     const detail = error
       ? error instanceof Error
-        ? error.stack ?? error.message
+        ? error.message
         : String(error)
       : '';
     try {

--- a/server/web/server/ws/handlePrompt.ts
+++ b/server/web/server/ws/handlePrompt.ts
@@ -1024,8 +1024,7 @@ export async function handlePromptMessage(deps: {
             : classifyError(error);
 
         const logMessage = `[${errorInfo.code}] ${errorInfo.message}`;
-        const stack = error instanceof Error ? error.stack : undefined;
-        deps.sessionLogger?.logError(stack ? `${logMessage}\n${stack}` : logMessage);
+        deps.sessionLogger?.logError(logMessage);
         deps.logger.warn(`[Prompt Error] code=${errorInfo.code} retryable=${errorInfo.retryable} needsReset=${errorInfo.needsReset} message=${errorInfo.message}`);
 
         deps.historyStore.add(deps.historyKey, {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application was logging the error stack trace (`error.stack`) to the `sessionLogger` in `server/web/server/ws/handlePrompt.ts` and `server/telegram/adapters/codex.ts`. 
🎯 Impact: This exposed internal implementation details, dependency versions, and file paths to the session logs, which could potentially be viewed by users.
🔧 Fix: Removed the `error.stack` property from being logged and correctly falls back to logging the `error.message`.
✅ Verification: Ran `pnpm lint`, `pnpm test`, and `pnpm build` to verify the changes do not introduce regressions.

This PR follows the Sentinel guidelines for security improvements.

---
*PR created automatically by Jules for task [1698448453888136479](https://jules.google.com/task/1698448453888136479) started by @Andy963*