### PR TITLE
feat(planner): grant danger-full-access sandbox mode to Advisor for GitHub CLI integration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,7 @@ ADS 会在启动时从当前工作目录向上查找 `.env` 文件，并自动�
 | `ADS_WEB_LOGIN_LOCKOUT_MS` | `300000` (5分钟) | 触发锁定后的基础冷却时长 |
 | `ADS_WEB_SESSION_SLIDING` | `false` | 是否开启滑动刷新 Session 有效期 |
 | `ADS_PLANNER_CODEX_MODEL` | 未设置 | Advisor (规划 Lane) 专用的 Codex 模型覆盖 |
+| `ADS_PLANNER_SANDBOX_MODE` | `danger-full-access` | Advisor Lane 沙箱权限覆盖；用于需要调用 GitHub CLI 的场景。非法值安全回退为 `workspace-write` |
 | `TASK_QUEUE_ENABLED` | `true` | 是否启用任务看板的后台队列执行器 |
 | `TASK_QUEUE_AUTO_START` | `false` | 服务启动后是否自动开始运行排队任务 |
 | `TASK_QUEUE_DEFAULT_MODEL` | 未设置 | 任务队列派发任务时的默认执行模型 |

--- a/docs/web.md
+++ b/docs/web.md
@@ -80,6 +80,7 @@ Web Console 经过专门的移动端交互优化：
 | `ADS_WEB_LOGIN_MAX_ATTEMPTS` | `5` | 登录重试超限锁定阈值 |
 | `ADS_WEB_LOGIN_LOCKOUT_MS` | `300000` (5分钟) | 登录锁定基础时长 |
 | `ADS_PLANNER_CODEX_MODEL` | 未设置 | Advisor Lane 使用的专属 Codex 模型覆盖 |
+| `ADS_PLANNER_SANDBOX_MODE` | `danger-full-access` | Advisor Lane 沙箱权限覆盖；非法值回退为 `workspace-write` |
 | `TASK_QUEUE_ENABLED` | `true` | 是否开启后台任务队列 |
 | `TASK_QUEUE_AUTO_START` | `false` | 服务启动后是否自动开始运行任务队列 |
 | `TASK_QUEUE_DEFAULT_MODEL` | 未设置 | 任务队列默认执行模型 |

--- a/server/web/server/start/webLaneResources.ts
+++ b/server/web/server/start/webLaneResources.ts
@@ -14,10 +14,13 @@ export const WEB_PLANNER_NAMESPACE = "web-planner";
 
 export function resolvePlannerSandboxMode(raw: string | undefined): SandboxMode {
   const value = raw?.trim();
+  if (value === undefined || value === "") {
+    return "danger-full-access";
+  }
   if (value === "read-only" || value === "workspace-write" || value === "danger-full-access") {
     return value;
   }
-  return "danger-full-access";
+  return "workspace-write";
 }
 
 export type MaterializationState = {

--- a/server/web/server/start/webLaneResources.ts
+++ b/server/web/server/start/webLaneResources.ts
@@ -12,6 +12,14 @@ import { WorkspaceLockPool } from "../workspaceLockPool.js";
 export const WEB_WORKER_NAMESPACE = "web-worker";
 export const WEB_PLANNER_NAMESPACE = "web-planner";
 
+export function resolvePlannerSandboxMode(raw: string | undefined): SandboxMode {
+  const value = raw?.trim();
+  if (value === "read-only" || value === "workspace-write" || value === "danger-full-access") {
+    return value;
+  }
+  return "danger-full-access";
+}
+
 export type MaterializationState = {
   materialized: boolean;
   materializeCount: number;
@@ -190,9 +198,14 @@ export function createWebLaneResources(args: {
   historyMaxEntriesPerSession?: number;
   historyMaxTextLength?: number;
   plannerCodexModel?: string;
+  plannerSandboxMode?: SandboxMode;
   workerSessionManagerOptions?: SessionManagerOptions;
   plannerSessionManagerOptions?: SessionManagerOptions;
 }): WebLaneResources {
+  const plannerSandboxMode =
+    args.plannerSandboxMode ??
+    resolvePlannerSandboxMode(process.env.ADS_PLANNER_SANDBOX_MODE);
+
   return {
     worker: createLaneRuntime({
       namespace: WEB_WORKER_NAMESPACE,
@@ -207,9 +220,10 @@ export function createWebLaneResources(args: {
     }),
     planner: createLaneRuntime({
       namespace: WEB_PLANNER_NAMESPACE,
-      // The Advisor needs to write paired issue/spec work items; everything it
-      // touches outside the allowlist is rolled back after each turn.
-      sandboxMode: "workspace-write",
+      // The Advisor needs danger-full-access for tools like GitHub CLI (gh),
+      // while specWriteGuard protects the local codebase by rolling back any
+      // mutations outside docs/issue/ and docs/spec/ after each turn.
+      sandboxMode: plannerSandboxMode,
       defaultModel: args.plannerCodexModel,
       sessionTimeoutMs: args.sessionTimeoutMs,
       sessionCleanupIntervalMs: args.sessionCleanupIntervalMs,

--- a/tests/web/lazyWebLanes.test.ts
+++ b/tests/web/lazyWebLanes.test.ts
@@ -94,30 +94,47 @@ describe("web lazy planner lane", () => {
   });
 
   it("supports overriding planner sandbox mode via environment variable and explicit argument", () => {
-    process.env.ADS_PLANNER_SANDBOX_MODE = "workspace-write";
-    const envLanes = createWebLaneResources({
-      stateDbPath: process.env.ADS_STATE_DB_PATH!,
-      sessionTimeoutMs: 0,
-      sessionCleanupIntervalMs: 0,
-    });
     try {
-      assert.equal(envLanes.planner.sessionManager.getStats().sandboxMode, "workspace-write");
-    } finally {
-      envLanes.worker.sessionManager.destroy();
-      destroySessionManagerIfMaterialized(envLanes.planner.sessionManager);
-    }
+      process.env.ADS_PLANNER_SANDBOX_MODE = "workspace-write";
+      const envLanes = createWebLaneResources({
+        stateDbPath: process.env.ADS_STATE_DB_PATH!,
+        sessionTimeoutMs: 0,
+        sessionCleanupIntervalMs: 0,
+      });
+      try {
+        assert.equal(envLanes.planner.sessionManager.getStats().sandboxMode, "workspace-write");
+      } finally {
+        envLanes.worker.sessionManager.destroy();
+        destroySessionManagerIfMaterialized(envLanes.planner.sessionManager);
+      }
 
-    const argLanes = createWebLaneResources({
-      stateDbPath: process.env.ADS_STATE_DB_PATH!,
-      sessionTimeoutMs: 0,
-      sessionCleanupIntervalMs: 0,
-      plannerSandboxMode: "read-only",
-    });
-    try {
-      assert.equal(argLanes.planner.sessionManager.getStats().sandboxMode, "read-only");
+      process.env.ADS_PLANNER_SANDBOX_MODE = "not-a-sandbox-mode";
+      const invalidEnvLanes = createWebLaneResources({
+        stateDbPath: process.env.ADS_STATE_DB_PATH!,
+        sessionTimeoutMs: 0,
+        sessionCleanupIntervalMs: 0,
+      });
+      try {
+        assert.equal(invalidEnvLanes.planner.sessionManager.getStats().sandboxMode, "workspace-write");
+      } finally {
+        invalidEnvLanes.worker.sessionManager.destroy();
+        destroySessionManagerIfMaterialized(invalidEnvLanes.planner.sessionManager);
+      }
+
+      const argLanes = createWebLaneResources({
+        stateDbPath: process.env.ADS_STATE_DB_PATH!,
+        sessionTimeoutMs: 0,
+        sessionCleanupIntervalMs: 0,
+        plannerSandboxMode: "read-only",
+      });
+      try {
+        assert.equal(argLanes.planner.sessionManager.getStats().sandboxMode, "read-only");
+      } finally {
+        argLanes.worker.sessionManager.destroy();
+        destroySessionManagerIfMaterialized(argLanes.planner.sessionManager);
+      }
     } finally {
-      argLanes.worker.sessionManager.destroy();
-      destroySessionManagerIfMaterialized(argLanes.planner.sessionManager);
+      delete process.env.ADS_PLANNER_SANDBOX_MODE;
     }
   });
 });

--- a/tests/web/lazyWebLanes.test.ts
+++ b/tests/web/lazyWebLanes.test.ts
@@ -64,6 +64,7 @@ describe("web lazy planner lane", () => {
         sessionManager: { materialized: false, materializeCount: 0 },
         workspaceLockPool: { materialized: false, materializeCount: 0 },
       });
+      assert.equal(lanes.planner.sessionManager.getStats().sandboxMode, "danger-full-access");
       const firstOrchestrator = lanes.planner.sessionManager.getOrCreate(123, workspaceRoot, false);
       assert.equal(firstOrchestrator.status().streaming, true);
       assert.equal(lanes.planner.historyStore.add("planner::session", { role: "user", text: "/pwd", ts: Date.now() }), true);
@@ -89,6 +90,34 @@ describe("web lazy planner lane", () => {
     } finally {
       lanes.worker.sessionManager.destroy();
       destroySessionManagerIfMaterialized(lanes.planner.sessionManager);
+    }
+  });
+
+  it("supports overriding planner sandbox mode via environment variable and explicit argument", () => {
+    process.env.ADS_PLANNER_SANDBOX_MODE = "workspace-write";
+    const envLanes = createWebLaneResources({
+      stateDbPath: process.env.ADS_STATE_DB_PATH!,
+      sessionTimeoutMs: 0,
+      sessionCleanupIntervalMs: 0,
+    });
+    try {
+      assert.equal(envLanes.planner.sessionManager.getStats().sandboxMode, "workspace-write");
+    } finally {
+      envLanes.worker.sessionManager.destroy();
+      destroySessionManagerIfMaterialized(envLanes.planner.sessionManager);
+    }
+
+    const argLanes = createWebLaneResources({
+      stateDbPath: process.env.ADS_STATE_DB_PATH!,
+      sessionTimeoutMs: 0,
+      sessionCleanupIntervalMs: 0,
+      plannerSandboxMode: "read-only",
+    });
+    try {
+      assert.equal(argLanes.planner.sessionManager.getStats().sandboxMode, "read-only");
+    } finally {
+      argLanes.worker.sessionManager.destroy();
+      destroySessionManagerIfMaterialized(argLanes.planner.sessionManager);
     }
   });
 });


### PR DESCRIPTION
## Summary
Updates the Advisor (Planner lane) default sandbox mode to `danger-full-access` (with optional override via `ADS_PLANNER_SANDBOX_MODE` or `plannerSandboxMode` arg), allowing the Advisor to execute external CLI tools such as `gh issue` and `gh pr` while relying on `specWriteGuard` for local workspace write boundaries.

Closes #70

## Changes
- Updated `createWebLaneResources` in `server/web/server/start/webLaneResources.ts` to default `planner` sandbox mode to `danger-full-access`.
- Added `resolvePlannerSandboxMode` helper to support `ADS_PLANNER_SANDBOX_MODE` environment variable override.
- Added unit tests in `tests/web/lazyWebLanes.test.ts` verifying default sandbox mode and override capabilities.

## Verification
- `npx tsx --test tests/web/lazyWebLanes.test.ts` passed.
- `npx tsx --test tests/web/specWriteGuard.test.ts` passed.
- `npm run lint` passed.
