### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in TaskBundleDraftPanel

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - ARIA Labels on Icon-only Buttons
+**Learning:** Found that custom buttons acting as icons (e.g. `<button><Delete /></button>`) can easily lack `aria-label` attributes if relying solely on native `title` for tooltip. The tooltip provides visual access but screen readers may rely primarily on ARIA attributes to announce action significance.
+**Action:** Ensure all icon-only buttons (`Refresh`, `Delete` actions in Draft panels, etc.) have explicit `aria-label` properties defined, even if `title` is set, to guarantee robust keyboard and screen-reader navigation.

--- a/client/src/components/TaskBundleDraftPanel.vue
+++ b/client/src/components/TaskBundleDraftPanel.vue
@@ -423,6 +423,7 @@ function toggleExpanded(): void {
           :disabled="Boolean(busy)"
           data-testid="task-bundle-drafts-refresh"
           title="刷新"
+          aria-label="刷新"
           @click="emit('refresh')"
         >
           <Refresh />
@@ -452,6 +453,7 @@ function toggleExpanded(): void {
               class="draftRowDelete"
               :disabled="Boolean(busy)"
               title="删除"
+              aria-label="删除"
               data-testid="task-bundle-draft-delete"
               @click.stop="emit('delete', draft.id)"
             >


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to the icon-only "Refresh" and "Delete" buttons in `TaskBundleDraftPanel.vue`.
🎯 **Why**: Icon-only buttons relying solely on the native `title` attribute for tooltips are not fully accessible. Adding explicit `aria-label` attributes ensures screen readers correctly announce the button's action.
📸 **Before/After**: Visually identical, but functionally improved for assistive technologies.
♿ **Accessibility**: Enhanced keyboard and screen-reader navigation by explicitly declaring the action's purpose.

---
*PR created automatically by Jules for task [1698169133580472022](https://jules.google.com/task/1698169133580472022) started by @Andy963*