### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon buttons

### DIFF
--- a/client/src/components/MainChatComposerPanel.vue
+++ b/client/src/components/MainChatComposerPanel.vue
@@ -334,7 +334,7 @@ const {
           {{ q.text || `[图片 x${q.imagesCount}]` }}
           <span v-if="q.text && q.imagesCount" class="queue-sub"> · 图片 x{{ q.imagesCount }}</span>
         </div>
-        <button class="queue-del" type="button" title="移除" @click="emit('removeQueued', q.id)">
+        <button class="queue-del" type="button" title="移除" aria-label="移除" @click="emit('removeQueued', q.id)">
           <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path
               fill-rule="evenodd"
@@ -361,7 +361,7 @@ const {
           <span v-else class="attachmentsThumbFallback">图片</span>
         </button>
       </div>
-      <button class="attachmentsClear" type="button" title="清空图片" @click="emit('clearImages')">
+      <button class="attachmentsClear" type="button" title="清空图片" aria-label="清空图片" @click="emit('clearImages')">
         <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
           <path
             fill-rule="evenodd"
@@ -385,7 +385,7 @@ const {
       />
       <div class="inputToolbar">
         <div class="inputToolbarLeft">
-          <button class="attachIcon" type="button" title="添加图片附件" @click="triggerFileInput">
+          <button class="attachIcon" type="button" title="添加图片附件" aria-label="添加图片附件" @click="triggerFileInput">
             <svg width="18" height="18" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path
                 fill-rule="evenodd"
@@ -454,6 +454,7 @@ const {
             :disabled="canInterrupt || transcribing"
             type="button"
             :title="recording ? '停止录音' : '语音输入（追加到输入框）'"
+            :aria-label="recording ? '停止录音' : '语音输入（追加到输入框）'"
             @click="toggleRecording"
           >
             <svg width="18" height="18" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -463,7 +464,7 @@ const {
               />
             </svg>
           </button>
-          <button v-if="canInterrupt" class="stopIcon" type="button" title="中断" @click="emit('interrupt')">
+          <button v-if="canInterrupt" class="stopIcon" type="button" title="中断" aria-label="中断" @click="emit('interrupt')">
             <span class="interruptSpinner" aria-hidden="true" />
           </button>
           <button
@@ -472,6 +473,7 @@ const {
             :disabled="(!input.trim() && pendingImages.length === 0) || recording || transcribing"
             type="button"
             title="发送"
+            aria-label="发送"
             @click="send"
           >
             <svg width="18" height="18" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/client/src/components/TaskBoard.vue
+++ b/client/src/components/TaskBoard.vue
@@ -940,7 +940,7 @@ function toggleQueue(): void {
                     </svg>
                   </button>
                   <button v-if="isActionAllowed(t, 'rerun') && canRerunTask(t) && editingId !== t.id"
-                    class="iconBtn primary" type="button" title="重新执行" :disabled="Boolean(editingId)"
+                    class="iconBtn primary" type="button" title="重新执行" aria-label="重新执行" :disabled="Boolean(editingId)"
                     @click.stop="startEdit(t)">
                     <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                       <path fill-rule="evenodd"
@@ -949,13 +949,13 @@ function toggleQueue(): void {
                     </svg>
                   </button>
                   <button v-if="isActionAllowed(t, 'edit') && canEditTask(t) && !canRerunTask(t) && editingId !== t.id"
-                    class="iconBtn" type="button" title="编辑" :disabled="Boolean(editingId)" data-testid="task-edit"
+                    class="iconBtn" type="button" title="编辑" aria-label="编辑" :disabled="Boolean(editingId)" data-testid="task-edit"
                     @click.stop="startEdit(t)">
                     <el-icon :size="16" aria-hidden="true" class="icon">
                       <Edit />
                     </el-icon>
                   </button>
-                  <button v-if="editingId === t.id" class="iconBtn" type="button" title="取消编辑"
+                  <button v-if="editingId === t.id" class="iconBtn" type="button" title="取消编辑" aria-label="取消编辑"
                     @click.stop="stopEdit()">
                     <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                       <path fill-rule="evenodd"
@@ -964,18 +964,18 @@ function toggleQueue(): void {
                     </svg>
                   </button>
                   <button v-if="isActionAllowed(t, 'cancel') && (t.status === 'running' || t.status === 'planning')"
-                    class="iconBtn danger" type="button" title="终止任务" @click.stop="emit('cancel', t.id)">
+                    class="iconBtn danger" type="button" title="终止任务" aria-label="终止任务" @click.stop="emit('cancel', t.id)">
                     <span class="interruptSpinner" aria-hidden="true" />
                   </button>
                   <button v-if="isActionAllowed(t, 'retry') && t.status === 'failed'" class="iconBtn" type="button"
-                    title="重试" @click.stop="emit('retry', t.id)">
+                    title="重试" aria-label="重试" @click.stop="emit('retry', t.id)">
                     <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                       <path fill-rule="evenodd"
                         d="M10 4a6 6 0 0 0-5.2 9h2.1a1 1 0 0 1 .8 1.6l-2.4 3.2a1 1 0 0 1-1.6 0l-2.4-3.2A1 1 0 0 1 2.1 13h1.2A8 8 0 1 1 10 18a.75.75 0 0 1 0-1.5A6.5 6.5 0 1 0 3.62 10a.75.75 0 1 1-1.5 0A8 8 0 0 1 10 2a.75.75 0 0 1 0 1.5Z"
                         clip-rule="evenodd" />
                     </svg>
                   </button>
-                  <button v-if="isActionAllowed(t, 'delete')" class="iconBtn danger" type="button" title="删除任务"
+                  <button v-if="isActionAllowed(t, 'delete')" class="iconBtn danger" type="button" title="删除任务" aria-label="删除任务"
                     :disabled="t.status === 'running' || t.status === 'planning'" @click.stop="emit('delete', t.id)">
                     <el-icon :size="16" aria-hidden="true" class="icon">
                       <Delete />


### PR DESCRIPTION
**💡 What:**
Added `aria-label` attributes to multiple icon-only buttons in `TaskBoard.vue` and `MainChatComposerPanel.vue` that only had `title` attributes.

**🎯 Why:**
While `title` attributes provide visual tooltips, `aria-label` is explicitly designed for screen readers and assistive technologies to guarantee accurate parsing. Adding both ensures a fully accessible, inclusive experience without affecting the existing visual design.

**📸 Before/After:**
- **Before:** `<button class="iconBtn" title="删除任务" ...>`
- **After:** `<button class="iconBtn" title="删除任务" aria-label="删除任务" ...>`
(No visual changes).

**♿ Accessibility:**
Improves keyboard and screen reader accessibility by ensuring interactive elements without visible text can be properly identified.

---
*PR created automatically by Jules for task [12665109606504064533](https://jules.google.com/task/12665109606504064533) started by @Andy963*