### PR TITLE
refactor: unify user and agent message recording across channels

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,6 +38,12 @@ ADS (Agent Dispatch & Orchestration System) 采用分层解耦的架构设计，
 
 ## 2. 核心架构特性
 
+### 2.0 统一会话消息记录
+
+Web、Telegram 与 Task Queue 保留各自现有的本地存储和消息交付行为。通道接受最终用户消息或成功记录最终 Agent 回复后，还会通过 `server/utils/conversationMessageRecorder.ts` 中的共享 `ConversationMessageRecorder` 契约发布规范化消息。
+
+该契约携带消息 ID、工作区、会话、来源、角色、正文及可用的 Agent 身份。消费者是可选且隔离的：recorder 抛错不得影响本地持久化、模型调用或通道交付。流式增量、命令、状态事件、工具输出和错误不属于最终会话消息，不通过该契约发布。
+
 ### 2.1 双层存储模型 (Two-Tier Storage)
 - **全局状态库 (`state.db`)**：
   - 存放 Web 管理员账号、认证 Session、模型管理配置、跨工作区全局规则（Global Rules）以及多工作区注册表。

--- a/server/tasks/executor.ts
+++ b/server/tasks/executor.ts
@@ -14,6 +14,7 @@ import {
   getLatestContextOfType,
   formatWorkspacePatchArtifactForPrompt,
 } from "./executorHelpers.js";
+import { recordConversationMessage } from "../utils/conversationMessageRecorder.js";
 
 export interface TaskExecutorHooks {
   onMessage?: (message: { role: string; content: string; modelUsed?: string | null }) => void;
@@ -144,7 +145,7 @@ export class OrchestratorTaskExecutor implements TaskExecutor {
         } catch {
           // ignore
         }
-        this.store.addConversationMessage({
+        const persistedUser = this.store.addConversationMessage({
           conversationId,
           taskId: task.id,
           role: "user",
@@ -153,6 +154,15 @@ export class OrchestratorTaskExecutor implements TaskExecutor {
           tokenCount: null,
           metadata: null,
           createdAt: Date.now(),
+        });
+        recordConversationMessage({
+          eventId: `${task.id}:user`,
+          workspaceRoot: this.workspaceRoot,
+          sessionId: conversationId,
+          source: "task",
+          role: "user",
+          text: persistedUser.content,
+          agentId,
         });
 
         const prompt = [
@@ -358,7 +368,7 @@ export class OrchestratorTaskExecutor implements TaskExecutor {
         } catch {
           // ignore
         }
-        this.store.addConversationMessage({
+        const persistedAssistant = this.store.addConversationMessage({
           conversationId,
           taskId: task.id,
           role: "assistant",
@@ -367,6 +377,15 @@ export class OrchestratorTaskExecutor implements TaskExecutor {
           tokenCount: null,
           metadata: null,
           createdAt: Date.now(),
+        });
+        recordConversationMessage({
+          eventId: `${task.id}:assistant`,
+          workspaceRoot: this.workspaceRoot,
+          sessionId: conversationId,
+          source: "task",
+          role: "assistant",
+          text: persistedAssistant.content,
+          agentId,
         });
         options?.hooks?.onMessage?.({ role: "assistant", content: lastOutput, modelUsed: modelForStorage });
 

--- a/server/telegram/adapters/codex.ts
+++ b/server/telegram/adapters/codex.ts
@@ -28,6 +28,7 @@ import { transcribeTelegramVoiceMessage } from '../utils/voiceTranscription.js';
 import type { ScheduleCompiler } from '../../scheduler/compiler.js';
 import type { SchedulerRuntime } from '../../scheduler/runtime.js';
 import { processScheduleOutput } from '../../web/server/planner/scheduleHandler.js';
+import { recordConversationMessage } from '../../utils/conversationMessageRecorder.js';
 // 全局中断管理器
 const interruptManager = new InterruptManager();
 const adapterLogger = createLogger('TelegramCodexAdapter');
@@ -347,6 +348,16 @@ export async function handleCodexMessage(
 
     // 记录用户输入
     userLogEntry = buildUserLogEntry(effectiveText, imagePaths, filePaths);
+    const telegramEventId = `telegram:${chatId}:${ctx.message?.message_id ?? ctx.update.update_id}`;
+    recordConversationMessage({
+      eventId: `${telegramEventId}:user`,
+      workspaceRoot,
+      sessionId: String(session.getThreadId?.() ?? `telegram-${chatId}`),
+      source: 'telegram',
+      role: 'user',
+      text: userLogEntry,
+      agentId: session.getActiveAgentId?.() ?? 'codex',
+    });
 
     // 监听事件
     unsubscribe = session.onEvent((event: AgentEvent) => {
@@ -449,6 +460,15 @@ export async function handleCodexMessage(
       replyOptions: replyParameters,
       logWarning,
       recordFallback,
+    });
+    recordConversationMessage({
+      eventId: `${telegramEventId}:assistant`,
+      workspaceRoot,
+      sessionId: String(session.getThreadId?.() ?? `telegram-${chatId}`),
+      source: 'telegram',
+      role: 'assistant',
+      text: outputToSend,
+      agentId: session.getActiveAgentId?.() ?? 'codex',
     });
 
     await statusUpdater.cleanup();

--- a/server/utils/conversationMessageRecorder.ts
+++ b/server/utils/conversationMessageRecorder.ts
@@ -1,0 +1,34 @@
+export type ConversationMessageSource = "web" | "telegram" | "task";
+
+export type ConversationMessage = {
+  eventId: string;
+  workspaceRoot: string;
+  sessionId: string;
+  source: ConversationMessageSource;
+  role: "user" | "assistant";
+  text: string;
+  agentId?: string;
+};
+
+export interface ConversationMessageRecorder {
+  record(message: ConversationMessage): void;
+}
+
+const noopRecorder: ConversationMessageRecorder = { record: () => undefined };
+let recorder: ConversationMessageRecorder = noopRecorder;
+
+export function setConversationMessageRecorder(next: ConversationMessageRecorder | null | undefined): void {
+  recorder = next ?? noopRecorder;
+}
+
+export function getConversationMessageRecorder(): ConversationMessageRecorder {
+  return recorder;
+}
+
+export function recordConversationMessage(message: ConversationMessage): void {
+  try {
+    recorder.record(message);
+  } catch {
+    // Observers must never break local message persistence.
+  }
+}

--- a/server/web/server/ws/handlePrompt.ts
+++ b/server/web/server/ws/handlePrompt.ts
@@ -34,6 +34,7 @@ import { attachWorkerPromptHandler } from "./workerPromptHandler.js";
 import { processPromptOutputBlocks } from "./promptOutputProcessing.js";
 import { handlePromptError } from "./promptErrorHandling.js";
 import { beginWsPromptRun, isWsPromptAbort, raceWsPromptAbort } from "./promptLifecycle.js";
+import { recordConversationMessage } from "../../../utils/conversationMessageRecorder.js";
 
 export { buildHistoryInjectionContext, prependContextToInput } from "./promptModelConfig.js";
 export { formatWriteExploredSummary } from "./workerPromptHandler.js";
@@ -371,7 +372,18 @@ export async function handlePromptMessage(deps: WsPromptHandlerDeps): Promise<{
         deps.observability.sessionLogger.attachThreadId(threadId ?? undefined);
         deps.observability.sessionLogger.logOutput(outputForChat);
       }
-      deps.history.historyStore.add(deps.context.historyKey, { role: "ai", text: outputForChat, ts: Date.now() });
+      const persistedAssistant = deps.history.historyStore.add(deps.context.historyKey, { role: "ai", text: outputForChat, ts: Date.now() });
+      if (persistedAssistant) {
+        recordConversationMessage({
+          eventId: `${deps.request.clientMessageId ?? deps.request.requestId}:assistant`,
+          workspaceRoot,
+          sessionId: deps.context.sessionId,
+          source: "web",
+          role: "assistant",
+          text: outputForChat,
+          agentId: orchestrator.getActiveAgentId?.(),
+        });
+      }
       if (threadReset) {
         deps.sessions.sessionManager.markHistoryInjection(deps.context.userId);
       }

--- a/server/web/server/ws/preflight.ts
+++ b/server/web/server/ws/preflight.ts
@@ -59,6 +59,7 @@ export function preflightPersistAndAck(args: {
   warn: (message: string) => void;
   sessionId: string;
   userId: number;
+  onPersistedMessage?: (message: { clientMessageId: string; role: "user"; text: string }) => void;
 }): { enqueue: boolean } {
   if (!args.clientMessageId) {
     return { enqueue: true };
@@ -120,6 +121,7 @@ export function preflightPersistAndAck(args: {
       }
       return { enqueue: replayIncomplete };
     }
+    args.onPersistedMessage?.({ clientMessageId: args.clientMessageId, role: "user", text: textResult.text });
     args.broadcastPersistedHistory?.();
     args.broadcastInFlight?.();
     return { enqueue: true };

--- a/server/web/server/ws/server.ts
+++ b/server/web/server/ws/server.ts
@@ -30,6 +30,7 @@ import { preflightPersistAndAck } from "./preflight.js";
 import { resolveSharedWorkerSyncLaneKey, resolveSyncLaneKeys, resolveSyncNamespace } from "../sync/lane.js";
 import { isStreamTerminalEvent, isTransientSyncEvent } from "../sync/eventClass.js";
 import { createDeltaStreamCoalescer } from "../sync/deltaStream.js";
+import { recordConversationMessage } from "../../../utils/conversationMessageRecorder.js";
 
 type AliveWebSocket = WebSocket & { isAlive?: boolean; missedPongs?: number; sessionTokenHash?: string };
 
@@ -530,6 +531,17 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
         warn: (message) => logger.warn(message),
         sessionId,
         userId,
+        onPersistedMessage: ({ clientMessageId: persistedId, text }) => {
+          recordConversationMessage({
+            eventId: persistedId,
+            workspaceRoot: normalizeWorkspaceRootForMeta(currentCwd),
+            sessionId,
+            source: "web",
+            role: "user",
+            text,
+            agentId: orchestrator.getActiveAgentId?.(),
+          });
+        },
       });
       if (!preflight.enqueue) {
         return;

--- a/tests/tasks/taskExecutorConversationRecorder.test.ts
+++ b/tests/tasks/taskExecutorConversationRecorder.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { OrchestratorTaskExecutor } from "../../server/tasks/executor.js";
+import { TaskStore } from "../../server/tasks/store.js";
+import type { Task } from "../../server/tasks/types.js";
+import { resetDatabaseForTests } from "../../server/storage/database.js";
+import {
+  setConversationMessageRecorder,
+  type ConversationMessage,
+} from "../../server/utils/conversationMessageRecorder.js";
+
+describe("task executor conversation recorder", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ads-task-recorder-"));
+    process.env.ADS_DATABASE_PATH = path.join(tmpDir, "tasks.db");
+    resetDatabaseForTests();
+  });
+
+  afterEach(() => {
+    setConversationMessageRecorder(null);
+    resetDatabaseForTests();
+    delete process.env.ADS_DATABASE_PATH;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("publishes the persisted user and final assistant messages", async () => {
+    const recorded: ConversationMessage[] = [];
+    setConversationMessageRecorder({ record: (message) => recorded.push(message) });
+    const store = new TaskStore();
+    const task = store.createTask({ title: "Fix bug", prompt: "Apply the fix", model: "auto" }) as Task;
+    const orchestrator = {
+      setModel() {},
+      setWorkingDirectory() {},
+      onEvent() { return () => undefined; },
+      async invokeAgent() { return { response: "Done" }; },
+    };
+    const executor = new OrchestratorTaskExecutor({
+      getOrchestrator: () => orchestrator as never,
+      store,
+      workspaceRoot: tmpDir,
+      autoModelOverride: "mock",
+    });
+
+    await executor.execute(task);
+
+    assert.deepEqual(recorded.map(({ source, role, text, workspaceRoot }) => ({ source, role, text, workspaceRoot })), [
+      { source: "task", role: "user", text: "任务标题: Fix bug\n任务描述: Apply the fix", workspaceRoot: tmpDir },
+      { source: "task", role: "assistant", text: "Done", workspaceRoot: tmpDir },
+    ]);
+  });
+});

--- a/tests/telegram/conversationMessageRecorder.test.ts
+++ b/tests/telegram/conversationMessageRecorder.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Context } from "grammy";
+
+import { handleCodexMessage } from "../../server/telegram/adapters/codex.js";
+import {
+  setConversationMessageRecorder,
+  type ConversationMessage,
+} from "../../server/utils/conversationMessageRecorder.js";
+
+describe("telegram conversation message recorder", () => {
+  const originalStatusUpdates = process.env.ADS_TELEGRAM_STATUS_UPDATES;
+
+  beforeEach(() => {
+    process.env.ADS_TELEGRAM_STATUS_UPDATES = "false";
+  });
+
+  afterEach(() => {
+    setConversationMessageRecorder(null);
+    if (originalStatusUpdates === undefined) delete process.env.ADS_TELEGRAM_STATUS_UPDATES;
+    else process.env.ADS_TELEGRAM_STATUS_UPDATES = originalStatusUpdates;
+  });
+
+  it("publishes accepted user input and the delivered final reply", async () => {
+    const recorded: ConversationMessage[] = [];
+    const replies: string[] = [];
+    setConversationMessageRecorder({ record: (message) => recorded.push(message) });
+
+    const session = {
+      getThreadId: () => "thread-1",
+      getActiveAgentId: () => "codex",
+      onEvent: () => () => undefined,
+      async send() { return { response: "Final answer" }; },
+    };
+    const sessionManager = {
+      getOrCreate: () => session,
+      saveThreadId: () => undefined,
+      reset: () => undefined,
+    };
+    const ctx = {
+      from: { id: 7 },
+      chat: { id: 42 },
+      message: { message_id: 99 },
+      update: { update_id: 123 },
+      api: { sendChatAction: async () => true },
+      reply: async (text: string) => {
+        replies.push(text);
+        return { message_id: replies.length };
+      },
+    } as unknown as Context;
+
+    await handleCodexMessage(ctx, "User prompt", sessionManager as never, 0, undefined, undefined, process.cwd());
+
+    assert.equal(replies.length, 1);
+    assert.deepEqual(recorded.map(({ eventId, source, role, text, sessionId }) => ({ eventId, source, role, text, sessionId })), [
+      { eventId: "telegram:42:99:user", source: "telegram", role: "user", text: "User prompt", sessionId: "thread-1" },
+      { eventId: "telegram:42:99:assistant", source: "telegram", role: "assistant", text: "Final answer", sessionId: "thread-1" },
+    ]);
+  });
+});

--- a/tests/utils/conversationMessageRecorder.test.ts
+++ b/tests/utils/conversationMessageRecorder.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  recordConversationMessage,
+  setConversationMessageRecorder,
+  type ConversationMessage,
+} from "../../server/utils/conversationMessageRecorder.js";
+
+const message: ConversationMessage = {
+  eventId: "event-1",
+  workspaceRoot: "/workspace",
+  sessionId: "session-1",
+  source: "web",
+  role: "user",
+  text: "hello",
+  agentId: "codex",
+};
+
+describe("conversation message recorder", () => {
+  afterEach(() => setConversationMessageRecorder(null));
+
+  it("publishes normalized messages to the configured recorder", () => {
+    const recorded: ConversationMessage[] = [];
+    setConversationMessageRecorder({ record: (entry) => recorded.push(entry) });
+    recordConversationMessage(message);
+    assert.deepEqual(recorded, [message]);
+  });
+
+  it("isolates recorder failures from the caller", () => {
+    setConversationMessageRecorder({ record: () => { throw new Error("observer failed"); } });
+    assert.doesNotThrow(() => recordConversationMessage(message));
+  });
+});

--- a/tests/web/preflight.test.ts
+++ b/tests/web/preflight.test.ts
@@ -83,6 +83,7 @@ describe("web/ws/preflight", () => {
   it("persists prompt execution metadata and dedupes by client id", () => {
     const historyStore = new HistoryStore({ namespace: "test-preflight-prompt-meta", maxEntriesPerSession: 20 });
     const sent: unknown[] = [];
+    const persistedMessages: Array<{ clientMessageId: string; role: "user"; text: string }> = [];
     const sanitizeInput = (payload: unknown) => {
       if (typeof payload === "string") return payload;
       if (payload && typeof payload === "object" && !Array.isArray(payload)) {
@@ -109,6 +110,7 @@ describe("web/ws/preflight", () => {
         warn: () => {},
         sessionId: "session-1",
         userId: 7,
+        onPersistedMessage: (message) => persistedMessages.push(message),
       });
       const second = preflightPersistAndAck({
         parsed: {
@@ -127,11 +129,13 @@ describe("web/ws/preflight", () => {
         warn: () => {},
         sessionId: "session-1",
         userId: 7,
+        onPersistedMessage: (message) => persistedMessages.push(message),
       });
 
       const entries = historyStore.get("history-1");
       assert.deepEqual(first, { enqueue: true });
       assert.deepEqual(second, { enqueue: false });
+      assert.deepEqual(persistedMessages, [{ clientMessageId: "p1", role: "user", text: "hello" }]);
       assert.deepEqual(sent, [
         { type: "ack", client_message_id: "p1", duplicate: false },
         { type: "ack", client_message_id: "p1", duplicate: true },


### PR DESCRIPTION
## Summary

- add one normalized recorder contract for final user and assistant messages
- publish messages from Web, Telegram, and Task Queue after their existing acceptance or persistence points
- isolate recorder failures from channel persistence, model invocation, and delivery
- document the contract and cover channel integrations with tests

## Scope

This PR does not change turn lifecycle, model invocation, context injection, database schema, migrations, or cf-mem integration.

## Verification

- npm test (968 passed)
- npm run lint
- npm run build

Closes #52