### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in custom HTTP server

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-30 - URL Encoded Path Traversal Bypass in HTTP Server
+**Vulnerability:** The custom HTTP server (`server/web/server/httpServer.ts`) was vulnerable to path traversal because URL-encoded characters (like `%2e%2e%2f` for `../`) were not decoded before normalizing the path. This allowed attackers to bypass the `resolved.startsWith(distClientDir)` check because `path.resolve` handles the encoded components literally, but file system functions read the underlying files if the OS decodes them or handles the strings differently.
+**Learning:** Node.js's `path` and `url` string manipulation functions don't automatically URL-decode strings. Security checks on paths must occur after full decoding.
+**Prevention:** URL paths must be manually decoded using `decodeURIComponent` within a try-catch block before normalizing the path, gracefully returning a 400 Bad Request on URIError.

--- a/server/web/server/httpServer.ts
+++ b/server/web/server/httpServer.ts
@@ -121,7 +121,17 @@ export function createHttpServer(options: {
       return true;
     }
 
-    const raw = (url.split("?")[0] ?? "/").trim();
+    let raw = (url.split("?")[0] ?? "/").trim();
+    try {
+      // Security: Decode URL components to prevent path traversal bypasses
+      // e.g. /%2e%2e/ translates to /../ and would bypass startswith verification if not decoded
+      raw = decodeURIComponent(raw);
+    } catch {
+      setSecurityHeaders(res);
+      res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("Bad Request");
+      return true;
+    }
     const rel = raw.startsWith("/") ? raw : `/${raw}`;
     const normalized = path.posix.normalize(rel);
     const safeRel = normalized.startsWith("/") ? normalized : `/${normalized}`;

--- a/tests/web/pathTraversal.test.ts
+++ b/tests/web/pathTraversal.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import path from "node:path";
+import fs from "node:fs";
+
+import { createHttpServer } from "../../server/web/server/httpServer.js";
+import { PROJECT_ROOT } from "../../server/utils/projectRoot.js";
+
+describe("web/server/httpServer/pathTraversal", () => {
+  let server: http.Server;
+  let port: number;
+  let testFileCreated = false;
+  const testSecretFile = path.join(PROJECT_ROOT, "dist", "client-secrets", "test-secret.txt");
+
+  before(async () => {
+    // Make sure dist/client-secrets exists
+    const secretsDir = path.dirname(testSecretFile);
+    if (!fs.existsSync(secretsDir)) {
+      fs.mkdirSync(secretsDir, { recursive: true });
+    }
+    fs.writeFileSync(testSecretFile, "THIS IS A SECRET FILE");
+    testFileCreated = true;
+
+    server = createHttpServer({});
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => {
+        port = (server.address() as any).port;
+        resolve();
+      });
+    });
+  });
+
+  after(() => {
+    if (server) {
+      server.close();
+    }
+    if (testFileCreated) {
+      try {
+        fs.unlinkSync(testSecretFile);
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  async function request(pathStr: string): Promise<{ statusCode: number; body: string }> {
+    return new Promise((resolve) => {
+      http.get(`http://localhost:${port}${pathStr}`, (res) => {
+        let body = "";
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+        res.on("end", () => {
+          resolve({ statusCode: res.statusCode || 500, body });
+        });
+      });
+    });
+  }
+
+  it("blocks simple path traversal using ..", async () => {
+    const res = await request("/../client-secrets/test-secret.txt");
+    assert.ok(res.statusCode === 403 || res.statusCode === 404);
+    assert.ok(!res.body.includes("SECRET FILE"));
+  });
+
+  it("blocks URL-encoded path traversal %2e%2e", async () => {
+    const res = await request("/%2e%2e/client-secrets/test-secret.txt");
+    assert.ok(res.statusCode === 403 || res.statusCode === 404);
+    assert.ok(!res.body.includes("SECRET FILE"));
+  });
+
+  it("blocks heavily URL-encoded path traversal", async () => {
+    const res = await request("/%2e%2e%2f%2e%2e%2fclient-secrets/test-secret.txt");
+    assert.ok(res.statusCode === 403 || res.statusCode === 404);
+    assert.ok(!res.body.includes("SECRET FILE"));
+  });
+
+  it("returns 400 Bad Request for malformed URI", async () => {
+    const res = await request("/%2e%2e%2f%c0%af%c0%afclient-secrets/test-secret.txt");
+    assert.equal(res.statusCode, 400);
+    assert.equal(res.body, "Bad Request");
+  });
+});


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path Traversal via URL-encoded components in `httpServer.ts`. The custom file server extracted paths from request URLs and verified they were contained within `distClientDir` using string matching. However, because URL-encoded values like `%2e%2e` (representing `..`) were not explicitly decoded prior to `path.posix.normalize`, the normalizer left them intact, which effectively bypassed the `startsWith()` boundaries since `path.resolve` handles encoded strings literally, potentially leading to unauthorized filesystem read access later when the string reaches the file system natively.
🎯 **Impact:** Attackers could break out of the configured static document root and read arbitrary files on the system with the same privileges as the Node.js process by sending URL-encoded dot-dot-slash characters.
🔧 **Fix:** Wrapped the incoming request path in `decodeURIComponent()` inside a `try/catch` block before applying normalization logic. Malformed encodings will now cleanly drop the connection with a 400 Bad Request.
✅ **Verification:** A new test suite was added in `tests/web/pathTraversal.test.ts` to actively test for bypassing using `/../`, `/%2e%2e/`, and malformed URI payloads. All tests passed. Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [13040755560575567873](https://jules.google.com/task/13040755560575567873) started by @Andy963*