### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF protection missing on PUT method

### DIFF
--- a/server/web/server/http.ts
+++ b/server/web/server/http.ts
@@ -2,7 +2,7 @@ import type http from "node:http";
 
 export function isStateChangingMethod(method: string | undefined): boolean {
   const normalized = String(method ?? "").toUpperCase();
-  return normalized === "POST" || normalized === "PATCH" || normalized === "DELETE";
+  return normalized === "POST" || normalized === "PUT" || normalized === "PATCH" || normalized === "DELETE";
 }
 
 export function resolveClientIp(req: http.IncomingMessage): string | null {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `isStateChangingMethod` missed the `PUT` HTTP method, which modifies state. 
🎯 Impact: This oversight could allow `PUT` requests to bypass state checks such as CSRF verification, rate limiting, and other critical security constraints.
🔧 Fix: Added `PUT` to the normalized string comparison in `isStateChangingMethod`.
✅ Verification: Ran testing to ensure functionality.

---
*PR created automatically by Jules for task [9642674772111277337](https://jules.google.com/task/9642674772111277337) started by @Andy963*