### PR TITLE
⚡ Bolt: Add missing database indexes to edges table

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - Missing Database Indexes for Graph Traversals
+**Learning:** For graph traversals in SQLite using recursive CTEs, adjacency list-style tables like `edges` must have explicit database indexes on both foreign keys (`source` and `target`) to avoid O(N) sequential table scans that severely impact performance.
+**Action:** Always verify that frequently queried relational foreign keys, especially those in graph connections and edge structures used in recursive queries, have corresponding indexes.

--- a/server/storage/migrations.ts
+++ b/server/storage/migrations.ts
@@ -497,9 +497,19 @@ export const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 14,
+    description: "Add indexes to edges table on source and target for optimized recursive CTE traversals",
+    up: (db) => {
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source);
+        CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target);
+      `);
+    },
+  },
   // 示例：未来的迁移
   // {
-  //   version: 13,
+  //   version: 15,
   //   description: "Add tags column to nodes",
   //   up: (db) => {
   //     // 检查列是否存在


### PR DESCRIPTION
💡 What: Added database indexes on the `source` and `target` columns of the `edges` table via a new migration in `server/storage/migrations.ts`. Also logged the architectural finding in `.jules/bolt.md`.
🎯 Why: Graph ancestry traversals (e.g. `getParentNodes`) use recursive Common Table Expressions (CTEs) which perform sequential scans of the `edges` table when fetching previous parent elements. Adding explicit indexes on the relational foreign keys prevents O(N) sequential table scans that severely impact performance.
📊 Impact: Expected to greatly reduce read query times for nested lineage components to constant O(1) database lookups instead of sequential O(N).
🔬 Measurement: Verify by executing an EXPLAIN QUERY PLAN against the recursive CTE in SQLite, comparing results with and without index. Tests will also remain passing without regression.

---
*PR created automatically by Jules for task [1122063669216669522](https://jules.google.com/task/1122063669216669522) started by @Andy963*