### PR TITLE
⚡ Bolt: [performance improvement] Optimize array backwards searching with `findLast`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Array backwards search optimization
+**Learning:** Found multiple instances of `[...array].reverse().find()` being used for array backwards searching. This is an anti-pattern as it causes an O(N) memory allocation and array mutation before performing the search.
+**Action:** Replaced instances of `[...array].reverse().find()` with the native ES2023 `array.findLast()` method to avoid unnecessary memory allocations.

--- a/server/utils/activityTracker/shell.ts
+++ b/server/utils/activityTracker/shell.ts
@@ -177,7 +177,7 @@ function summarizeSed(commandLine: string): string | null {
   if (tokens[0] !== "sed") {
     return null;
   }
-  const file = [...tokens].reverse().find((token) => token && !token.startsWith("-"));
+  const file = tokens.findLast((token) => token && !token.startsWith("-"));
   if (!file || file === "sed") {
     return null;
   }

--- a/server/web/server/api/routes/tasks.ts
+++ b/server/web/server/api/routes/tasks.ts
@@ -429,7 +429,7 @@ export async function handleTaskRoutes(ctx: ApiRouteContext, deps: ApiSharedDeps
 
     try {
       const contexts = taskCtx.taskStore.getContext(source.id);
-      const latestPatch = [...contexts].reverse().find((c) => c.contextType === "artifact:workspace_patch") ?? null;
+      const latestPatch = contexts.findLast((c) => c.contextType === "artifact:workspace_patch") ?? null;
       if (latestPatch) {
         taskCtx.taskStore.saveContext(
           created.id,

--- a/server/web/server/taskQueue/manager.ts
+++ b/server/web/server/taskQueue/manager.ts
@@ -873,9 +873,9 @@ export function createTaskQueueManager(deps: {
       })();
       try {
         const contexts = ctx.taskStore.getContext(taskId);
-        const latestPatch = [...contexts].reverse().find((c) => c.contextType === "artifact:workspace_patch") ?? null;
+        const latestPatch = contexts.findLast((c) => c.contextType === "artifact:workspace_patch") ?? null;
         patchArtifact = latestPatch ? safeParseJson<TaskWorkspacePatchArtifact>(latestPatch.content) : null;
-        const latestChanged = [...contexts].reverse().find((c) => c.contextType === "artifact:changed_paths") ?? null;
+        const latestChanged = contexts.findLast((c) => c.contextType === "artifact:changed_paths") ?? null;
         const changedParsed = latestChanged ? safeParseJson<ChangedPathsContext>(latestChanged.content) : null;
         changedFiles = Array.isArray(changedParsed?.paths)
           ? (changedParsed?.paths as unknown[]).map((p) => String(p ?? "").trim()).filter(Boolean)


### PR DESCRIPTION
💡 **What:** Replaced instances of the anti-pattern `[...array].reverse().find()` with the native ES2023 `array.findLast()` method.
🎯 **Why:** The previous approach caused an unnecessary O(N) memory allocation and array mutation before performing the search. This is an explicit codebase anti-pattern.
📊 **Impact:** Reduces memory allocation and avoids mutating array copies during backwards search operations.
🔬 **Measurement:** Verify by ensuring `findLast` is used instead of `.reverse().find()` and all tests pass (or remain unchanged in their failure state, as observed with unrelated skills tests).

---
*PR created automatically by Jules for task [10361612184389494265](https://jules.google.com/task/10361612184389494265) started by @Andy963*