### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in file download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-28 - URL Encoded Path Traversal Bypass
+**Vulnerability:** The HTTP server implementation matched normalized directory paths without first decoding URL-encoded characters (like `%2e%2e` for `..`) and used a vulnerable partial string match (`startsWith`) to verify directory bounds.
+**Learning:** Node.js HTTP req.url contains raw, encoded strings. Standard path resolution (`path.resolve`) preserves URL-encoded segments like `%2e%2e` as literal directory names, but clients passing these through to `fs.statSync` or serving logic can exploit implicit decoding or OS-level file access. Additionally, `startsWith('/app/dist')` is vulnerable to matching siblings like `/app/dist_secrets`.
+**Prevention:** Always `decodeURIComponent` requested URLs in a `try/catch` block before normalizing. When validating directory scope using string matching, append the OS-specific path separator (`path.sep`) or check for an exact directory match.

--- a/server/web/server/httpServer.ts
+++ b/server/web/server/httpServer.ts
@@ -121,12 +121,22 @@ export function createHttpServer(options: {
       return true;
     }
 
-    const raw = (url.split("?")[0] ?? "/").trim();
+    let raw = (url.split("?")[0] ?? "/").trim();
+    try {
+      raw = decodeURIComponent(raw);
+    } catch {
+      setSecurityHeaders(res);
+      res.writeHead(400).end("Bad Request");
+      return true;
+    }
+
     const rel = raw.startsWith("/") ? raw : `/${raw}`;
     const normalized = path.posix.normalize(rel);
     const safeRel = normalized.startsWith("/") ? normalized : `/${normalized}`;
     const resolved = path.resolve(distClientDir, "." + safeRel);
-    if (!resolved.startsWith(distClientDir)) {
+
+    // Prevent directory traversal bypasses using encoded strings and partial path matches
+    if (!(resolved === distClientDir || resolved.startsWith(distClientDir + path.sep))) {
       setSecurityHeaders(res);
       res.writeHead(403).end("Forbidden");
       return true;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A path traversal vulnerability existed in the web server where URL-encoded segments (`%2e%2e` for `..`) bypassed string-based normalization checks. Furthermore, the `startsWith` validation was vulnerable to partial directory name matches (e.g., `/app/dist` matching `/app/dist-secrets`).
🎯 Impact: Attackers could bypass directory restrictions to read arbitrary files from the server's file system, potentially exposing secrets, configurations, or source code.
🔧 Fix:
- Added `decodeURIComponent` in a `try...catch` block (returning 400 Bad Request on failure).
- Updated the directory restriction check to ensure the resolved path exactly matches the allowed directory or starts with the allowed directory plus a path separator (`path.sep`).
✅ Verification: Ensured HTTP server properly blocks relative URL-encoded traversals and passes `vitest` unit tests. Verified by manually testing combinations of `%2e` and directory names against the isolated server logic.

---
*PR created automatically by Jules for task [15567848846263251582](https://jules.google.com/task/15567848846263251582) started by @Andy963*