### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to clear and delete buttons in composer

### DIFF
--- a/client/src/components/MainChatComposerPanel.vue
+++ b/client/src/components/MainChatComposerPanel.vue
@@ -334,7 +334,7 @@ const {
           {{ q.text || `[图片 x${q.imagesCount}]` }}
           <span v-if="q.text && q.imagesCount" class="queue-sub"> · 图片 x{{ q.imagesCount }}</span>
         </div>
-        <button class="queue-del" type="button" title="移除" @click="emit('removeQueued', q.id)">
+        <button class="queue-del" type="button" title="移除" aria-label="移除排队消息" @click="emit('removeQueued', q.id)">
           <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path
               fill-rule="evenodd"
@@ -361,7 +361,7 @@ const {
           <span v-else class="attachmentsThumbFallback">图片</span>
         </button>
       </div>
-      <button class="attachmentsClear" type="button" title="清空图片" @click="emit('clearImages')">
+      <button class="attachmentsClear" type="button" title="清空图片" aria-label="清空图片" @click="emit('clearImages')">
         <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
           <path
             fill-rule="evenodd"


### PR DESCRIPTION
## 🎨 Palette: [UX improvement] Add ARIA labels to clear and delete buttons in composer

**💡 What:** 
Added `aria-label` attributes to the icon-only "clear images" and "delete queued prompt" buttons in `MainChatComposerPanel.vue`.

**🎯 Why:** 
These buttons previously only had `title` attributes. While `title` provides a tooltip on hover, `aria-label` is the robust standard for ensuring screen readers accurately announce the purpose of icon-only interactive elements. Without this, screen reader users would only hear "button", leaving them guessing about the action.

**♿ Accessibility:** 
Improves screen reader accessibility by providing explicit, semantic names ("清空图片" and "移除排队消息") for these key composer actions.

---
*PR created automatically by Jules for task [9792656689722965050](https://jules.google.com/task/9792656689722965050) started by @Andy963*