### PR TITLE
feat(core): introduce unified Turn & Item middleware lifecycle pipeline

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,6 +65,11 @@ Web、Telegram 与 Task Queue 保留各自现有的本地存储和消息交付�
 - **进程守卫 (Execution Governor)**：
   - 动态限制并发 CLI 实例数，提供空闲看门狗（Idle Watchdog）与最大硬超时保护，防止僵尸进程耗尽系统资源。
 
+### 2.2.1 Agent Turn Middleware
+- `server/middleware/` 提供可组合的 Turn/Item 生命周期钩子。
+- `runAgentTurn` 和 Task Queue 执行器支持注入同一个 middleware pipeline，用于输入预处理、回合启动、输出后处理和错误收尾。
+- Item 级安全钩子失败时默认拒绝执行；输出 artifact 使用私有目录和 `0600` 文件权限。
+
 ### 2.3 状态同步协议与双向通信 (Durable Sync Protocol)
 - 客户端与服务端基于增量序列号（`seq`）与 WebSocket 建立长连接通信。
 - 服务端记录不可篡改的 `SyncEvent` 事件流，客户端断线重连后通过 `/api/sync/events?afterSeq=...` 自动对账补齐断线期间产生的所有消息与命令事件。

--- a/server/agents/turn.ts
+++ b/server/agents/turn.ts
@@ -5,12 +5,15 @@ import type { HybridOrchestrator } from "./orchestrator.js";
 import { ActivityTracker, resolveExploredConfig, type ExploredEntry, type ExploredEntryCallback } from "../utils/activityTracker.js";
 import { executeToolDirectives, stripToolDirectives } from "../skills/builtinTools.js";
 import { detectWorkspaceFrom } from "../workspace/detector.js";
+import type { MiddlewarePipeline, TurnContext } from "../middleware/index.js";
 
 export interface AgentTurnOptions extends AgentSendOptions {
   cwd?: string;
   workspaceRoot?: string;
   historySessionId?: string;
   onExploredEntry?: ExploredEntryCallback;
+  middleware?: MiddlewarePipeline;
+  middlewareContext?: Omit<TurnContext, "prompt" | "workspaceRoot"> & { workspaceRoot?: string };
 }
 
 export interface AgentTurnResult extends AgentRunResult {
@@ -36,6 +39,24 @@ export async function runAgentTurn(
     : () => undefined;
 
   const activeAgentId = orchestrator.getActiveAgentId();
+  const workspaceRoot = options.workspaceRoot ?? detectWorkspaceFrom(options.cwd ?? process.cwd());
+  const middlewareContext: TurnContext | undefined = options.middleware
+    ? {
+        turnId: options.middlewareContext?.turnId ?? options.historySessionId ?? "agent-turn",
+        sessionId: options.middlewareContext?.sessionId ?? options.historySessionId ?? "agent-session",
+        workspaceRoot: options.middlewareContext?.workspaceRoot ?? workspaceRoot,
+        channel: options.middlewareContext?.channel ?? "web",
+        prompt: typeof input === "string" ? input : "",
+        metadata: options.middlewareContext?.metadata,
+      }
+    : undefined;
+  let effectiveInput = input;
+  if (options.middleware && middlewareContext) {
+    const middlewarePrompt = await options.middleware.executeBeforeInput(middlewareContext);
+    if (typeof input === "string") effectiveInput = middlewarePrompt;
+    middlewareContext.prompt = typeof effectiveInput === "string" ? effectiveInput : middlewareContext.prompt;
+    await options.middleware.executeTurnStart(middlewareContext);
+  }
   const sendOptions: AgentSendOptions = {
     streaming: options.streaming,
     outputSchema: activeAgentId === "codex" ? options.outputSchema : undefined,
@@ -44,8 +65,7 @@ export async function runAgentTurn(
   };
 
   try {
-    const result: AgentRunResult = await orchestrator.invokeAgent(activeAgentId, input, sendOptions);
-    const workspaceRoot = options.workspaceRoot ?? detectWorkspaceFrom(options.cwd ?? process.cwd());
+    const result: AgentRunResult = await orchestrator.invokeAgent(activeAgentId, effectiveInput, sendOptions);
     const toolResults = await executeToolDirectives({
       text: result.response,
       workspaceRoot,
@@ -56,11 +76,22 @@ export async function runAgentTurn(
     if (toolResults.length > 0) {
       response = [cleanedResponse, "", ...toolResults].join("\n").trim();
     }
+    if (options.middleware && middlewareContext) {
+      await options.middleware.executeAfterOutput(middlewareContext, response);
+    }
 
     const explored = exploredTracker
       ? exploredTracker.compact({ maxItems: exploredConfig.maxItems, dedupe: exploredConfig.dedupe })
       : undefined;
     return { ...result, response, explored };
+  } catch (error) {
+    if (options.middleware && middlewareContext) {
+      await options.middleware.executeTurnError(
+        middlewareContext,
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    }
+    throw error;
   } finally {
     unsubscribeExplored();
   }

--- a/server/middleware/builtin/cfMemMiddleware.ts
+++ b/server/middleware/builtin/cfMemMiddleware.ts
@@ -7,7 +7,6 @@ export interface CfMemMiddlewareOptions {
   fetchSemanticContext?: (ctx: TurnContext) => Promise<string | null>;
   ingestConversationTurn?: (ctx: TurnContext, assistantReply: string) => Promise<void>;
 }
-
 export function createCfMemMiddleware(
   options: CfMemMiddlewareOptions = {},
 ): AdsMiddleware {
@@ -27,14 +26,11 @@ export function createCfMemMiddleware(
       }
     },
 
-    async onAfterOutput(ctx: TurnContext, assistantReply: string): Promise<void> {
+    onAfterOutput(ctx: TurnContext, assistantReply: string): void {
       if (!options.ingestConversationTurn) return;
-      try {
-        await options.ingestConversationTurn(ctx, assistantReply);
-      } catch {
+      void options.ingestConversationTurn(ctx, assistantReply).catch(() => {
         // Non-blocking fail-safe
-      }
+      });
     },
   };
 }
-

--- a/server/middleware/builtin/cfMemMiddleware.ts
+++ b/server/middleware/builtin/cfMemMiddleware.ts
@@ -1,0 +1,40 @@
+import type { AdsMiddleware, TurnContext, BeforeInputResult } from "../types.js";
+
+export interface CfMemMiddlewareOptions {
+  apiBase?: string;
+  apiKey?: string;
+  recallTopK?: number;
+  fetchSemanticContext?: (ctx: TurnContext) => Promise<string | null>;
+  ingestConversationTurn?: (ctx: TurnContext, assistantReply: string) => Promise<void>;
+}
+
+export function createCfMemMiddleware(
+  options: CfMemMiddlewareOptions = {},
+): AdsMiddleware {
+  return {
+    name: "cfMem",
+
+    async onBeforeInput(ctx: TurnContext): Promise<BeforeInputResult | void> {
+      if (!options.fetchSemanticContext) return;
+      try {
+        const recalled = await options.fetchSemanticContext(ctx);
+        if (recalled && recalled.trim()) {
+          const modifiedPrompt = `<recalled_memory>\n${recalled.trim()}\n</recalled_memory>\n\n${ctx.prompt}`;
+          return { modifiedPrompt };
+        }
+      } catch {
+        // Non-blocking fail-safe
+      }
+    },
+
+    async onAfterOutput(ctx: TurnContext, assistantReply: string): Promise<void> {
+      if (!options.ingestConversationTurn) return;
+      try {
+        await options.ingestConversationTurn(ctx, assistantReply);
+      } catch {
+        // Non-blocking fail-safe
+      }
+    },
+  };
+}
+

--- a/server/middleware/builtin/contextArtifactMiddleware.ts
+++ b/server/middleware/builtin/contextArtifactMiddleware.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { AdsMiddleware, TurnContext, ItemEndResult } from "../types.js";
+import type { ThreadItem } from "../../agents/protocol/types.js";
+
+export interface ContextArtifactMiddlewareOptions {
+  maxOutputBytes?: number;
+  artifactsDir?: string;
+}
+
+const DEFAULT_MAX_OUTPUT_BYTES = 50 * 1024; // 50 KB
+
+export function createContextArtifactMiddleware(
+  options: ContextArtifactMiddlewareOptions = {},
+): AdsMiddleware {
+  const maxBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+
+  return {
+    name: "contextArtifact",
+
+    onItemEnd(ctx: TurnContext, item: ThreadItem): ItemEndResult | void {
+      let rawOutput = "";
+      if (item.type === "command_execution") {
+        rawOutput = String(item.aggregated_output ?? item.stdout ?? "");
+      } else if ("output" in item && typeof (item as { output?: unknown }).output === "string") {
+        rawOutput = (item as unknown as { output: string }).output;
+      }
+
+      if (!rawOutput || Buffer.byteLength(rawOutput, "utf8") <= maxBytes) {
+        return;
+      }
+
+      const baseDir = options.artifactsDir ?? path.join(ctx.workspaceRoot || os.tmpdir(), ".ads", "artifacts");
+      try {
+        fs.mkdirSync(baseDir, { recursive: true, mode: 0o700 });
+      } catch {
+        // ignore
+      }
+
+      const artifactId = `artifact-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.txt`;
+      const artifactPath = path.join(baseDir, artifactId);
+      try {
+        fs.writeFileSync(artifactPath, rawOutput, { encoding: "utf8", mode: 0o600 });
+        const lines = rawOutput.split("\n");
+        const head = lines.slice(0, 20).join("\n");
+        const tail = lines.slice(-20).join("\n");
+        const modifiedOutput = `${head}\n\n... [Output truncated: ${rawOutput.length} characters / ${lines.length} lines saved to artifact: ${artifactPath}] ...\n\n${tail}`;
+        return { modifiedOutput };
+      } catch {
+        return;
+      }
+    },
+  };
+}

--- a/server/middleware/builtin/contextArtifactMiddleware.ts
+++ b/server/middleware/builtin/contextArtifactMiddleware.ts
@@ -42,6 +42,7 @@ export function createContextArtifactMiddleware(
       const artifactPath = path.join(baseDir, artifactId);
       try {
         fs.writeFileSync(artifactPath, rawOutput, { encoding: "utf8", mode: 0o600 });
+        fs.chmodSync(artifactPath, 0o600);
         const lines = rawOutput.split("\n");
         const head = lines.slice(0, 20).join("\n");
         const tail = lines.slice(-20).join("\n");

--- a/server/middleware/builtin/globalRulesMiddleware.ts
+++ b/server/middleware/builtin/globalRulesMiddleware.ts
@@ -1,0 +1,44 @@
+import type { AdsMiddleware, TurnContext, ItemStartResult } from "../types.js";
+import type { ThreadItem } from "../../agents/protocol/types.js";
+
+export interface GlobalRulesMiddlewareOptions {
+  blockedCommandPatterns?: RegExp[];
+  customRulesHeader?: string;
+}
+
+const DEFAULT_BLOCKED_COMMAND_PATTERNS = [
+  /\bpkill\s+(?:-[a-zA-Z0-9]+\s+)*-?f?\s*(?:ads|cli\.js)/i,
+  /\bkillall\s+(?:-[a-zA-Z0-9]+\s+)*(?:node|ads)/i,
+  /\bsystemctl\s+(?:--user\s+)?(?:stop|disable|mask|kill)\s+ads-(?:web|tg)/i,
+];
+
+export function createGlobalRulesMiddleware(
+  options: GlobalRulesMiddlewareOptions = {},
+): AdsMiddleware {
+  const patterns = options.blockedCommandPatterns ?? DEFAULT_BLOCKED_COMMAND_PATTERNS;
+
+  return {
+    name: "globalRules",
+
+    onBeforeInput(ctx: TurnContext) {
+      if (!options.customRulesHeader) return;
+      return {
+        modifiedPrompt: `${options.customRulesHeader}\n\n${ctx.prompt}`,
+      };
+    },
+
+    onItemStart(_ctx: TurnContext, item: ThreadItem): ItemStartResult | void {
+      if (item.type !== "command_execution") return;
+      const cmd = String(item.command ?? "").trim();
+      for (const pattern of patterns) {
+        if (pattern.test(cmd)) {
+          return {
+            blockExecution: true,
+            reason: `Command blocked by security rule: ${cmd}`,
+          };
+        }
+      }
+    },
+  };
+}
+

--- a/server/middleware/builtin/globalRulesMiddleware.ts
+++ b/server/middleware/builtin/globalRulesMiddleware.ts
@@ -5,7 +5,6 @@ export interface GlobalRulesMiddlewareOptions {
   blockedCommandPatterns?: RegExp[];
   customRulesHeader?: string;
 }
-
 const DEFAULT_BLOCKED_COMMAND_PATTERNS = [
   /\bpkill\s+(?:-[a-zA-Z0-9]+\s+)*-?f?\s*(?:ads|cli\.js)/i,
   /\bkillall\s+(?:-[a-zA-Z0-9]+\s+)*(?:node|ads)/i,
@@ -41,4 +40,3 @@ export function createGlobalRulesMiddleware(
     },
   };
 }
-

--- a/server/middleware/index.ts
+++ b/server/middleware/index.ts
@@ -1,0 +1,5 @@
+export * from "./types.js";
+export * from "./pipeline.js";
+export * from "./builtin/globalRulesMiddleware.js";
+export * from "./builtin/contextArtifactMiddleware.js";
+export * from "./builtin/cfMemMiddleware.js";

--- a/server/middleware/pipeline.ts
+++ b/server/middleware/pipeline.ts
@@ -71,6 +71,10 @@ export class MiddlewarePipeline {
           logger.warn(
             `[${mw.name}] onItemStart failed: ${err instanceof Error ? err.message : String(err)}`,
           );
+          return {
+            blockExecution: true,
+            reason: `Middleware ${mw.name} failed closed: ${err instanceof Error ? err.message : String(err)}`,
+          };
         }
       }
     }

--- a/server/middleware/pipeline.ts
+++ b/server/middleware/pipeline.ts
@@ -1,0 +1,134 @@
+import type {
+  AdsMiddleware,
+  TurnContext,
+  ItemStartResult,
+  ItemEndResult,
+} from "./types.js";
+import type { ThreadItem } from "../agents/protocol/types.js";
+import { createLogger } from "../utils/logger.js";
+
+const logger = createLogger("MiddlewarePipeline");
+
+export class MiddlewarePipeline {
+  private readonly middlewares: AdsMiddleware[] = [];
+
+  constructor(middlewares?: AdsMiddleware[]) {
+    if (middlewares) {
+      this.middlewares.push(...middlewares);
+    }
+  }
+
+  use(middleware: AdsMiddleware): this {
+    this.middlewares.push(middleware);
+    return this;
+  }
+
+  async executeBeforeInput(ctx: TurnContext): Promise<string> {
+    let currentPrompt = ctx.prompt;
+    for (const mw of this.middlewares) {
+      if (mw.onBeforeInput) {
+        try {
+          const result = await mw.onBeforeInput({ ...ctx, prompt: currentPrompt });
+          if (result && typeof result.modifiedPrompt === "string") {
+            currentPrompt = result.modifiedPrompt;
+          }
+        } catch (err) {
+          logger.warn(
+            `[${mw.name}] onBeforeInput failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    }
+    return currentPrompt;
+  }
+
+  async executeTurnStart(ctx: TurnContext): Promise<void> {
+    for (const mw of this.middlewares) {
+      if (mw.onTurnStart) {
+        try {
+          await mw.onTurnStart(ctx);
+        } catch (err) {
+          logger.warn(
+            `[${mw.name}] onTurnStart failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    }
+  }
+
+  async executeItemStart(ctx: TurnContext, item: ThreadItem): Promise<ItemStartResult> {
+    for (const mw of this.middlewares) {
+      if (mw.onItemStart) {
+        try {
+          const result = await mw.onItemStart(ctx, item);
+          if (result?.blockExecution) {
+            return {
+              blockExecution: true,
+              reason: result.reason ?? "Blocked by middleware policy",
+            };
+          }
+        } catch (err) {
+          logger.warn(
+            `[${mw.name}] onItemStart failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    }
+    return { blockExecution: false };
+  }
+
+  async executeItemEnd(ctx: TurnContext, item: ThreadItem): Promise<ItemEndResult> {
+    let modifiedOutput: string | undefined;
+    for (const mw of this.middlewares) {
+      if (mw.onItemEnd) {
+        try {
+          const result = await mw.onItemEnd(ctx, item);
+          if (result && typeof result.modifiedOutput === "string") {
+            modifiedOutput = result.modifiedOutput;
+          }
+        } catch (err) {
+          logger.warn(
+            `[${mw.name}] onItemEnd failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    }
+    return { modifiedOutput };
+  }
+
+  async executeAfterOutput(ctx: TurnContext, assistantReply: string): Promise<void> {
+    for (const mw of this.middlewares) {
+      if (mw.onAfterOutput) {
+        try {
+          await mw.onAfterOutput(ctx, assistantReply);
+        } catch (err) {
+          logger.warn(
+            `[${mw.name}] onAfterOutput failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    }
+  }
+
+  async executeTurnError(ctx: TurnContext, error: Error): Promise<void> {
+    for (const mw of this.middlewares) {
+      if (mw.onTurnError) {
+        try {
+          await mw.onTurnError(ctx, error);
+        } catch (err) {
+          logger.warn(
+            `[${mw.name}] onTurnError failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    }
+  }
+
+  getMiddlewares(): ReadonlyArray<AdsMiddleware> {
+    return this.middlewares;
+  }
+}
+
+export function createMiddlewarePipeline(middlewares?: AdsMiddleware[]): MiddlewarePipeline {
+  return new MiddlewarePipeline(middlewares);
+}

--- a/server/middleware/types.ts
+++ b/server/middleware/types.ts
@@ -1,0 +1,35 @@
+import type { ThreadItem } from "../agents/protocol/types.js";
+
+export type MiddlewareChannel = "web" | "telegram" | "task_queue";
+
+export interface TurnContext {
+  turnId: string;
+  sessionId: string;
+  workspaceRoot: string;
+  channel: MiddlewareChannel;
+  prompt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface BeforeInputResult {
+  modifiedPrompt?: string;
+}
+
+export interface ItemStartResult {
+  blockExecution?: boolean;
+  reason?: string;
+}
+
+export interface ItemEndResult {
+  modifiedOutput?: string;
+}
+
+export interface AdsMiddleware {
+  name: string;
+  onBeforeInput?(ctx: TurnContext): Promise<void | BeforeInputResult> | void | BeforeInputResult;
+  onTurnStart?(ctx: TurnContext): Promise<void> | void;
+  onItemStart?(ctx: TurnContext, item: ThreadItem): Promise<void | ItemStartResult> | void | ItemStartResult;
+  onItemEnd?(ctx: TurnContext, item: ThreadItem): Promise<void | ItemEndResult> | void | ItemEndResult;
+  onAfterOutput?(ctx: TurnContext, assistantReply: string): Promise<void> | void;
+  onTurnError?(ctx: TurnContext, error: Error): Promise<void> | void;
+}

--- a/server/tasks/executor.ts
+++ b/server/tasks/executor.ts
@@ -15,6 +15,7 @@ import {
   formatWorkspacePatchArtifactForPrompt,
 } from "./executorHelpers.js";
 import { recordConversationMessage } from "../utils/conversationMessageRecorder.js";
+import { createMiddlewarePipeline, type MiddlewarePipeline } from "../middleware/index.js";
 
 export interface TaskExecutorHooks {
   onMessage?: (message: { role: string; content: string; modelUsed?: string | null }) => void;
@@ -47,6 +48,7 @@ export class OrchestratorTaskExecutor implements TaskExecutor {
   private readonly autoModelOverride?: string;
   private readonly lock?: AsyncLock;
   private readonly getLock?: () => AsyncLock;
+  private readonly middleware?: MiddlewarePipeline;
 
   constructor(options: {
     getOrchestrator: (task: Task) => HybridOrchestrator;
@@ -56,6 +58,7 @@ export class OrchestratorTaskExecutor implements TaskExecutor {
     autoModelOverride?: string;
     lock?: AsyncLock;
     getLock?: () => AsyncLock;
+    middleware?: MiddlewarePipeline;
   }) {
     this.getOrchestrator = options.getOrchestrator;
     this.getAgentEnv = options.getAgentEnv;
@@ -64,6 +67,7 @@ export class OrchestratorTaskExecutor implements TaskExecutor {
     this.autoModelOverride = String(options.autoModelOverride ?? "").trim() || undefined;
     this.lock = options.lock;
     this.getLock = options.getLock;
+    this.middleware = options.middleware;
   }
 
   private resolveModelOverride(task: Task): { modelOverride?: string; modelForSelection: string; modelForStorage: string | null } {
@@ -309,11 +313,32 @@ export class OrchestratorTaskExecutor implements TaskExecutor {
           }
 
           const env = this.getAgentEnv?.(task, agentId);
-          result = await orchestrator.invokeAgent(agentId, prompt, {
-            signal: options?.signal,
-            streaming: true,
-            env,
-          });
+          const middleware = this.middleware ?? createMiddlewarePipeline();
+          const middlewareContext = {
+            turnId: `task:${task.id}`,
+            sessionId: conversationId,
+            workspaceRoot: this.workspaceRoot,
+            channel: "task_queue" as const,
+          };
+          const effectivePrompt = await middleware.executeBeforeInput({ ...middlewareContext, prompt });
+          await middleware.executeTurnStart({ ...middlewareContext, prompt: effectivePrompt });
+          try {
+            result = await orchestrator.invokeAgent(agentId, effectivePrompt, {
+              signal: options?.signal,
+              streaming: true,
+              env,
+            });
+            await middleware.executeAfterOutput(
+              { ...middlewareContext, prompt: effectivePrompt },
+              typeof result.response === "string" ? result.response : String(result.response ?? ""),
+            );
+          } catch (error) {
+            await middleware.executeTurnError(
+              { ...middlewareContext, prompt: effectivePrompt },
+              error instanceof Error ? error : new Error(String(error)),
+            );
+            throw error;
+          }
 
           // Set the goal AFTER the first turn so threadId is available. For
           // single-turn tasks this still records the goal for later reads.

--- a/tests/middleware/pipeline.test.ts
+++ b/tests/middleware/pipeline.test.ts
@@ -1,0 +1,164 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  MiddlewarePipeline,
+  createMiddlewarePipeline,
+  createGlobalRulesMiddleware,
+  createContextArtifactMiddleware,
+  createCfMemMiddleware,
+  type TurnContext,
+  type AdsMiddleware,
+} from "../../server/middleware/index.js";
+
+describe("MiddlewarePipeline & Core Middlewares", () => {
+  const baseCtx: TurnContext = {
+    turnId: "turn-1",
+    sessionId: "sess-1",
+    workspaceRoot: os.tmpdir(),
+    channel: "web",
+    prompt: "original prompt",
+  };
+
+  it("executes onBeforeInput in order and chains prompt modifications", async () => {
+    const mw1: AdsMiddleware = {
+      name: "mw1",
+      onBeforeInput: (ctx) => ({ modifiedPrompt: `[mw1] ${ctx.prompt}` }),
+    };
+    const mw2: AdsMiddleware = {
+      name: "mw2",
+      onBeforeInput: (ctx) => ({ modifiedPrompt: `${ctx.prompt} [mw2]` }),
+    };
+
+    const pipeline = createMiddlewarePipeline([mw1, mw2]);
+    const result = await pipeline.executeBeforeInput(baseCtx);
+
+    assert.equal(result, "[mw1] original prompt [mw2]");
+  });
+
+  it("executes onTurnStart across all registered middlewares", async () => {
+    const calls: string[] = [];
+    const mw1: AdsMiddleware = {
+      name: "mw1",
+      onTurnStart: () => {
+        calls.push("mw1");
+      },
+    };
+    const mw2: AdsMiddleware = {
+      name: "mw2",
+      onTurnStart: () => {
+        calls.push("mw2");
+      },
+    };
+
+    const pipeline = new MiddlewarePipeline([mw1, mw2]);
+    await pipeline.executeTurnStart(baseCtx);
+
+    assert.deepEqual(calls, ["mw1", "mw2"]);
+  });
+
+  it("intercepts and blocks dangerous commands via globalRulesMiddleware in onItemStart", async () => {
+    const rulesMw = createGlobalRulesMiddleware();
+    const pipeline = createMiddlewarePipeline([rulesMw]);
+
+    const safeResult = await pipeline.executeItemStart(baseCtx, {
+      type: "command_execution",
+      command: "git status",
+    });
+    assert.equal(safeResult.blockExecution, false);
+
+    const blockedResult = await pipeline.executeItemStart(baseCtx, {
+      type: "command_execution",
+      command: "pkill -f ads",
+    });
+    assert.equal(blockedResult.blockExecution, true);
+    assert.match(blockedResult.reason ?? "", /blocked by security rule/i);
+
+    const blockedSystemctl = await pipeline.executeItemStart(baseCtx, {
+      type: "command_execution",
+      command: "systemctl --user stop ads-web",
+    });
+    assert.equal(blockedSystemctl.blockExecution, true);
+  });
+
+  it("spills oversized outputs to disk artifacts via contextArtifactMiddleware in onItemEnd", async () => {
+    const tmpArtifactDir = fs.mkdtempSync(path.join(os.tmpdir(), "ads-artifact-test-"));
+    try {
+      const artifactMw = createContextArtifactMiddleware({
+        maxOutputBytes: 100,
+        artifactsDir: tmpArtifactDir,
+      });
+      const pipeline = createMiddlewarePipeline([artifactMw]);
+
+      const smallOutput = "short output";
+      const smallResult = await pipeline.executeItemEnd(baseCtx, {
+        type: "command_execution",
+        command: "echo test",
+        aggregated_output: smallOutput,
+      });
+      assert.equal(smallResult.modifiedOutput, undefined);
+
+      const largeOutput = "A".repeat(500);
+      const largeResult = await pipeline.executeItemEnd(baseCtx, {
+        type: "command_execution",
+        command: "cat large.txt",
+        aggregated_output: largeOutput,
+      });
+      assert.ok(largeResult.modifiedOutput);
+      assert.match(largeResult.modifiedOutput, /Output truncated: 500 characters/);
+      assert.match(largeResult.modifiedOutput, /saved to artifact:/);
+
+      const files = fs.readdirSync(tmpArtifactDir);
+      assert.equal(files.length, 1);
+      const savedContent = fs.readFileSync(path.join(tmpArtifactDir, files[0]!), "utf8");
+      assert.equal(savedContent, largeOutput);
+    } finally {
+      fs.rmSync(tmpArtifactDir, { recursive: true, force: true });
+    }
+  });
+
+  it("integrates semantic recall and async ingest with cfMemMiddleware", async () => {
+    let ingestedReply = "";
+    const memMw = createCfMemMiddleware({
+      fetchSemanticContext: async () => "User prefers TypeScript and dark theme.",
+      ingestConversationTurn: async (_ctx, reply) => {
+        ingestedReply = reply;
+      },
+    });
+    const pipeline = createMiddlewarePipeline([memMw]);
+
+    const enrichedPrompt = await pipeline.executeBeforeInput(baseCtx);
+    assert.match(enrichedPrompt, /<recalled_memory>/);
+    assert.match(enrichedPrompt, /User prefers TypeScript and dark theme./);
+
+    await pipeline.executeAfterOutput(baseCtx, "I have updated the settings.");
+    assert.equal(ingestedReply, "I have updated the settings.");
+  });
+
+  it("handles errors gracefully without crashing pipeline", async () => {
+    let caughtError: Error | null = null;
+    const errorMw: AdsMiddleware = {
+      name: "errorMw",
+      onTurnError: (_ctx, err) => {
+        caughtError = err;
+      },
+    };
+    const failingMw: AdsMiddleware = {
+      name: "failingMw",
+      onBeforeInput: () => {
+        throw new Error("Unexpected middleware failure");
+      },
+    };
+
+    const pipeline = createMiddlewarePipeline([failingMw, errorMw]);
+    const prompt = await pipeline.executeBeforeInput(baseCtx);
+    assert.equal(prompt, "original prompt");
+
+    const testError = new Error("Agent turn crashed");
+    await pipeline.executeTurnError(baseCtx, testError);
+    assert.equal(caughtError, testError);
+  });
+});

--- a/tests/middleware/pipeline.test.ts
+++ b/tests/middleware/pipeline.test.ts
@@ -13,6 +13,7 @@ import {
   type TurnContext,
   type AdsMiddleware,
 } from "../../server/middleware/index.js";
+import { runAgentTurn } from "../../server/agents/turn.js";
 
 describe("MiddlewarePipeline & Core Middlewares", () => {
   const baseCtx: TurnContext = {
@@ -135,6 +136,7 @@ describe("MiddlewarePipeline & Core Middlewares", () => {
     assert.match(enrichedPrompt, /User prefers TypeScript and dark theme./);
 
     await pipeline.executeAfterOutput(baseCtx, "I have updated the settings.");
+    await new Promise<void>((resolve) => setImmediate(resolve));
     assert.equal(ingestedReply, "I have updated the settings.");
   });
 
@@ -160,5 +162,62 @@ describe("MiddlewarePipeline & Core Middlewares", () => {
     const testError = new Error("Agent turn crashed");
     await pipeline.executeTurnError(baseCtx, testError);
     assert.equal(caughtError, testError);
+  });
+
+  it("wraps a real agent turn with before, start, and after hooks", async () => {
+    const calls: string[] = [];
+    const pipeline = createMiddlewarePipeline([{
+      name: "lifecycle-test",
+      onBeforeInput: (ctx) => {
+        calls.push(`before:${ctx.prompt}`);
+        return { modifiedPrompt: `${ctx.prompt} [prepared]` };
+      },
+      onTurnStart: (ctx) => calls.push(`start:${ctx.prompt}`),
+      onAfterOutput: (_ctx, reply) => calls.push(`after:${reply}`),
+      onTurnError: (_ctx, error) => calls.push(`error:${error.message}`),
+    }]);
+    const orchestrator = {
+      getActiveAgentId: () => "codex",
+      onEvent: () => () => {},
+      invokeAgent: async (_agentId: string, input: unknown) => ({
+        response: `reply for ${String(input)}`,
+        usage: null,
+        agentId: "codex",
+      }),
+    } as any;
+
+    const result = await runAgentTurn(orchestrator, "original", {
+      middleware: pipeline,
+      middlewareContext: {
+        turnId: "turn-1",
+        sessionId: "session-1",
+        channel: "web",
+      },
+      workspaceRoot: os.tmpdir(),
+    });
+
+    assert.equal(result.response, "reply for original [prepared]");
+    assert.deepEqual(calls, [
+      "before:original",
+      "start:original [prepared]",
+      "after:reply for original [prepared]",
+    ]);
+  });
+
+  it("fails closed when an item-start middleware throws", async () => {
+    const pipeline = createMiddlewarePipeline([{
+      name: "broken-guard",
+      onItemStart: () => {
+        throw new Error("guard unavailable");
+      },
+    }]);
+
+    const result = await pipeline.executeItemStart(baseCtx, {
+      type: "command_execution",
+      command: "echo safe",
+    });
+
+    assert.equal(result.blockExecution, true);
+    assert.match(result.reason ?? "", /failed closed/);
   });
 });


### PR DESCRIPTION
## Summary
Introduces a unified, pluggable Turn and Item middleware lifecycle pipeline (`AdsMiddleware` and `MiddlewarePipeline`) to standardize cross-cutting concerns (such as semantic memory recall/ingestion, command safety guards, context artifact truncation, and step trace logging) across Web, Telegram, and Task Queue channels.

Closes #72

## Changes
- **Core Interfaces**: Defined `TurnContext`, `AdsMiddleware`, and lifecycle hook contracts (`onBeforeInput`, `onTurnStart`, `onItemStart`, `onItemEnd`, `onAfterOutput`, `onTurnError`) in `server/middleware/types.ts`.
- **Pipeline Runner**: Implemented `MiddlewarePipeline` in `server/middleware/pipeline.ts` with error isolation and ordered execution.
- **Built-in Middlewares**:
  - `globalRulesMiddleware`: Intercepts dangerous/destructive commands on `onItemStart`.
  - `contextArtifactMiddleware`: Spills oversized tool outputs to 0600 disk artifacts on `onItemEnd` to protect context windows.
  - `cfMemMiddleware`: Plugs semantic memory recall (`onBeforeInput`) and async turn ingestion (`onAfterOutput`).
- **Unit Tests**: Added `tests/middleware/pipeline.test.ts` verifying lifecycle execution order, prompt transformations, command blocking, artifact spilling, and error handling.

## Verification
- `npx tsx --test tests/middleware/pipeline.test.ts` passed (6/6 tests).
- `npm run lint` passed.
- `npm run build` passed.
