### PR TITLE
fix(chat): preserve user prompt message bubble on flush errors

### DIFF
--- a/client/src/__tests__/chat-prompt-error-preservation.test.ts
+++ b/client/src/__tests__/chat-prompt-error-preservation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createAppContext, type AppContext } from "../app/controller";
+import { createChatActions } from "../app/chat";
+
+describe("flushQueuedPrompts error handling", () => {
+  it("preserves user message bubble in transcript when ws sendPrompt fails", async () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const rt = ctx.activeRuntime.value;
+
+    rt.connected.value = true;
+    rt.ws = {
+      sendPrompt: vi.fn().mockReturnValue(false),
+      clearHistory: vi.fn(),
+    } as unknown as typeof rt.ws;
+
+    chat.enqueuePrompt("Analyze database deadlock issue", []);
+
+    expect(rt.ws?.sendPrompt).toHaveBeenCalled();
+
+    // User message bubble must be preserved
+    const userMessages = rt.messages.value.filter((m) => m.role === "user");
+    expect(userMessages).toHaveLength(1);
+    expect(userMessages[0]?.content).toBe("Analyze database deadlock issue");
+
+    // Empty assistant placeholder must be dropped
+    const assistantMessages = rt.messages.value.filter((m) => m.role === "assistant");
+    expect(assistantMessages).toHaveLength(0);
+
+    // State flags must be cleared
+    expect(rt.busy.value).toBe(false);
+    expect(rt.turnInFlight).toBe(false);
+    expect(rt.connected.value).toBe(false);
+
+    // Failed prompt must remain in queuedPrompts for retry
+    expect(rt.queuedPrompts.value).toHaveLength(1);
+    expect(rt.queuedPrompts.value[0]?.text).toBe("Analyze database deadlock issue");
+  });
+
+  it("does not duplicate user bubble if retry is flushed again", async () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const rt = ctx.activeRuntime.value;
+
+    let allowSend = false;
+    rt.connected.value = true;
+    rt.ws = {
+      sendPrompt: vi.fn().mockImplementation(() => allowSend),
+      clearHistory: vi.fn(),
+    } as unknown as typeof rt.ws;
+
+    chat.enqueuePrompt("Check server logs", []);
+    expect(rt.messages.value.filter((m) => m.role === "user")).toHaveLength(1);
+
+    // Reconnect and retry
+    rt.connected.value = true;
+    allowSend = true;
+    await chat.flushQueuedPrompts(rt);
+
+    // User message should still only have 1 entry
+    const userMessages = rt.messages.value.filter((m) => m.role === "user");
+    expect(userMessages).toHaveLength(1);
+    expect(userMessages[0]?.content).toBe("Check server logs");
+  });
+});

--- a/client/src/__tests__/ws-reconnect-preserve.test.ts
+++ b/client/src/__tests__/ws-reconnect-preserve.test.ts
@@ -673,7 +673,7 @@ describe("WS reconnect preserves UI unless thread_reset", () => {
     expect(rt.turnInFlight).toBe(false);
     expect(rt.pendingAckClientMessageId).toBeNull();
     expect(rt.queuedPrompts.value.map((q: any) => q.text)).toEqual(["send later"]);
-    expect(rt.messages.value.map((m: any) => String(m.content ?? ""))).not.toContain("send later");
+    expect(rt.messages.value.map((m: any) => String(m.content ?? ""))).toContain("send later");
     expect(localStorage.getItem("ads.outbox.default.main")).not.toBeNull();
     wrapper.unmount();
   });

--- a/client/src/app/chat.ts
+++ b/client/src/app/chat.ts
@@ -624,7 +624,10 @@ export function createChatActions(ctx: AppContext) {
         ...(model ? { model } : {}),
         ...(effort ? { modelReasoningEffort: effort } : {}),
       };
-      pushMessageBeforeLive({ id: next.clientMessageId, role: "user", kind: "text", content: display, execution }, state);
+      const alreadyInMessages = state.messages.value.some((m) => m.id === next.clientMessageId);
+      if (!alreadyInMessages) {
+        pushMessageBeforeLive({ id: next.clientMessageId, role: "user", kind: "text", content: display, execution }, state);
+      }
       pushMessageBeforeLive({ role: "assistant", kind: "text", content: "", streaming: true }, state);
       state.busy.value = true;
       state.turnInFlight = true;
@@ -646,13 +649,16 @@ export function createChatActions(ctx: AppContext) {
         state.laneStatus.value = { kind: "progress", message: "请求已重新发送，正在等待后端结果…" };
       }
     } catch {
-      state.messages.value = messagesBeforeFlush;
-      state.busy.value = busyBeforeFlush;
-      state.turnInFlight = turnInFlightBeforeFlush;
-      state.turnHasPatch = turnHasPatchBeforeFlush;
-      state.pendingAckClientMessageId = pendingAckBeforeFlush;
+      dropEmptyAssistantPlaceholder(state);
+      state.busy.value = false;
+      state.turnInFlight = false;
+      state.turnHasPatch = false;
+      state.pendingAckClientMessageId = null;
       if (!sendAccepted) {
         state.connected.value = false;
+        if (!options?.preserveErrorStatus && !state.laneStatus.value) {
+          state.laneStatus.value = { kind: "error", message: "Failed to send prompt: connection lost or prompt rejected." };
+        }
       }
       const remaining = state.queuedPrompts.value.filter((q) => q.clientMessageId !== next.clientMessageId);
       state.queuedPrompts.value = [next, ...remaining];

--- a/client/src/app/chat.ts
+++ b/client/src/app/chat.ts
@@ -577,11 +577,6 @@ export function createChatActions(ctx: AppContext) {
 
     const next = state.queuedPrompts.value[0]!;
     state.queuedPrompts.value = state.queuedPrompts.value.slice(1);
-    const messagesBeforeFlush = state.messages.value.slice();
-    const busyBeforeFlush = state.busy.value;
-    const turnInFlightBeforeFlush = state.turnInFlight;
-    const turnHasPatchBeforeFlush = state.turnHasPatch;
-    const pendingAckBeforeFlush = state.pendingAckClientMessageId;
     let sendAccepted = false;
 
     try {


### PR DESCRIPTION
## Summary

Fixes #60.

When sending a prompt encounters an error (such as a WebSocket send rejection or network failure):
- Prevents rolling back `state.messages.value = messagesBeforeFlush` so that the user's prompt bubble remains in the transcript.
- Removes empty streaming assistant placeholder on send failure to prevent dangling placeholder state.
- Deduplicates user message insertion before sending to avoid duplicate bubbles on retry.
- Sets error status on `laneStatus` and keeps the failed prompt in the queue for retry.

## Tests

- Added `client/src/__tests__/chat-prompt-error-preservation.test.ts` verifying that prompt bubbles are preserved across send errors and not duplicated on retry.
- Verified existing test suites (`error-placeholder-order.test.ts`, `chat_sync.test.ts`) pass cleanly.
- Validated with `npm run build`.
