### PR TITLE
feat(ui): show per-lane WebSocket status

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -274,16 +274,6 @@
   background: rgba(15, 23, 42, 0.06);
   color: #0f172a;
 }
-.dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 999px;
-  background: #ef4444;
-}
-.dot.on {
-  background: #10b981;
-  box-shadow: 0 0 8px rgba(16, 185, 129, 0.5);
-}
 .layout {
   --sidebar-width: clamp(280px, 24vw, 360px);
   flex: 1;
@@ -634,6 +624,14 @@
   border-radius: 12px;
   cursor: pointer;
   transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.laneTab--connected {
+  color: #059669;
+}
+
+.laneTab--disconnected {
+  color: #94a3b8;
 }
 
 .laneTab:hover {

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -33,6 +33,7 @@ import {
   Setting,
   Clock,
 } from "@element-plus/icons-vue";
+import { isLaneConnected } from "./lib/laneConnectionStatus";
 const {
   isExecuteBlockFixture,
   loggedIn,
@@ -630,7 +631,6 @@ const plannerConnectionStatus = computed(() => {
         >
           <el-icon :size="18" aria-hidden="true"><MoreFilled /></el-icon>
         </button>
-        <span class="dot" :class="{ on: connected }" :title="connected ? 'WS connected' : 'WS disconnected'" />
       </div>
       <div
         v-if="isMobile && mobileContextMenuOpen"
@@ -879,7 +879,11 @@ const plannerConnectionStatus = computed(() => {
             :key="tab.id"
             type="button"
             class="laneTab"
-            :class="{ active: activeWorkspaceTab === tab.id }"
+            :class="{
+              active: activeWorkspaceTab === tab.id,
+              'laneTab--connected': isLaneConnected(tab.id, { planner: plannerConnected, worker: connected }),
+              'laneTab--disconnected': tab.id !== 'tasks' && !isLaneConnected(tab.id, { planner: plannerConnected, worker: connected }),
+            }"
             role="tab"
             :aria-selected="activeWorkspaceTab === tab.id"
             :aria-controls="`lane-panel-${tab.id}`"

--- a/client/src/__tests__/lane-connection-status.test.ts
+++ b/client/src/__tests__/lane-connection-status.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { isLaneConnected } from "../lib/laneConnectionStatus";
+
+describe("lane connection status", () => {
+  it("maps the Advisor and Worker tabs to their independent runtime states", () => {
+    const states = { planner: true, worker: false };
+
+    expect(isLaneConnected("planner", states)).toBe(true);
+    expect(isLaneConnected("worker", states)).toBe(false);
+  });
+
+  it("does not mark the Task tab as connected", () => {
+    expect(isLaneConnected("tasks", { planner: true, worker: true })).toBe(false);
+  });
+});

--- a/client/src/__tests__/mobile-pane-tabs.test.ts
+++ b/client/src/__tests__/mobile-pane-tabs.test.ts
@@ -19,7 +19,7 @@ describe("mobile navigation shell", () => {
     expect(sfc).toMatch(/v-show="activeWorkspaceTab === 'worker'"/);
     expect(sfc).toMatch(/v-show="activeWorkspaceTab === 'tasks'"/);
     expect(sfc).not.toMatch(/v-show="activeWorkspaceTab === 'reviewer'"/);
-    expect(sfc).toMatch(/:class="\{ active: activeWorkspaceTab === tab.id \}"/);
+    expect(sfc).toMatch(/:class="\{[\s\S]*active:\s*activeWorkspaceTab === tab.id/);
     expect(sfc).toMatch(/:aria-selected="activeWorkspaceTab === tab.id"/);
   });
 

--- a/client/src/lib/laneConnectionStatus.ts
+++ b/client/src/lib/laneConnectionStatus.ts
@@ -1,0 +1,12 @@
+import type { ChatLane } from "../composables/app/useLaneRuntimeBridge";
+
+export type WorkspaceTab = "tasks" | ChatLane;
+
+export function isLaneConnected(
+  tab: WorkspaceTab,
+  states: { planner: boolean; worker: boolean },
+): boolean {
+  if (tab === "planner") return states.planner;
+  if (tab === "worker") return states.worker;
+  return false;
+}


### PR DESCRIPTION
## Summary
- show independent Advisor and Worker WebSocket state on their workspace tabs
- remove the redundant global connection indicator
- add focused mapping tests and update the mobile tab assertion

## Validation
- `npm run lint`
- `npm run test:web`
- `npm run build`
- `git diff --check`

The full server test suite was run; 983/988 passed. The five existing `httpServerPathTraversal` failures consistently returned 503 instead of their expected 400/404 responses and are unrelated to this frontend change.

Closes #81
Closes #82