### PR TITLE
⚡ Bolt: [performance improvement] Replace array copy and reverse with findLast

### DIFF
--- a/server/utils/activityTracker/shell.ts
+++ b/server/utils/activityTracker/shell.ts
@@ -177,7 +177,8 @@ function summarizeSed(commandLine: string): string | null {
   if (tokens[0] !== "sed") {
     return null;
   }
-  const file = [...tokens].reverse().find((token) => token && !token.startsWith("-"));
+  // ⚡ Bolt: Use findLast to avoid O(N) array allocation and reverse mutation
+  const file = tokens.findLast((token) => token && !token.startsWith("-"));
   if (!file || file === "sed") {
     return null;
   }

--- a/server/web/server/api/routes/tasks.ts
+++ b/server/web/server/api/routes/tasks.ts
@@ -429,7 +429,8 @@ export async function handleTaskRoutes(ctx: ApiRouteContext, deps: ApiSharedDeps
 
     try {
       const contexts = taskCtx.taskStore.getContext(source.id);
-      const latestPatch = [...contexts].reverse().find((c) => c.contextType === "artifact:workspace_patch") ?? null;
+      // ⚡ Bolt: Use findLast to avoid O(N) array allocation and reverse mutation
+      const latestPatch = contexts.findLast((c) => c.contextType === "artifact:workspace_patch") ?? null;
       if (latestPatch) {
         taskCtx.taskStore.saveContext(
           created.id,

--- a/server/web/server/taskQueue/manager.ts
+++ b/server/web/server/taskQueue/manager.ts
@@ -873,9 +873,10 @@ export function createTaskQueueManager(deps: {
       })();
       try {
         const contexts = ctx.taskStore.getContext(taskId);
-        const latestPatch = [...contexts].reverse().find((c) => c.contextType === "artifact:workspace_patch") ?? null;
+        // ⚡ Bolt: Use findLast to avoid O(N) array allocation and reverse mutation
+        const latestPatch = contexts.findLast((c) => c.contextType === "artifact:workspace_patch") ?? null;
         patchArtifact = latestPatch ? safeParseJson<TaskWorkspacePatchArtifact>(latestPatch.content) : null;
-        const latestChanged = [...contexts].reverse().find((c) => c.contextType === "artifact:changed_paths") ?? null;
+        const latestChanged = contexts.findLast((c) => c.contextType === "artifact:changed_paths") ?? null;
         const changedParsed = latestChanged ? safeParseJson<ChangedPathsContext>(latestChanged.content) : null;
         changedFiles = Array.isArray(changedParsed?.paths)
           ? (changedParsed?.paths as unknown[]).map((p) => String(p ?? "").trim()).filter(Boolean)


### PR DESCRIPTION
💡 What: The optimization replaces the `[...array].reverse().find()` pattern with the native ES2023 `array.findLast()` method in several places within the task routing, queue manager, and activity tracker modules.

🎯 Why: The original pattern was inefficient because it created a new array copy (O(N) memory allocation) and mutated it via `.reverse()` (O(N) operations) before searching.

📊 Impact: Reduces memory overhead and improves performance slightly for array searches starting from the end by making the search O(1) in memory allocation and avoiding the full reversal mutation. 

🔬 Measurement: Verified through passing test suites and successful lint checks, confirming no functional changes while reducing memory allocations.

---
*PR created automatically by Jules for task [15045323389980324607](https://jules.google.com/task/15045323389980324607) started by @Andy963*