### PR TITLE
⚡ Bolt: Add database indexes for graph traversal performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-20 - [Graph Adjacency List Secondary Indexes]
+**Learning:** Graph ancestry traversals (such as those using recursive CTEs) perform exceptionally poorly (O(N) per hop instead of O(log N)) if explicit secondary database indexes on adjacency list foreign keys (`source` and `target` in an `edges` table) are missing, resulting in full sequential table scans for every parent lookup.
+**Action:** Always ensure that adjacency list tables used for graph connections have explicit indexes on both their source and target reference columns, especially when used in CTEs or loop-based query traversals.

--- a/server/storage/migrations.ts
+++ b/server/storage/migrations.ts
@@ -497,9 +497,19 @@ export const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 14,
+    description: "Graph edges - add indexes on source and target for traversal performance",
+    up: (db) => {
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source);
+        CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target);
+      `);
+    },
+  },
   // 示例：未来的迁移
   // {
-  //   version: 13,
+  //   version: 15,
   //   description: "Add tags column to nodes",
   //   up: (db) => {
   //     // 检查列是否存在


### PR DESCRIPTION
### 💡 What: 
Added a database migration (`server/storage/migrations.ts` version 14) to explicitly create secondary indexes on the `source` and `target` columns of the `edges` table (`idx_edges_source` and `idx_edges_target`).

### 🎯 Why:
The application performs numerous graph adjacency and ancestry traversals (e.g., retrieving parents/children) using recursive Common Table Expressions (CTEs) in SQLite (e.g. in `server/graph/crud.ts`). Without explicit indexes on these foreign-key-style reference columns, every single hop in the graph traversal forces the database to perform a full sequential scan of the entire `edges` table (O(N)), resulting in massive performance bottlenecks as the graph grows. 

### 📊 Impact: 
Converts O(N) table scans per relationship lookup into O(log N) index lookups. This will drastically reduce CPU/memory usage and significantly improve latency for operations involving workflow structures, dependencies, or full-graph data retrievals.

### 🔬 Measurement: 
To verify this improvement, run a large recursive CTE query fetching lineage from a heavily populated `edges` table both before and after applying the schema migration, and observe execution times drop drastically. Tests run cleanly to ensure no schema regressions occurred.

---
*PR created automatically by Jules for task [13105558657925640689](https://jules.google.com/task/13105558657925640689) started by @Andy963*