### PR TITLE
refactor(ws): support in-band chat session switching without connection teardown

### DIFF
--- a/client/src/__tests__/ws-session-switch-inband.test.ts
+++ b/client/src/__tests__/ws-session-switch-inband.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createAppContext, type AppContext } from "../app/controller";
+import { createChatActions } from "../app/chat";
+import { createProjectActions } from "../app/projectsWs/projectActions";
+
+describe("in-band chat session switching", () => {
+  it("switches session via switchChatSession without closing WebSocket when connected", async () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const deps = {
+      activateProject: vi.fn(async () => {}),
+    };
+    const projects = createProjectActions({ ...ctx, ...chat } as AppContext & ReturnType<typeof createChatActions>, deps);
+
+    ctx.loggedIn.value = true;
+    projects.initializeProjects();
+
+    const rt = ctx.activeRuntime.value;
+    rt.connected.value = true;
+
+    const mockWs = {
+      switchChatSession: vi.fn().mockReturnValue(true),
+      close: vi.fn(),
+      clearHistory: vi.fn(),
+    };
+    rt.ws = mockWs as unknown as typeof rt.ws;
+
+    const initialChatSessionId = rt.chatSessionId;
+    await projects.startNewChatSession();
+
+    // Must call in-band switch
+    expect(mockWs.switchChatSession).toHaveBeenCalledTimes(1);
+    const newChatSessionId = mockWs.switchChatSession.mock.calls[0]![0];
+    expect(newChatSessionId).toBeTruthy();
+    expect(newChatSessionId).not.toBe(initialChatSessionId);
+
+    // Must NOT close the connection
+    expect(mockWs.close).not.toHaveBeenCalled();
+
+    // Must keep connected status alive
+    expect(rt.connected.value).toBe(true);
+
+    // Must NOT trigger full project reactivation
+    expect(deps.activateProject).not.toHaveBeenCalled();
+
+    // Runtime state must reflect new chatSessionId
+    expect(rt.chatSessionId).toBe(newChatSessionId);
+  });
+
+  it("falls back to full project reactivation when disconnected", async () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const deps = {
+      activateProject: vi.fn(async () => {}),
+    };
+    const projects = createProjectActions({ ...ctx, ...chat } as AppContext & ReturnType<typeof createChatActions>, deps);
+
+    ctx.loggedIn.value = true;
+    projects.initializeProjects();
+
+    const rt = ctx.activeRuntime.value;
+    rt.connected.value = false;
+
+    const mockWs = {
+      switchChatSession: vi.fn().mockReturnValue(false),
+      close: vi.fn(),
+      clearHistory: vi.fn(),
+    };
+    rt.ws = mockWs as unknown as typeof rt.ws;
+
+    await projects.startNewChatSession();
+
+    // When disconnected, it should fall back to activateProject
+    expect(deps.activateProject).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/api/ws.ts
+++ b/client/src/api/ws.ts
@@ -59,7 +59,7 @@ type WsMessage =
 export class AdsWebSocket {
   private ws: WebSocket | null = null;
   private readonly sessionId: string;
-  private readonly chatSessionId: string;
+  private chatSessionId: string;
   private pingTimer: number | null = null;
 
   onOpen?: () => void;
@@ -98,6 +98,13 @@ export class AdsWebSocket {
   /** Returns false when the socket is not open, so the caller can fall back to HTTP. */
   interrupt(): boolean {
     return this.send("interrupt");
+  }
+
+  switchChatSession(chatSessionId: string): boolean {
+    const id = String(chatSessionId ?? "").trim();
+    if (!id) return false;
+    this.chatSessionId = id;
+    return this.send("switch_chat_session", { chatSessionId: id });
   }
 
   clearHistory(payload?: unknown): void {

--- a/client/src/app/projectsWs/projectActions.ts
+++ b/client/src/app/projectsWs/projectActions.ts
@@ -391,7 +391,6 @@ export function createProjectActions(ctx: AppContext & ChatActions, deps: Projec
     busy.value = false;
     activeRuntime.value.inputLocked.value = false;
     activeRuntime.value.laneStatus.value = null;
-    activeRuntime.value.composerDraft.value = "";
     activeRuntime.value.pendingCdRequestedPath = null;
     queuedPrompts.value = [];
     pendingImages.value = [];
@@ -419,10 +418,18 @@ export function createProjectActions(ctx: AppContext & ChatActions, deps: Projec
     const newChatSessionId = crypto.randomUUID?.() ?? randomId("chat");
     updateProject(pid, { chatSessionId: newChatSessionId });
     activeRuntime.value.chatSessionId = newChatSessionId;
-    activeRuntime.value.ignoreNextHistory = true;
+    activeRuntime.value.ignoreNextHistory = false;
     activeRuntime.value.suppressNextClearHistoryResult = false;
 
     clearChatState();
+
+    const currentWs = activeRuntime.value.ws as { switchChatSession?: (id: string) => boolean; close?: () => void } | null;
+    if (activeRuntime.value.connected.value && typeof currentWs?.switchChatSession === "function") {
+      const switched = currentWs.switchChatSession(newChatSessionId);
+      if (switched) {
+        return;
+      }
+    }
 
     const prev = activeRuntime.value.ws as { close?: () => void } | null;
     activeRuntime.value.ws = null;

--- a/server/web/server/ws/connectionIdentity.ts
+++ b/server/web/server/ws/connectionIdentity.ts
@@ -18,6 +18,7 @@ export function buildWsConnectionIdentity(args: {
   authUserId: string;
   sessionId: string;
   chatSessionId: string;
+  connectionId?: string;
   randomHex?: (bytes: number) => string;
 }): WsConnectionIdentity {
   const authUserId = String(args.authUserId ?? "").trim();
@@ -27,7 +28,8 @@ export function buildWsConnectionIdentity(args: {
   const legacyUserId = deriveLegacyWebUserId(authUserId, chatKey);
   const userId = deriveWebUserId(authUserId, chatKey);
   const historyKey = `${authUserId}::${sessionId}::${chatSessionId}`;
-  const connectionId = (args.randomHex ?? ((bytes) => crypto.randomBytes(bytes).toString("hex")))(3);
+  const connectionId =
+    String(args.connectionId ?? "").trim() || (args.randomHex ?? ((bytes) => crypto.randomBytes(bytes).toString("hex")))(3);
   const cacheKey = `${authUserId}::${sessionId}`;
 
   return {

--- a/server/web/server/ws/server.ts
+++ b/server/web/server/ws/server.ts
@@ -182,19 +182,19 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
       aliveWs.missedPongs = 0;
     });
 
-    let {
-      authUserId,
-      legacyUserId,
-      userId,
-      historyKey,
-      connectionId,
-      cacheKey,
-      clientMeta,
-    } = buildWsConnectionIdentity({
+    const initialIdentity = buildWsConnectionIdentity({
       authUserId: authResult.userId,
       sessionId,
       chatSessionId,
     });
+    const { authUserId, connectionId } = initialIdentity;
+    let {
+      legacyUserId,
+      userId,
+      historyKey,
+      cacheKey,
+      clientMeta,
+    } = initialIdentity;
     sessionManager.maybeMigrateThreadState(legacyUserId, userId);
     state.clientMetaByWs.set(ws, clientMeta);
     registerSeenChatSessionId(authUserId, sessionId, chatSessionId);
@@ -261,7 +261,7 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
     );
     const inFlight = state.interruptControllers.has(historyKey);
 
-    const syncNamespace = resolveSyncNamespace(chatSessionId);
+    let syncNamespace = resolveSyncNamespace(chatSessionId);
     const syncLaneKeys = resolveSyncLaneKeys({
       authUserId,
       sessionId,
@@ -276,7 +276,7 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
       });
     };
     const syncEventStore = state.syncEventStore;
-    const deltaCoalescer = syncEventStore
+    let deltaCoalescer = syncEventStore
       ? createDeltaStreamCoalescer({
           store: syncEventStore,
           namespace: syncNamespace,
@@ -471,6 +471,7 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
     });
 
     let messageChain = Promise.resolve();
+    let pendingSwitchCount = 0;
     let lastReceivedAt = 0;
 
     ws.on("message", (data: RawData) => {
@@ -506,6 +507,31 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
         return;
       }
 
+      if (parsed.type === "interrupt" && pendingSwitchCount > 0) {
+        messageChain = messageChain
+          .then(() => {
+            handleImmediateWsMessage({
+              parsed,
+              receivedAt,
+              abortInFlight: () => abortInFlightForHistoryKey(historyKey),
+              sendJson: (payload) => safeJsonSend(ws, payload),
+              broadcastJson,
+              recordStatusError: (message) =>
+                historyStore.add(historyKey, {
+                  role: "status",
+                  text: message,
+                  ts: Date.now(),
+                  kind: "error",
+                }),
+            });
+          })
+          .catch((error) => {
+            const message = error instanceof Error ? error.message : String(error);
+            logger.warn(`[WebSocket] deferred interrupt failed conn=${connectionId} user=${userId}: ${message}`);
+          });
+        return;
+      }
+
       const requestId = crypto.randomBytes(4).toString("hex");
       if (config.traceWsDuplication) {
         const meta = state.clientMetaByWs.get(ws);
@@ -516,6 +542,7 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
       }
 
       if (parsed.type === "switch_chat_session") {
+        pendingSwitchCount += 1;
         messageChain = messageChain
           .then(async () => {
             const payload = parsed.payload;
@@ -539,11 +566,14 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
               chatSessionId,
               connectionId,
             });
+            const workspaceRoot = clientMeta.workspaceRoot;
             legacyUserId = nextIdentity.legacyUserId;
             userId = nextIdentity.userId;
             historyKey = nextIdentity.historyKey;
             cacheKey = nextIdentity.cacheKey;
-            clientMeta = nextIdentity.clientMeta;
+            clientMeta = workspaceRoot
+              ? { ...nextIdentity.clientMeta, workspaceRoot }
+              : nextIdentity.clientMeta;
             state.clientMetaByWs.set(ws, clientMeta);
             registerSeenChatSessionId(authUserId, sessionId, chatSessionId);
 
@@ -557,6 +587,15 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
               sessionId,
               chatSessionId,
             });
+            deltaCoalescer?.finish();
+            syncNamespace = nextSyncNamespace;
+            deltaCoalescer = syncEventStore
+              ? createDeltaStreamCoalescer({
+                  store: syncEventStore,
+                  namespace: syncNamespace,
+                  laneKey: historyKey,
+                })
+              : null;
 
             sendInitialBootstrapMessages({
               ws,
@@ -586,45 +625,55 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
             const message = error instanceof Error ? error.message : String(error);
             logger.warn("[WebSocket] switch_chat_session failed conn=" + connectionId + " user=" + userId + ": " + message);
             safeJsonSend(ws, { type: "error", message: "Failed to switch chat session" });
+          })
+          .finally(() => {
+            pendingSwitchCount = Math.max(0, pendingSwitchCount - 1);
           });
         return;
       }
 
-            const preflight = preflightPersistAndAck({
-        parsed,
-        requestId,
-        clientMessageId,
-        receivedAt,
-        historyStore,
-        historyKey,
-        sanitizeInput: commands.sanitizeInput,
-        sendJson: (payload) => safeJsonSend(ws, payload),
-        broadcastPersistedHistory: broadcastHistoryToSiblingConnections,
-        broadcastInFlight: broadcastInFlightToSiblingConnections,
-        inFlight: state.interruptControllers.has(historyKey),
-        traceWsDuplication: config.traceWsDuplication,
-        warn: (message) => logger.warn(message),
-        sessionId,
-        userId,
-        onPersistedMessage: ({ clientMessageId: persistedId, text }) => {
-          recordConversationMessage({
-            eventId: persistedId,
-            workspaceRoot: normalizeWorkspaceRootForMeta(currentCwd),
-            sessionId,
-            source: "web",
-            role: "user",
-            text,
-            agentId: orchestrator.getActiveAgentId?.(),
-          });
-        },
-      });
-      if (!preflight.enqueue) {
+      const runPreflight = (): ReturnType<typeof preflightPersistAndAck> =>
+        preflightPersistAndAck({
+          parsed,
+          requestId,
+          clientMessageId,
+          receivedAt,
+          historyStore,
+          historyKey,
+          sanitizeInput: commands.sanitizeInput,
+          sendJson: (payload) => safeJsonSend(ws, payload),
+          broadcastPersistedHistory: broadcastHistoryToSiblingConnections,
+          broadcastInFlight: broadcastInFlightToSiblingConnections,
+          inFlight: state.interruptControllers.has(historyKey),
+          traceWsDuplication: config.traceWsDuplication,
+          warn: (message) => logger.warn(message),
+          sessionId,
+          userId,
+          onPersistedMessage: ({ clientMessageId: persistedId, text }) => {
+            recordConversationMessage({
+              eventId: persistedId,
+              workspaceRoot: normalizeWorkspaceRootForMeta(currentCwd),
+              sessionId,
+              source: "web",
+              role: "user",
+              text,
+              agentId: orchestrator.getActiveAgentId?.(),
+            });
+          },
+        });
+      const preflight = pendingSwitchCount === 0 ? runPreflight() : null;
+      if (preflight && !preflight.enqueue) {
         return;
       }
 
       const msg: IncomingWsMessage = { parsed, requestId, clientMessageId, receivedAt };
       messageChain = messageChain
         .then(async () => {
+          const queuedPreflight = preflight ?? runPreflight();
+          if (!queuedPreflight.enqueue) {
+            return;
+          }
+
           const result = await dispatchWsMessage({
             msg,
             ws,

--- a/server/web/server/ws/server.ts
+++ b/server/web/server/ws/server.ts
@@ -161,8 +161,8 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
     }
 
     const sessionId = resolveWebSocketSessionId({ protocols: parsedProtocols, workspaceRoot: config.workspaceRoot });
-    const chatSessionId = resolveWebSocketChatSessionId({ protocols: parsedProtocols });
-    const { sessionManager, historyStore, getWorkspaceLock } = resolveWsLaneResources({
+    let chatSessionId = resolveWebSocketChatSessionId({ protocols: parsedProtocols });
+    let { sessionManager, historyStore, getWorkspaceLock } = resolveWsLaneResources({
       chatSessionId,
       sessions,
       history,
@@ -182,7 +182,7 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
       aliveWs.missedPongs = 0;
     });
 
-    const {
+    let {
       authUserId,
       legacyUserId,
       userId,
@@ -515,7 +515,82 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
         );
       }
 
-      const preflight = preflightPersistAndAck({
+      if (parsed.type === "switch_chat_session") {
+        messageChain = messageChain
+          .then(async () => {
+            const payload = parsed.payload;
+            const targetChatSessionId =
+              typeof payload === "object" && payload !== null && "chatSessionId" in payload
+                ? String((payload as { chatSessionId?: unknown }).chatSessionId ?? "").trim()
+                : "";
+            const nextChatSessionId = targetChatSessionId || crypto.randomUUID();
+
+            abortInFlightForHistoryKey(historyKey);
+
+            chatSessionId = nextChatSessionId;
+            const laneRes = resolveWsLaneResources({ chatSessionId, sessions, history });
+            sessionManager = laneRes.sessionManager;
+            historyStore = laneRes.historyStore;
+            getWorkspaceLock = laneRes.getWorkspaceLock;
+
+            const nextIdentity = buildWsConnectionIdentity({
+              authUserId,
+              sessionId,
+              chatSessionId,
+              connectionId,
+            });
+            legacyUserId = nextIdentity.legacyUserId;
+            userId = nextIdentity.userId;
+            historyKey = nextIdentity.historyKey;
+            cacheKey = nextIdentity.cacheKey;
+            clientMeta = nextIdentity.clientMeta;
+            state.clientMetaByWs.set(ws, clientMeta);
+            registerSeenChatSessionId(authUserId, sessionId, chatSessionId);
+
+            registerSessionCacheBinding();
+            sessionManager.maybeMigrateThreadState(legacyUserId, userId);
+            orchestrator = sessionManager.getOrCreate(userId, currentCwd, true);
+
+            const nextSyncNamespace = resolveSyncNamespace(chatSessionId);
+            const nextSyncLaneKeys = resolveSyncLaneKeys({
+              authUserId,
+              sessionId,
+              chatSessionId,
+            });
+
+            sendInitialBootstrapMessages({
+              ws,
+              safeJsonSend,
+              sessionManager,
+              orchestrator,
+              userId,
+              agentAvailability: agents.agentAvailability,
+              sessionId,
+              chatSessionId,
+              workspace: getWorkspaceState(currentCwd),
+              inFlight: false,
+              historyStore,
+              historyKey,
+              additionalHistoryEntries:
+                chatSessionId === "planner"
+                  ? undefined
+                  : historyStore.get(resolveSharedWorkerSyncLaneKey(sessionId)),
+              latestSeq: state.syncEventStore?.getLatestSeqForLanes(nextSyncNamespace, nextSyncLaneKeys) ?? 0,
+            });
+
+            logger.info(
+              "[WebSocket] in-band session switch conn=" + connectionId + " session=" + sessionId + " chat=" + chatSessionId + " user=" + userId + " history=" + historyKey,
+            );
+          })
+          .catch((error) => {
+            const message = error instanceof Error ? error.message : String(error);
+            logger.warn("[WebSocket] switch_chat_session failed conn=" + connectionId + " user=" + userId + ": " + message);
+            safeJsonSend(ws, { type: "error", message: "Failed to switch chat session" });
+          });
+        return;
+      }
+
+            const preflight = preflightPersistAndAck({
         parsed,
         requestId,
         clientMessageId,

--- a/tests/web/wsSwitchChatSession.test.ts
+++ b/tests/web/wsSwitchChatSession.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+import WebSocket, { type RawData } from "ws";
+
+import { resetStateDatabaseForTests } from "../../server/state/database.js";
+import { AsyncLock } from "../../server/utils/asyncLock.js";
+import { HistoryStore } from "../../server/utils/historyStore.js";
+import { SessionManager } from "../../server/telegram/utils/sessionManager.js";
+import { DirectoryManager } from "../../server/telegram/utils/directoryManager.js";
+import { NoopAgentAvailability } from "../../server/agents/health/agentAvailability.js";
+import { attachWebSocketServer } from "../../server/web/server/ws/server.js";
+
+type WsJson = { type?: unknown; [k: string]: unknown };
+
+function waitForWsOpen(client: WebSocket, timeoutMs = 2000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("Timed out waiting for ws open")), timeoutMs);
+    client.once("open", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    client.once("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+function waitForWsMessage(client: WebSocket, predicate: (msg: WsJson) => boolean, timeoutMs = 2000): Promise<WsJson> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("Timed out waiting for ws message")), timeoutMs);
+    const handler = (raw: RawData) => {
+      let parsed: WsJson | null = null;
+      try {
+        parsed = JSON.parse(raw.toString("utf8")) as WsJson;
+      } catch {
+        return;
+      }
+      if (!predicate(parsed)) {
+        return;
+      }
+      clearTimeout(timer);
+      client.off("message", handler);
+      resolve(parsed);
+    };
+    client.on("message", handler);
+    client.once("error", (err) => {
+      clearTimeout(timer);
+      client.off("message", handler);
+      reject(err);
+    });
+  });
+}
+
+function createFakeSessionFactory(prefix: string) {
+  let nextId = 1;
+  const created: any[] = [];
+
+  return {
+    created,
+    factory: ({ cwd }: { cwd: string }) => {
+      const session = {
+        resetCalls: 0,
+        threadId: `${prefix}-thread-${nextId++}`,
+        workingDirectory: cwd,
+        send: async () => ({ response: "ok" }),
+        onEvent: () => () => {},
+        getThreadId: () => session.threadId,
+        reset: () => {
+          session.resetCalls += 1;
+          session.threadId = null;
+        },
+        setModel: () => {},
+        setWorkingDirectory: (workingDirectory: string, options?: { preserveSession?: boolean }) => {
+          session.workingDirectory = workingDirectory;
+          if (!options?.preserveSession) {
+            session.threadId = null;
+          }
+        },
+        status: () => ({ ready: true, streaming: false }),
+        getActiveAgentId: () => "codex",
+        listAgents: () => [{ metadata: { id: "codex", name: "Codex" }, status: { ready: true, streaming: false } }],
+        switchAgent: () => {},
+      };
+      created.push(session);
+      return session;
+    },
+  };
+}
+
+describe("web/server/ws: in-band switch_chat_session", () => {
+  let server: http.Server;
+  let port: number;
+  let tmpDir: string;
+  let workspaceRoot: string;
+  let workerHistoryStore: HistoryStore;
+  let plannerHistoryStore: HistoryStore;
+  const sockets: WebSocket[] = [];
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ads-ws-switch-test-"));
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ads-ws-switch-ws-"));
+    process.env.ADS_STATE_DB_PATH = path.join(tmpDir, "state.db");
+    resetStateDatabaseForTests(process.env.ADS_STATE_DB_PATH);
+
+    server = http.createServer();
+    const clients = new Set<import("ws").WebSocket>();
+    const clientMetaByWs = new Map<import("ws").WebSocket, any>();
+    workerHistoryStore = new HistoryStore({ storagePath: process.env.ADS_STATE_DB_PATH, namespace: "test-worker" });
+    plannerHistoryStore = new HistoryStore({ storagePath: process.env.ADS_STATE_DB_PATH, namespace: "test-planner" });
+    const lock = new AsyncLock();
+    const agentAvailability = new NoopAgentAvailability();
+    const directoryManager = new DirectoryManager([workspaceRoot]);
+    const workerFactory = createFakeSessionFactory("worker");
+    const plannerFactory = createFakeSessionFactory("planner");
+
+    attachWebSocketServer({
+      server,
+      logger: { info: () => {}, warn: () => {}, debug: () => {} },
+      config: {
+        workspaceRoot,
+        allowedDirs: [workspaceRoot],
+        maxClients: 10,
+        pingIntervalMs: 0,
+        maxMissedPongs: 0,
+        traceWsDuplication: false,
+      },
+      auth: {
+        allowedOrigins: new Set(),
+        isOriginAllowed: () => true,
+        authenticateRequest: () => ({ ok: true, userId: "test" }),
+      },
+      agents: {
+        agentAvailability,
+      },
+      state: {
+        directoryManager,
+        workspaceCache: new Map(),
+        sessionCacheRegistry: { registerBinding: () => {}, clearForUser: () => {} },
+        interruptControllers: new Map<string, AbortController>(),
+        clientMetaByWs,
+        clients,
+        cwdStore: new Map(),
+        cwdStorePath: process.env.ADS_STATE_DB_PATH,
+        persistCwdStore: () => {},
+      },
+      sessions: {
+        workerSessionManager: new SessionManager(0, 0, "workspace-write", "test-model", undefined, undefined, {
+          createSession: workerFactory.factory as never,
+        }),
+        plannerSessionManager: new SessionManager(0, 0, "read-only", "test-model", undefined, undefined, {
+          createSession: plannerFactory.factory as never,
+        }),
+        getWorkspaceLock: () => lock,
+        getPlannerWorkspaceLock: () => lock,
+      },
+      history: {
+        workerHistoryStore,
+        plannerHistoryStore,
+      },
+      tasks: {
+        ensureTaskContext: () => ({} as unknown as any),
+        promoteQueuedTasksToPending: () => {},
+        broadcastToSession: () => {},
+      },
+      commands: {
+        runAdsCommandLine: async () => ({ ok: true, output: "" }),
+        sanitizeInput: (payload) => String(payload ?? ""),
+        syncWorkspaceTemplates: () => {},
+      },
+      scheduler: {},
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        port = typeof addr === "object" && addr ? addr.port : 0;
+        resolve();
+      });
+      server.once("error", reject);
+    });
+  });
+
+  afterEach(async () => {
+    for (const ws of sockets) {
+      try {
+        ws.close();
+      } catch {}
+    }
+    sockets.length = 0;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.rmSync(workspaceRoot, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it("switches chatSessionId in-band without dropping the socket connection", async () => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`, ["ads-v1", "ads-session.main", "ads-chat.session-initial"]);
+    sockets.push(ws);
+
+    let isClosed = false;
+    ws.on("close", () => {
+      isClosed = true;
+    });
+
+    const welcomePromise = waitForWsMessage(ws, (m) => m.type === "welcome");
+    await waitForWsOpen(ws);
+
+    const initialWelcome = await welcomePromise;
+    assert.equal(initialWelcome.chatSessionId, "session-initial");
+
+    // Send in-band switch message and wait for new welcome
+    const switchPromise = waitForWsMessage(ws, (m) => m.type === "welcome" && m.chatSessionId === "session-switched");
+    ws.send(JSON.stringify({
+      type: "switch_chat_session",
+      payload: { chatSessionId: "session-switched" },
+    }));
+
+    const switchedWelcome = await switchPromise;
+    assert.equal(switchedWelcome.chatSessionId, "session-switched");
+
+    // Connection must have remained open
+    assert.equal(isClosed, false);
+    assert.equal(ws.readyState, WebSocket.OPEN);
+  });
+});

--- a/tests/web/wsSwitchChatSession.test.ts
+++ b/tests/web/wsSwitchChatSession.test.ts
@@ -8,12 +8,15 @@ import path from "node:path";
 import WebSocket, { type RawData } from "ws";
 
 import { resetStateDatabaseForTests } from "../../server/state/database.js";
+import { HybridOrchestrator } from "../../server/agents/orchestrator.js";
 import { AsyncLock } from "../../server/utils/asyncLock.js";
 import { HistoryStore } from "../../server/utils/historyStore.js";
 import { SessionManager } from "../../server/telegram/utils/sessionManager.js";
 import { DirectoryManager } from "../../server/telegram/utils/directoryManager.js";
 import { NoopAgentAvailability } from "../../server/agents/health/agentAvailability.js";
 import { attachWebSocketServer } from "../../server/web/server/ws/server.js";
+import { resolveSyncLaneKey, resolveSyncNamespace } from "../../server/web/server/sync/lane.js";
+import { SyncEventStore } from "../../server/web/server/sync/store.js";
 
 type WsJson = { type?: unknown; [k: string]: unknown };
 
@@ -31,9 +34,17 @@ function waitForWsOpen(client: WebSocket, timeoutMs = 2000): Promise<void> {
   });
 }
 
-function waitForWsMessage(client: WebSocket, predicate: (msg: WsJson) => boolean, timeoutMs = 2000): Promise<WsJson> {
+function waitForWsMessage(
+  client: WebSocket,
+  predicate: (msg: WsJson) => boolean,
+  timeoutMs = 2000,
+  label = "",
+): Promise<WsJson> {
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error("Timed out waiting for ws message")), timeoutMs);
+    const timer = setTimeout(
+      () => reject(new Error(`Timed out waiting for ws message${label ? `: ${label}` : ""}`)),
+      timeoutMs,
+    );
     const handler = (raw: RawData) => {
       let parsed: WsJson | null = null;
       try {
@@ -57,39 +68,66 @@ function waitForWsMessage(client: WebSocket, predicate: (msg: WsJson) => boolean
   });
 }
 
-function createFakeSessionFactory(prefix: string) {
+function createFakeSessionFactory(prefix: string, options: { blockFirstSend?: boolean } = {}) {
   let nextId = 1;
+  let firstSend = true;
+  let resolveFirstSendStarted: (() => void) | null = null;
+  let releaseFirstSend: (() => void) | null = null;
+  const firstSendStarted = new Promise<void>((resolve) => {
+    resolveFirstSendStarted = resolve;
+  });
+  const firstSendGate = new Promise<void>((resolve) => {
+    releaseFirstSend = resolve;
+  });
   const created: any[] = [];
 
   return {
     created,
     factory: ({ cwd }: { cwd: string }) => {
-      const session = {
-        resetCalls: 0,
-        threadId: `${prefix}-thread-${nextId++}`,
-        workingDirectory: cwd,
-        send: async () => ({ response: "ok" }),
-        onEvent: () => () => {},
-        getThreadId: () => session.threadId,
-        reset: () => {
-          session.resetCalls += 1;
-          session.threadId = null;
+      let resetCalls = 0;
+      let threadId: string | null = `${prefix}-thread-${nextId++}`;
+      let workingDirectory = cwd;
+      const adapter = {
+        id: "codex" as const,
+        metadata: { id: "codex" as const, name: "Codex", capabilities: ["text" as const] },
+        send: async (input: unknown) => {
+          if (options.blockFirstSend && firstSend) {
+            firstSend = false;
+            resolveFirstSendStarted?.();
+            await firstSendGate;
+          }
+          const inputText = typeof input === "string" ? input : "";
+          const response = inputText.includes("first prompt")
+            ? "first response"
+            : inputText.includes("second prompt")
+              ? "second response"
+              : "ok";
+          return { response, usage: null, agentId: "codex" };
         },
-        setModel: () => {},
-        setWorkingDirectory: (workingDirectory: string, options?: { preserveSession?: boolean }) => {
-          session.workingDirectory = workingDirectory;
+        onEvent: () => () => {},
+        getThreadId: () => threadId,
+        reset: () => {
+          resetCalls += 1;
+          threadId = null;
+        },
+        setWorkingDirectory: (nextDirectory: string, options?: { preserveSession?: boolean }) => {
+          workingDirectory = nextDirectory;
           if (!options?.preserveSession) {
-            session.threadId = null;
+            threadId = null;
           }
         },
         status: () => ({ ready: true, streaming: false }),
-        getActiveAgentId: () => "codex",
-        listAgents: () => [{ metadata: { id: "codex", name: "Codex" }, status: { ready: true, streaming: false } }],
-        switchAgent: () => {},
       };
-      created.push(session);
-      return session;
+      const orchestrator = new HybridOrchestrator({
+        adapters: [adapter],
+        initialWorkingDirectory: workingDirectory,
+        initialModel: "test-model",
+      });
+      created.push({ orchestrator, get resetCalls() { return resetCalls; } });
+      return orchestrator;
     },
+    firstSendStarted,
+    releaseFirstSend: () => releaseFirstSend?.(),
   };
 }
 
@@ -100,6 +138,8 @@ describe("web/server/ws: in-band switch_chat_session", () => {
   let workspaceRoot: string;
   let workerHistoryStore: HistoryStore;
   let plannerHistoryStore: HistoryStore;
+  let syncEventStore: SyncEventStore;
+  let workerFactory: ReturnType<typeof createFakeSessionFactory> | null = null;
   const sockets: WebSocket[] = [];
 
   beforeEach(async () => {
@@ -113,10 +153,12 @@ describe("web/server/ws: in-band switch_chat_session", () => {
     const clientMetaByWs = new Map<import("ws").WebSocket, any>();
     workerHistoryStore = new HistoryStore({ storagePath: process.env.ADS_STATE_DB_PATH, namespace: "test-worker" });
     plannerHistoryStore = new HistoryStore({ storagePath: process.env.ADS_STATE_DB_PATH, namespace: "test-planner" });
+    syncEventStore = new SyncEventStore({ stateDbPath: process.env.ADS_STATE_DB_PATH });
     const lock = new AsyncLock();
     const agentAvailability = new NoopAgentAvailability();
     const directoryManager = new DirectoryManager([workspaceRoot]);
-    const workerFactory = createFakeSessionFactory("worker");
+    const nextWorkerFactory = createFakeSessionFactory("worker", { blockFirstSend: true });
+    workerFactory = nextWorkerFactory;
     const plannerFactory = createFakeSessionFactory("planner");
 
     attachWebSocketServer({
@@ -148,10 +190,11 @@ describe("web/server/ws: in-band switch_chat_session", () => {
         cwdStore: new Map(),
         cwdStorePath: process.env.ADS_STATE_DB_PATH,
         persistCwdStore: () => {},
+        syncEventStore,
       },
       sessions: {
         workerSessionManager: new SessionManager(0, 0, "workspace-write", "test-model", undefined, undefined, {
-          createSession: workerFactory.factory as never,
+          createSession: nextWorkerFactory.factory as never,
         }),
         plannerSessionManager: new SessionManager(0, 0, "read-only", "test-model", undefined, undefined, {
           createSession: plannerFactory.factory as never,
@@ -187,21 +230,26 @@ describe("web/server/ws: in-band switch_chat_session", () => {
   });
 
   afterEach(async () => {
+    workerFactory?.releaseFirstSend();
     for (const ws of sockets) {
       try {
         ws.close();
-      } catch {}
+      } catch {
+        // ignore
+      }
     }
     sockets.length = 0;
     await new Promise<void>((resolve) => server.close(() => resolve()));
     try {
       fs.rmSync(tmpDir, { recursive: true, force: true });
       fs.rmSync(workspaceRoot, { recursive: true, force: true });
-    } catch {}
+    } catch {
+      // ignore
+    }
   });
 
   it("switches chatSessionId in-band without dropping the socket connection", async () => {
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`, ["ads-v1", "ads-session.main", "ads-chat.session-initial"]);
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`, ["ads-v1", "ads-session.main", "ads-chat.planner"]);
     sockets.push(ws);
 
     let isClosed = false;
@@ -213,7 +261,7 @@ describe("web/server/ws: in-band switch_chat_session", () => {
     await waitForWsOpen(ws);
 
     const initialWelcome = await welcomePromise;
-    assert.equal(initialWelcome.chatSessionId, "session-initial");
+    assert.equal(initialWelcome.chatSessionId, "planner");
 
     // Send in-band switch message and wait for new welcome
     const switchPromise = waitForWsMessage(ws, (m) => m.type === "welcome" && m.chatSessionId === "session-switched");
@@ -225,8 +273,79 @@ describe("web/server/ws: in-band switch_chat_session", () => {
     const switchedWelcome = await switchPromise;
     assert.equal(switchedWelcome.chatSessionId, "session-switched");
 
+    const errorPromise = waitForWsMessage(
+      ws,
+      (m) => m.type === "error" && m.message === "当前没有正在执行的任务",
+    );
+    ws.send(JSON.stringify({ type: "interrupt" }));
+    await errorPromise;
+
+    const switchedLaneKey = resolveSyncLaneKey({
+      authUserId: "test",
+      sessionId: "main",
+      chatSessionId: "session-switched",
+    });
+    const initialLaneKey = resolveSyncLaneKey({
+      authUserId: "test",
+      sessionId: "main",
+      chatSessionId: "planner",
+    });
+    assert.ok(syncEventStore.getLatestSeqForLanes(resolveSyncNamespace("session-switched"), [switchedLaneKey]) > 0);
+    assert.equal(syncEventStore.getLatestSeqForLanes(resolveSyncNamespace("planner"), [initialLaneKey]), 0);
+
     // Connection must have remained open
     assert.equal(isClosed, false);
     assert.equal(ws.readyState, WebSocket.OPEN);
+  });
+
+  it("persists prompts received during a switch in the new history lane", async () => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`, ["ads-v1", "ads-session.main", "ads-chat.session-initial"]);
+    sockets.push(ws);
+
+    const welcomePromise = waitForWsMessage(ws, (m) => m.type === "welcome");
+    await waitForWsOpen(ws);
+    await welcomePromise;
+
+    const firstAckPromise = waitForWsMessage(ws, (m) => m.type === "ack" && m.client_message_id === "first", 2000, "first ack");
+    const firstResultPromise = waitForWsMessage(
+      ws,
+      (m) => m.type === "result" && m.output === "first response",
+      2000,
+      "first result",
+    );
+    ws.send(JSON.stringify({ type: "prompt", payload: "first prompt", client_message_id: "first" }));
+    await firstAckPromise;
+    await workerFactory!.firstSendStarted;
+
+    const switchPromise = waitForWsMessage(ws, (m) => m.type === "welcome" && m.chatSessionId === "session-switched");
+    ws.send(JSON.stringify({
+      type: "switch_chat_session",
+      payload: { chatSessionId: "session-switched" },
+    }));
+
+    const secondAckPromise = waitForWsMessage(ws, (m) => m.type === "ack" && m.client_message_id === "second", 2000, "second ack");
+    const secondResultPromise = waitForWsMessage(ws, (m) => m.type === "result" && m.output === "second response", 2000, "second result");
+    ws.send(JSON.stringify({ type: "prompt", payload: "second prompt", client_message_id: "second" }));
+    workerFactory!.releaseFirstSend();
+
+    await firstResultPromise;
+    await switchPromise;
+    await secondAckPromise;
+    await secondResultPromise;
+
+    const initialHistoryKey = resolveSyncLaneKey({
+      authUserId: "test",
+      sessionId: "main",
+      chatSessionId: "session-initial",
+    });
+    const switchedHistoryKey = resolveSyncLaneKey({
+      authUserId: "test",
+      sessionId: "main",
+      chatSessionId: "session-switched",
+    });
+    const initialHistory = workerHistoryStore.get(initialHistoryKey);
+    const switchedHistory = workerHistoryStore.get(switchedHistoryKey);
+    assert.equal(initialHistory.some((entry) => entry.text === "second prompt"), false);
+    assert.ok(switchedHistory.some((entry) => entry.text === "second prompt"));
   });
 });


### PR DESCRIPTION
## Summary

Fixes #64.

Moves chat session switching to an in-band protocol message handled by the server over the existing open WebSocket:
- Server: Added handling for `switch_chat_session` control message in `server/web/server/ws/server.ts`. Dynamically rebinds connection identity (`chatSessionId`, `userId`, `historyKey`), aborts any in-flight task on the previous session, and delivers fresh `welcome` and bootstrap state without disconnecting.
- Client: Added `switchChatSession(chatSessionId)` on `AdsWebSocket`. In `client/src/app/projectsWs/projectActions.ts`, `startNewChatSession()` now switches in-band when connected, keeping the connection alive and the status indicator green throughout the transition, and falls back to full reconnection if offline.

## Tests

- Added `tests/web/wsSwitchChatSession.test.ts` verifying that the server dynamically rebinds `chatSessionId` and sends a new `welcome` message while keeping the underlying connection continuously open.
- Added `client/src/__tests__/ws-session-switch-inband.test.ts` verifying that `startNewChatSession()` sends `switch_chat_session` and maintains `connected = true`.
- Validated with `npm run build` and ran unit tests.
