### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing PUT method in CSRF protection

### DIFF
--- a/server/web/server/http.ts
+++ b/server/web/server/http.ts
@@ -2,7 +2,7 @@ import type http from "node:http";
 
 export function isStateChangingMethod(method: string | undefined): boolean {
   const normalized = String(method ?? "").toUpperCase();
-  return normalized === "POST" || normalized === "PATCH" || normalized === "DELETE";
+  return normalized === "POST" || normalized === "PUT" || normalized === "PATCH" || normalized === "DELETE";
 }
 
 export function resolveClientIp(req: http.IncomingMessage): string | null {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `isStateChangingMethod` helper failed to identify `PUT` requests, allowing CSRF protection (origin validation) to be bypassed for PUT endpoints.
🎯 Impact: Attackers could potentially bypass CSRF protection for any state-changing endpoint using the PUT method.
🔧 Fix: Explicitly included the `PUT` method in the `isStateChangingMethod` checks inside `server/web/server/http.ts`.
✅ Verification: Ran `pnpm test` (all 823 tests passed) to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [16375919864522015342](https://jules.google.com/task/16375919864522015342) started by @Andy963*