### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix partial directory match path traversal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-25 - Path traversal via partial directory match
+**Vulnerability:** Path traversal possible by matching partial directory names (e.g., matching /dist-secrets against /dist) when using string.startsWith() for path validation.
+**Learning:** Using startsWith on raw strings without appending a path separator allows access to sibling directories that share the same prefix.
+**Prevention:** Always append a path separator to the base directory before using startsWith, and explicitly allow exact base directory matches.

--- a/server/web/server/httpServer.ts
+++ b/server/web/server/httpServer.ts
@@ -121,12 +121,22 @@ export function createHttpServer(options: {
       return true;
     }
 
-    const raw = (url.split("?")[0] ?? "/").trim();
+    let decodedUrl = url;
+    try {
+      decodedUrl = decodeURIComponent(url);
+    } catch {
+      // Ignore malformed URIs, continue with raw url
+    }
+
+    const raw = (decodedUrl.split("?")[0] ?? "/").trim();
     const rel = raw.startsWith("/") ? raw : `/${raw}`;
     const normalized = path.posix.normalize(rel);
     const safeRel = normalized.startsWith("/") ? normalized : `/${normalized}`;
     const resolved = path.resolve(distClientDir, "." + safeRel);
-    if (!resolved.startsWith(distClientDir)) {
+
+    // Ensure exact directory match or match with trailing path separator to avoid partial directory traversal
+    const distClientDirWithSep = distClientDir.endsWith(path.sep) ? distClientDir : distClientDir + path.sep;
+    if (!(resolved === distClientDir || resolved.startsWith(distClientDirWithSep))) {
       setSecurityHeaders(res);
       res.writeHead(403).end("Forbidden");
       return true;


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path traversal possible via partial directory match. The `startsWith` check on `resolved.startsWith(distClientDir)` allows matching sibling directories that share the same prefix (e.g., if `distClientDir` is `/app/dist`, an attacker requesting a path that resolves to `/app/dist-secrets` would bypass the check since `/app/dist-secrets`.startsWith(`/app/dist`) evaluates to true). Additionally, encoded paths could potentially bypass the `path.posix.normalize` logic.
🎯 **Impact:** An attacker could potentially access arbitrary files on the file system within sibling directories, or outside if encoded paths were manipulated correctly.
🔧 **Fix:** 
1. Added a `try/catch` block with `decodeURIComponent` to safely decode `req.url` before parsing.
2. Appended a path separator (`path.sep`) to the base directory before using `startsWith` to prevent partial matches, and allowed exact directory matches.
✅ **Verification:** Ran `pnpm test` and ensured all tests passed successfully. Verified locally that requests for `..%2f` and partial directory strings are rejected. Recorded findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [3584445191143069254](https://jules.google.com/task/3584445191143069254) started by @Andy963*