### PR TITLE
fix(chat): preserve composer draft text when starting a new session

### DIFF
--- a/client/src/__tests__/chat-composer-draft-preservation.test.ts
+++ b/client/src/__tests__/chat-composer-draft-preservation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createAppContext, type AppContext } from "../app/controller";
 import { createChatActions } from "../app/chat";
 import { createProjectActions } from "../app/projectsWs/projectActions";
+import { createTaskActions } from "../app/tasks";
 
 describe("composer draft preservation on session reset", () => {
   it("preserves composerDraft text when clearChatState is executed", () => {
@@ -56,5 +57,30 @@ describe("composer draft preservation on session reset", () => {
     // Composer draft text must be preserved
     expect(rt.composerDraft.value).toBe("Draft for a new clean session");
   });
-});
 
+  it("preserves drafts when resetting worker and planner chat state", async () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const projects = createProjectActions({ ...ctx, ...chat } as AppContext & ReturnType<typeof createChatActions>, {
+      activateProject: vi.fn(async () => {}),
+    });
+    const tasks = createTaskActions({ ...ctx, ...chat } as AppContext & ReturnType<typeof createChatActions>, {
+      connectWs: vi.fn(async () => {}),
+      connectPlannerWs: vi.fn(async () => {}),
+    });
+
+    ctx.loggedIn.value = true;
+    projects.initializeProjects();
+
+    const workerRt = ctx.activeRuntime.value;
+    const plannerRt = ctx.activePlannerRuntime.value;
+    workerRt.composerDraft.value = "Worker reset draft";
+    plannerRt.composerDraft.value = "Planner reset draft";
+
+    tasks.clearActiveChat();
+    tasks.clearPlannerChat();
+
+    expect(workerRt.composerDraft.value).toBe("Worker reset draft");
+    expect(plannerRt.composerDraft.value).toBe("Planner reset draft");
+  });
+});

--- a/client/src/__tests__/chat-composer-draft-preservation.test.ts
+++ b/client/src/__tests__/chat-composer-draft-preservation.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createAppContext, type AppContext } from "../app/controller";
+import { createChatActions } from "../app/chat";
+import { createProjectActions } from "../app/projectsWs/projectActions";
+
+describe("composer draft preservation on session reset", () => {
+  it("preserves composerDraft text when clearChatState is executed", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const deps = {
+      activateProject: vi.fn(async () => {}),
+    };
+    const projects = createProjectActions({ ...ctx, ...chat } as AppContext & ReturnType<typeof createChatActions>, deps);
+
+    const rt = ctx.activeRuntime.value;
+    rt.composerDraft.value = "Unfinished prompt drafted by user";
+    rt.messages.value = [
+      { id: "m1", role: "user", kind: "text", content: "Old message" },
+      { id: "m2", role: "assistant", kind: "text", content: "Old response" },
+    ];
+    rt.queuedPrompts.value = [
+      { id: "q1", clientMessageId: "c1", text: "Queued", images: [], createdAt: Date.now() },
+    ];
+
+    projects.clearChatState();
+
+    // History and queues must be cleared
+    expect(rt.messages.value).toHaveLength(0);
+    expect(rt.queuedPrompts.value).toHaveLength(0);
+
+    // Composer draft must remain intact
+    expect(rt.composerDraft.value).toBe("Unfinished prompt drafted by user");
+  });
+
+  it("preserves composerDraft when starting a new chat session", async () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const deps = {
+      activateProject: vi.fn(async () => {}),
+    };
+    const projects = createProjectActions({ ...ctx, ...chat } as AppContext & ReturnType<typeof createChatActions>, deps);
+
+    ctx.loggedIn.value = true;
+    projects.initializeProjects();
+
+    const rt = ctx.activeRuntime.value;
+    rt.composerDraft.value = "Draft for a new clean session";
+    const initialSessionId = rt.chatSessionId;
+
+    await projects.startNewChatSession();
+
+    // Session ID should be changed
+    expect(rt.chatSessionId).not.toBe(initialSessionId);
+
+    // Composer draft text must be preserved
+    expect(rt.composerDraft.value).toBe("Draft for a new clean session");
+  });
+});
+

--- a/client/src/app/projectsWs/projectActions.ts
+++ b/client/src/app/projectsWs/projectActions.ts
@@ -391,7 +391,6 @@ export function createProjectActions(ctx: AppContext & ChatActions, deps: Projec
     busy.value = false;
     activeRuntime.value.inputLocked.value = false;
     activeRuntime.value.laneStatus.value = null;
-    activeRuntime.value.composerDraft.value = "";
     activeRuntime.value.pendingCdRequestedPath = null;
     queuedPrompts.value = [];
     pendingImages.value = [];

--- a/client/src/app/tasks.ts
+++ b/client/src/app/tasks.ts
@@ -607,7 +607,6 @@ export function createTaskActions(ctx: AppContext & ChatActions, deps: TaskDeps)
 
   const clearActiveChat = (): void => {
     const rt = activeRuntime.value;
-    rt.composerDraft.value = "";
     rt.queuedPrompts.value = [];
     clearPendingPromptReplayState(rt);
     threadReset(rt, {
@@ -622,7 +621,6 @@ export function createTaskActions(ctx: AppContext & ChatActions, deps: TaskDeps)
 
   const clearPlannerChat = (): void => {
     const rt = activePlannerRuntime.value;
-    rt.composerDraft.value = "";
     rt.queuedPrompts.value = [];
     clearPendingPromptReplayState(rt);
     threadReset(rt, {


### PR DESCRIPTION
## Summary

Fixes #65.

Preserves the user's unsubmitted composer draft text when resetting conversation state or creating a new chat session:
- Removed `activeRuntime.value.composerDraft.value = ""` from `clearChatState()` in `client/src/app/projectsWs/projectActions.ts`.
- Prevents wiping user-entered prompts when switching to a clean session context.

## Tests

- Added `client/src/__tests__/chat-composer-draft-preservation.test.ts` verifying composer draft text is retained during `clearChatState()` and `startNewChatSession()`.
- Ran existing project actions tests (`projectActions.defaultChatSession.test.ts`).
- Validated with `npm run build`.
