### PR TITLE
⚡ Bolt: [performance improvement] Optimize array searches with findLast

### DIFF
--- a/server/utils/activityTracker/shell.ts
+++ b/server/utils/activityTracker/shell.ts
@@ -177,7 +177,8 @@ function summarizeSed(commandLine: string): string | null {
   if (tokens[0] !== "sed") {
     return null;
   }
-  const file = [...tokens].reverse().find((token) => token && !token.startsWith("-"));
+  // ⚡ Bolt: Use findLast instead of [...array].reverse().find() to avoid O(N) memory allocation
+  const file = tokens.findLast((token) => token && !token.startsWith("-"));
   if (!file || file === "sed") {
     return null;
   }

--- a/server/web/server/api/routes/tasks.ts
+++ b/server/web/server/api/routes/tasks.ts
@@ -429,7 +429,8 @@ export async function handleTaskRoutes(ctx: ApiRouteContext, deps: ApiSharedDeps
 
     try {
       const contexts = taskCtx.taskStore.getContext(source.id);
-      const latestPatch = [...contexts].reverse().find((c) => c.contextType === "artifact:workspace_patch") ?? null;
+      // ⚡ Bolt: Use findLast instead of [...array].reverse().find() to avoid O(N) memory allocation
+      const latestPatch = contexts.findLast((c) => c.contextType === "artifact:workspace_patch") ?? null;
       if (latestPatch) {
         taskCtx.taskStore.saveContext(
           created.id,

--- a/server/web/server/taskQueue/manager.ts
+++ b/server/web/server/taskQueue/manager.ts
@@ -873,9 +873,10 @@ export function createTaskQueueManager(deps: {
       })();
       try {
         const contexts = ctx.taskStore.getContext(taskId);
-        const latestPatch = [...contexts].reverse().find((c) => c.contextType === "artifact:workspace_patch") ?? null;
+        // ⚡ Bolt: Use findLast instead of [...array].reverse().find() to avoid O(N) memory allocation
+        const latestPatch = contexts.findLast((c) => c.contextType === "artifact:workspace_patch") ?? null;
         patchArtifact = latestPatch ? safeParseJson<TaskWorkspacePatchArtifact>(latestPatch.content) : null;
-        const latestChanged = [...contexts].reverse().find((c) => c.contextType === "artifact:changed_paths") ?? null;
+        const latestChanged = contexts.findLast((c) => c.contextType === "artifact:changed_paths") ?? null;
         const changedParsed = latestChanged ? safeParseJson<ChangedPathsContext>(latestChanged.content) : null;
         changedFiles = Array.isArray(changedParsed?.paths)
           ? (changedParsed?.paths as unknown[]).map((p) => String(p ?? "").trim()).filter(Boolean)


### PR DESCRIPTION
💡 What: Replaced occurrences of `[...array].reverse().find(condition)` with the native ES2023 method `array.findLast(condition)` in:
- `server/utils/activityTracker/shell.ts`
- `server/web/server/api/routes/tasks.ts`
- `server/web/server/taskQueue/manager.ts`

🎯 Why: The original pattern spreads an existing array into a new one and then reverses it in place just to search it from the end. This is a common performance anti-pattern that creates unnecessary `O(N)` memory allocations and operations.

📊 Impact: Reduces memory overhead and processing time to `O(1)` memory allocation and `O(N)` search time, eliminating garbage collection pressure for hot paths where shell tokens and context arrays are parsed.

🔬 Measurement: Verify correctness by ensuring unit tests continue to pass and `[...array].reverse().find()` is no longer present in these files.

---
*PR created automatically by Jules for task [17283302532525086920](https://jules.google.com/task/17283302532525086920) started by @Andy963*