### PR TITLE
fix: keep plan cards synchronized and deduplicated

### DIFF
--- a/client/src/app/projectsWs/wsMessage.ts
+++ b/client/src/app/projectsWs/wsMessage.ts
@@ -1343,10 +1343,14 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
       const itemId = `plan:${planId}`;
       const existing = Array.isArray(rt.messages.value) ? rt.messages.value.slice() : [];
       const content = items.map((entry) => `${entry.status === "completed" ? "[x]" : entry.status === "in_progress" ? "[~]" : "[ ]"} ${entry.text}`).join("\n");
-      const idx = existing.findIndex((m) => String(m?.id ?? "") === itemId);
+      const matchingIndexes = existing
+        .map((message, index) => String(message?.plan?.planId ?? "").trim() === planId ? index : -1)
+        .filter((index) => index >= 0);
+      const idx = matchingIndexes[0] ?? -1;
       if (idx >= 0) {
         existing[idx] = { ...existing[idx]!, content, plan, ts };
-        rt.messages.value = existing;
+        const duplicates = new Set(matchingIndexes.slice(1));
+        rt.messages.value = existing.filter((_message, index) => !duplicates.has(index));
       } else {
         pushMessageBeforeLive({ id: itemId, role: "system", kind: "plan", content, plan, ts }, rt);
       }

--- a/client/src/lib/chat_sync.test.ts
+++ b/client/src/lib/chat_sync.test.ts
@@ -25,6 +25,7 @@ function msg(overrides: Partial<ChatItem>): ChatItem {
     commandsLimit: overrides.commandsLimit,
     ts: overrides.ts,
     streaming: overrides.streaming,
+    plan: overrides.plan,
   };
 }
 
@@ -109,6 +110,49 @@ describe("chat_sync.finalizeStreamingOnDisconnect", () => {
 });
 
 describe("chat_sync.mergeHistoryFromServer", () => {
+  it("keeps only the newest snapshot for a duplicated logical plan", () => {
+    const plan = (id: string, status: "in_progress" | "completed", itemStatus: "pending" | "completed") =>
+      msg({
+        id,
+        role: "system",
+        kind: "plan",
+        content: itemStatus === "completed" ? "[x] Step" : "[ ] Step",
+        plan: { planId: "logical-plan", status, items: [{ text: "Step", status: itemStatus }] },
+      });
+    const server = [
+      msg({ id: "u1", role: "user", content: "Work" }),
+      plan("plan:first", "in_progress", "pending"),
+      plan("plan:second", "completed", "completed"),
+    ];
+
+    const out = mergeHistoryFromServer([], server, LIVE);
+
+    expect(out.filter((item) => item.kind === "plan")).toHaveLength(1);
+    expect(out.find((item) => item.kind === "plan")?.plan?.status).toBe("completed");
+  });
+
+  it("prefers a persisted plan snapshot over a stale local snapshot", () => {
+    const local = [
+      msg({ id: "u1", role: "user", content: "Work" }),
+      msg({
+        id: "plan:live", role: "system", kind: "plan", content: "[ ] Step",
+        plan: { planId: "logical-plan", status: "in_progress", items: [{ text: "Step", status: "pending" }] },
+      }),
+    ];
+    const server = [
+      msg({ id: "h-u-0", role: "user", content: "Work" }),
+      msg({
+        id: "plan:persisted", role: "system", kind: "plan", content: "[x] Step",
+        plan: { planId: "logical-plan", status: "completed", items: [{ text: "Step", status: "completed" }] },
+      }),
+    ];
+
+    const out = mergeHistoryFromServer(local, server, LIVE);
+    const plans = out.filter((item) => item.kind === "plan");
+    expect(plans).toHaveLength(1);
+    expect(plans[0]?.plan?.status).toBe("completed");
+  });
+
   it("appends only the server tail after the newest overlap", () => {
     const local: ChatItem[] = [
       msg({ id: "u1", role: "user", content: "Hi" }),

--- a/client/src/lib/chat_sync.ts
+++ b/client/src/lib/chat_sync.ts
@@ -24,7 +24,27 @@ function isTransientExecutePreview(item: ChatItem): boolean {
 }
 
 function withoutLiveAndTransientExecute(items: ChatItem[], liveStepId: string): ChatItem[] {
-  return items.filter((m) => m.id !== liveStepId && !isTransientExecutePreview(m));
+  const filtered = items.filter((m) => m.id !== liveStepId && !isTransientExecutePreview(m));
+  const lastPlanIndex = new Map<string, number>();
+  for (let i = 0; i < filtered.length; i += 1) {
+    const planId = String(filtered[i]?.plan?.planId ?? "").trim();
+    if (planId) lastPlanIndex.set(planId, i);
+  }
+  return filtered.filter((item, index) => {
+    const planId = String(item.plan?.planId ?? "").trim();
+    return !planId || lastPlanIndex.get(planId) === index;
+  });
+}
+
+function preferServerPlanSnapshots(local: ChatItem[], server: ChatItem[]): ChatItem[] {
+  const serverPlanIds = new Set(
+    server.map((item) => String(item.plan?.planId ?? "").trim()).filter(Boolean),
+  );
+  if (serverPlanIds.size === 0) return local;
+  return local.filter((item) => {
+    const planId = String(item.plan?.planId ?? "").trim();
+    return !planId || !serverPlanIds.has(planId);
+  });
 }
 
 function toComparable(items: ChatItem[]): ComparableChat[] {
@@ -122,8 +142,8 @@ export function mergeHistoryFromServer(
   serverHistory: ChatItem[],
   liveStepId: string,
 ): ChatItem[] {
-  const local = withoutLiveAndTransientExecute(localMessages, liveStepId);
   const server = withoutLiveAndTransientExecute(serverHistory, liveStepId);
+  const local = preferServerPlanSnapshots(withoutLiveAndTransientExecute(localMessages, liveStepId), server);
   if (local.length === 0) return server;
   if (server.length === 0) return local;
 

--- a/docs/web.md
+++ b/docs/web.md
@@ -22,6 +22,7 @@ Web Console 将对话与任务流组织为三大工作区：
   - 专注于代码执行、命令运行与文件修改的执行 Lane。
   - 执行任务时先读取批准时固定的 issue/spec 快照；spec 是执行真源，issue 只提供讨论背景。
   - 实时展示任务阶段 trace（如 `[analysis]`、`[tool]`、`[editing]`）与命令执行输出（最新命令预览），自动收起长文本输出。
+  - Plan 卡片按单轮逻辑计划合并 provider 更新，并在任务完成与历史重连时保持唯一且状态一致。
 
 ### 2. Provider CLI 与全局模型配置 (Provider & Models)
 - **多 Provider CLI 接入**：

--- a/server/agents/adapters/codexAppServerAdapter.ts
+++ b/server/agents/adapters/codexAppServerAdapter.ts
@@ -615,6 +615,32 @@ export class CodexAppServerAdapter implements AgentAdapter {
       }),
     );
     cleanupFns.push(
+      client.onNotification("turn/plan/updated", (params) => {
+        if (!belongsToThisTurn(params)) return;
+        const payload = params as { plan?: unknown };
+        const steps = Array.isArray(payload.plan) ? payload.plan : [];
+        const items = steps
+          .map((step) => {
+            if (!step || typeof step !== "object") return null;
+            const rec = step as Record<string, unknown>;
+            const text = String(rec.step ?? "").trim();
+            if (!text) return null;
+            const status = String(rec.status ?? "pending").trim().toLowerCase();
+            return {
+              text,
+              status: status === "completed" ? "completed" : status === "inprogress" ? "in_progress" : "pending",
+            };
+          })
+          .filter((item): item is { text: string; status: "pending" | "in_progress" | "completed" } => item !== null);
+        if (items.length === 0) return;
+        const completed = items.every((item) => item.status === "completed");
+        emit({
+          type: "item.updated",
+          item: { type: "todo_list", id: "codex-turn-plan", status: completed ? "completed" : "in_progress", items },
+        });
+      }),
+    );
+    cleanupFns.push(
       client.onNotification("thread/tokenUsage/updated", (params) => {
         if (!belongsToThisTurn(params)) return;
         const usage = extractUsageFromTokenUsage(params);

--- a/server/web/server/ws/workerPromptHandler.ts
+++ b/server/web/server/ws/workerPromptHandler.ts
@@ -24,6 +24,9 @@ type Logger = {
   debug: (msg: string) => void;
 };
 
+type PlanItem = { text: string; status: "pending" | "in_progress" | "completed" };
+type PlanSnapshot = { planId: string; status: "in_progress" | "completed" | "failed"; items: PlanItem[] };
+
 function isTransientRetryEvent(event: AgentEvent): boolean {
   const raw = event.raw as ThreadEvent | null | undefined;
   if (raw?.type !== "turn.failed" && raw?.type !== "error") return false;
@@ -111,6 +114,24 @@ export function attachWorkerPromptHandler(args: {
   const terminalCommandKeys = new Set<string>();
   let hasCommandOutput = false;
   let exploredHeaderSent = false;
+  let logicalPlanId: string | null = null;
+  let latestPlan: PlanSnapshot | null = null;
+
+  const publishPlan = (snapshot: PlanSnapshot): void => {
+    latestPlan = snapshot;
+    const ts = Date.now();
+    args.sendToChat({ type: "plan", ...snapshot, ts });
+    try {
+      args.historyStore.upsertEntryByKind(args.historyKey, {
+        role: "status",
+        text: JSON.stringify(snapshot),
+        ts,
+        kind: `plan:${snapshot.planId}`,
+      });
+    } catch (err) {
+      args.logger.debug(`[Plan] failed to persist plan snapshot: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
 
   /**
    * Report every command the agent runs to the global-rule gate. The gate ships
@@ -152,6 +173,10 @@ export function attachWorkerPromptHandler(args: {
     args.sessionLogger?.logEvent(event);
     args.logger.debug(`[Event] phase=${event.phase} title=${event.title} detail=${event.detail?.slice(0, 50)}`);
     const raw = event.raw as ThreadEvent;
+    if (raw.type === "turn.started") {
+      logicalPlanId = null;
+      latestPlan = null;
+    }
     if (raw.type === "thread.started" && raw.thread_id) {
       args.onThreadStarted?.(raw.thread_id);
     }
@@ -179,6 +204,13 @@ export function attachWorkerPromptHandler(args: {
         maxAttempts: event.retry.maxAttempts,
       });
       return;
+    }
+    if (raw.type === "turn.completed" && latestPlan && latestPlan.status !== "failed") {
+      publishPlan({
+        ...latestPlan,
+        status: "completed",
+        items: latestPlan.items.map((item) => ({ ...item, status: "completed" })),
+      });
     }
     if (event.phase === "responding" && typeof event.delta === "string" && event.delta) {
       const next = event.delta;
@@ -230,16 +262,8 @@ export function attachWorkerPromptHandler(args: {
     }
     if (rawItemType === "todo_list" && (raw.type === "item.started" || raw.type === "item.updated" || raw.type === "item.completed")) {
       const item = rawItem as { id?: unknown; status?: unknown; items?: unknown };
-      const planId = String(item.id ?? "").trim() || `plan-${event.timestamp}`;
+      const providerPlanId = String(item.id ?? "").trim();
       const planStatusRaw = String(item.status ?? "").trim().toLowerCase();
-      const planStatus =
-        raw.type === "item.completed"
-          ? planStatusRaw === "failed"
-            ? "failed"
-            : "completed"
-          : planStatusRaw === "completed"
-            ? "completed"
-            : "in_progress";
       const rawItems = Array.isArray(item.items) ? item.items : [];
       const items = rawItems
         .map((entry) => {
@@ -262,25 +286,23 @@ export function attachWorkerPromptHandler(args: {
           return { text, status };
         })
         .filter((entry): entry is { text: string; status: "pending" | "in_progress" | "completed" } => entry !== null);
-      const ts = Date.now();
-      args.sendToChat({
-        type: "plan",
-        planId,
-        status: planStatus,
-        items,
-        ts,
-      });
-      const persistText = JSON.stringify({ planId, status: planStatus, items });
-      try {
-        args.historyStore.upsertEntryByKind(args.historyKey, {
-          role: "status",
-          text: persistText,
-          ts,
-          kind: `plan:${planId}`,
-        });
-      } catch (err) {
-        args.logger.debug(`[Plan] failed to persist plan snapshot: ${err instanceof Error ? err.message : String(err)}`);
-      }
+      const latestTexts = latestPlan?.items.map((entry) => entry.text) ?? [];
+      const nextTexts = items.map((entry) => entry.text);
+      const startsDistinctPlan =
+        Boolean(logicalPlanId) &&
+        Boolean(providerPlanId) &&
+        providerPlanId !== logicalPlanId &&
+        latestPlan?.status === "completed" &&
+        JSON.stringify(latestTexts) !== JSON.stringify(nextTexts);
+      const planId = startsDistinctPlan ? providerPlanId : logicalPlanId ?? (providerPlanId || `plan-${event.timestamp}`);
+      logicalPlanId = planId;
+      const hasIncompleteItems = items.some((entry) => entry.status !== "completed");
+      const planStatus = planStatusRaw === "failed"
+        ? "failed"
+        : raw.type === "item.completed" && !hasIncompleteItems
+          ? "completed"
+          : "in_progress";
+      publishPlan({ planId, status: planStatus, items });
       return;
     }
     if (isStepTracePhase(event.phase)) {

--- a/tests/codex/appServer/codexAppServerAdapter.test.ts
+++ b/tests/codex/appServer/codexAppServerAdapter.test.ts
@@ -162,6 +162,47 @@ describe("CodexAppServerAdapter", () => {
     await registry.stopAll();
   });
 
+  it("bridges structured turn plan updates as todo_list events", async () => {
+    const fake = buildFakeServer({
+      autoReplies: {
+        "thread/start": () => ({ thread: { id: "thread-plan" } }),
+        "turn/start": () => ({}),
+      },
+    });
+    const registry = new CodexAppServerDaemonRegistry({ factory: () => fake.client });
+    const adapter = new CodexAppServerAdapter({ projectId: "plan-events", registry });
+    const rawEvents: unknown[] = [];
+    adapter.onEvent((event) => rawEvents.push(event.raw));
+
+    const sendPromise = adapter.send("execute the plan");
+    await waitForRequestCount(fake, "turn/start", 1);
+    fake.notify("turn/started", { threadId: "thread-plan", turn: { id: "turn-plan" } });
+    fake.notify("turn/plan/updated", {
+      threadId: "thread-plan",
+      turnId: "turn-plan",
+      explanation: null,
+      plan: [
+        { step: "Inspect", status: "completed" },
+        { step: "Implement", status: "inProgress" },
+        { step: "Verify", status: "pending" },
+      ],
+    });
+    fake.notify("turn/completed", { threadId: "thread-plan", turn: { id: "turn-plan" } });
+    await sendPromise;
+
+    const planEvent = rawEvents.find((event) => {
+      const raw = event as { type?: unknown; item?: { type?: unknown } };
+      return raw.type === "item.updated" && raw.item?.type === "todo_list";
+    }) as { item?: { items?: Array<{ text: string; status: string }> } } | undefined;
+    assert.deepEqual(planEvent?.item?.items, [
+      { text: "Inspect", status: "completed" },
+      { text: "Implement", status: "in_progress" },
+      { text: "Verify", status: "pending" },
+    ]);
+
+    await registry.stopAll();
+  });
+
   it("reuses an existing threadId on a subsequent send", async () => {
     const fake = buildFakeServer({
       autoReplies: {

--- a/tests/web/workerPromptHandler.test.ts
+++ b/tests/web/workerPromptHandler.test.ts
@@ -296,4 +296,75 @@ describe("web/server/ws/workerPromptHandler", () => {
     assert.equal(parsed.status, "completed");
     assert.deepEqual(parsed.items.map((entry) => entry.status), ["completed", "completed"]);
   });
+
+  it("keeps one logical plan when provider item IDs change within a turn", () => {
+    const { emit, sent, upserts } = createHarness();
+
+    emit({
+      phase: "analysis",
+      title: "plan",
+      timestamp: 1,
+      raw: {
+        type: "item.updated",
+        item: { type: "todo_list", id: "tool-call-1", items: [{ text: "Step A", status: "in_progress" }] },
+      },
+    });
+    emit({
+      phase: "analysis",
+      title: "plan",
+      timestamp: 2,
+      raw: {
+        type: "item.updated",
+        item: { type: "todo_list", id: "tool-call-2", items: [{ text: "Step A", status: "completed" }] },
+      },
+    });
+
+    const planMessages = sent.filter((payload) => (payload as { type?: unknown }).type === "plan") as Array<{ planId: string }>;
+    assert.deepEqual(planMessages.map((message) => message.planId), ["tool-call-1", "tool-call-1"]);
+    assert.deepEqual(upserts.map((entry) => entry.kind), ["plan:tool-call-1", "plan:tool-call-1"]);
+  });
+
+  it("publishes an authoritative completed snapshot when the turn succeeds", () => {
+    const { emit, sent, upserts } = createHarness();
+
+    emit({
+      phase: "analysis",
+      title: "plan",
+      timestamp: 1,
+      raw: {
+        type: "item.updated",
+        item: {
+          type: "todo_list",
+          id: "plan-final",
+          items: [
+            { text: "Step A", status: "completed" },
+            { text: "Step B", status: "in_progress" },
+          ],
+        },
+      },
+    });
+    emit({ phase: "done", title: "done", timestamp: 2, raw: { type: "turn.completed" } });
+
+    const finalMessage = sent.at(-1) as { type: string; status: string; items: Array<{ status: string }> };
+    assert.equal(finalMessage.type, "plan");
+    assert.equal(finalMessage.status, "completed");
+    assert.deepEqual(finalMessage.items.map((item) => item.status), ["completed", "completed"]);
+    const persisted = JSON.parse(upserts.at(-1)?.text ?? "{}") as { status?: string };
+    assert.equal(persisted.status, "completed");
+  });
+
+  it("creates a new card for a distinct plan after the prior plan completes", () => {
+    const { emit, sent } = createHarness();
+    emit({
+      phase: "analysis", title: "plan", timestamp: 1,
+      raw: { type: "item.completed", item: { type: "todo_list", id: "plan-a", items: [{ text: "Step A", status: "completed" }] } },
+    });
+    emit({
+      phase: "analysis", title: "plan", timestamp: 2,
+      raw: { type: "item.started", item: { type: "todo_list", id: "plan-b", items: [{ text: "Step B", status: "pending" }] } },
+    });
+
+    const plans = sent.filter((payload) => (payload as { type?: unknown }).type === "plan") as Array<{ planId: string }>;
+    assert.deepEqual(plans.map((plan) => plan.planId), ["plan-a", "plan-b"]);
+  });
 });


### PR DESCRIPTION
Summary:
- Keep one logical plan card across provider item ID changes within a turn.
- Bridge Codex App Server plan notifications and reconcile terminal/history snapshots.
- Add regression coverage for provider IDs, terminal completion, distinct plans, and history replay.

Validation:
- npm run lint
- npm run build
- workerPromptHandler tests: 11 passed
- chat_sync tests: 23 passed
- npm test: 965/966 passed; one existing timing-sensitive cliRunner test passed when rerun alone

Closes #56