### PR TITLE
refactor(tasks): support GitHub-native task drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ ADS 是一个面向 AI 编程工作流的本地 Web Console 与智能任务编�
 - **现代 Web Console**：基于 Vue 3 + Vite 构建的响应式控制台，支持移动端抽屉导航与桌面端全功能布局。
 - **三 Tab 协作工作流**：
   - **Task (任务看板)**：可视化任务排队、执行、重试、错误追踪及 Task Bundle 任务草稿审批。
-  - **Advisor (规划 Lane)**：专属架构方案研讨；结论沉淀到 `docs/issue/<key>/`，并生成对应的 `docs/spec/<key>/`。
-  - **Worker (执行 Lane)**：读取批准时固定的 issue/spec 快照，专注代码执行与命令运行，实时输出紧凑预览。
+  - **Advisor (规划 Lane)**：专属架构方案研讨；任务草稿可直接引用 GitHub Issue/PR 或使用自包含 prompt，不要求本地 issue/spec 文档。
+  - **Worker (执行 Lane)**：有本地快照时读取批准时固定的 issue/spec 内容，否则直接依据任务 prompt 与 GitHub 引用执行，实时输出紧凑预览。
 - **多 Provider CLI 支持**：原生适配 **OpenAI Codex**、**Anthropic Claude Code** 与 **Factory Droid CLI**，支持模型可视化启用/停用与即时配置。
 - **全局规则引擎 (Global Rules)**：跨项目、跨终端（Web / Telegram）统一注入 system prompt 规范，支持在线测试与修改即时生效。
 - **原生会话恢复 (Session Resume)**：零 Token 冗余恢复底层 CLI 真实历史上下文，断线重连自动增量同步。

--- a/docs/web.md
+++ b/docs/web.md
@@ -16,12 +16,12 @@ Web Console 将对话与任务流组织为三大工作区：
   - 集成 **Task Bundle Drafts（任务草稿箱）**：查看 Advisor 生成的结构化任务束，支持在线编辑子任务与一键审批入队。
 - **Advisor (规划 Lane)**：
   - 默认对话 Lane，用于方案讨论、代码架构设计与任务拆解。
-  - 讨论完成后将一个稳定 work-item key 的结论写入 `docs/issue/<key>/`，再在 `docs/spec/<key>/` 生成 Worker 规格。
-  - Task Bundle 必须同时携带匹配的 `issueRef` / `specRef` 目录，并且一个 spec 只生成一个 task；服务端会在批准时拒绝单文件引用、缺目录或 key 不匹配的 bundle。
+  - Task Bundle 可直接引用 GitHub Issue/PR URL，或只携带自包含的任务 prompt；不要求先创建本地 `docs/issue/` 与 `docs/spec/` 目录。
+  - 显式使用本地 `/draft` 快照时，仍可携带匹配的 `issueRef` / `specRef` 目录并在批准时固定内容；本地快照是兼容能力，不是 GitHub-native 流程的前置条件。
   - 支持输出 `ads-schedule` 定时指令或生成 Task Bundle 任务草稿。
 - **Worker (执行 Lane)**：
   - 专注于代码执行、命令运行与文件修改的执行 Lane。
-  - 执行任务时先读取批准时固定的 issue/spec 快照；spec 是执行真源，issue 只提供讨论背景。
+  - 若任务带有本地 issue/spec 快照，执行时先读取批准时固定的内容；没有快照时直接以任务 prompt 及其 GitHub 引用作为执行依据。
   - 实时展示任务阶段 trace（如 `[analysis]`、`[tool]`、`[editing]`）与命令执行输出（最新命令预览），自动收起长文本输出。
   - Plan 卡片按单轮逻辑计划合并 provider 更新，并在任务完成与历史重连时保持唯一且状态一致。
 

--- a/server/skills/builtin/planner-slash-draft/SKILL.md
+++ b/server/skills/builtin/planner-slash-draft/SKILL.md
@@ -1,35 +1,49 @@
 ---
 name: planner-slash-draft
-description: Delivery protocol for the Advisor `/draft` command. Use when turning a design discussion into one paired issue/spec work-item directory plus exactly one ads-tasks bundle for the Worker.
+description: Delivery protocol for the Advisor `/draft` command. Use when turning a design discussion into exactly one ads-tasks bundle for the Worker, backed by a GitHub reference, a self-contained prompt, or an optional local snapshot.
 ---
 
 # Planner `/draft` Delivery Protocol
 
 You are the **Advisor**. `/draft` is the moment a discussion becomes a delivery.
-The discussion may have branched, reversed, or explored dead ends. The work item
-you emit must reflect only the **final agreed state**, and that state must live
-in files — not only in the conversation.
+The discussion may have branched, reversed, or explored dead ends. The bundle
+you emit must reflect only the **final agreed state**. The source of that state
+may be a GitHub Issue or PR, a self-contained task prompt, or an optional local
+snapshot when the repository workflow benefits from one.
 
 ## Non-negotiable rules
 
-1. **Write the issue and spec first, then the bundle.** Never emit a bundle for
-   directories that do not exist on disk.
-2. **Exactly one** ` ```ads-tasks ` fenced block per `/draft`, containing
+1. **Exactly one** ` ```ads-tasks ` fenced block per `/draft`, containing
    **exactly one** task. More than one block, or more than one task, is rejected
    by the server and the draft is discarded.
-3. **`issueRef` and `specRef` are mandatory paired directory references.** Both
-   must be workspace-relative direct children of their roots:
+2. `issueRef` and `specRef` are optional. Use GitHub Issue or PR URLs when the
+   repository workflow is GitHub-native, or omit both when the task `prompt` is
+   self-contained.
+3. When using local snapshots, `issueRef` and `specRef` must be paired
+   workspace-relative direct children of their roots:
    `docs/issue/<work-item-key>/` and `docs/spec/<work-item-key>/`. The keys must
    be identical. File references such as `docs/spec/foo.md`, absolute paths,
    `..`, and mismatched keys are rejected by the server.
-4. **Never restate issue or spec content inside `prompt`.** The directories hold
-   the detail. Duplicating it in the prompt guarantees that the handoff can
+4. For GitHub-native or prompt-only bundles, put the complete implementation
+   intent and acceptance criteria in `prompt`; do not assume the Worker can
+   infer missing details from the conversation.
+5. For local snapshots, do not restate issue or spec content inside `prompt`.
+   The directories hold the detail, and duplicating it can make the handoff
    diverge.
 
-## Step 1 — write or update the paired work item
+## Step 1 — choose the delivery anchor
 
-Choose one kebab-case `<work-item-key>` that is stable across revisions of the
-same feature. Use exactly the same key in both directory names:
+Prefer a canonical GitHub Issue or PR URL when the work is already tracked
+there. If no remote reference exists, write a self-contained prompt with the
+goal, acceptance criteria, constraints, and verification commands. Local paired
+directories remain supported when immutable repository-local snapshots are
+useful, but they are not required.
+
+### Optional local snapshot
+
+If using local snapshots, choose one kebab-case `<work-item-key>` that is stable
+across revisions of the same feature. Use exactly the same key in both directory
+names:
 
 - Issue record: `docs/issue/<work-item-key>/README.md`
 - Delivery spec: `docs/spec/<work-item-key>/requirements.md`
@@ -39,9 +53,9 @@ not create a second key for a revision. The issue record captures the final
 Advisor discussion, while the spec turns that decision into an executable
 Worker contract.
 
-You have write access to `docs/issue/` and `docs/spec/` only. Use your normal
-file tools. Read anything in the project to inform the work item; write nothing
-outside those two roots.
+When `/draft` needs to create or update local snapshots, write only to
+`docs/issue/` and `docs/spec/`. Use your normal file tools. Read anything in the
+project to inform the work item; write nothing outside those two roots.
 
 Recommended issue structure:
 
@@ -107,21 +121,20 @@ in a repo built on a different toolchain.
 ```ads-tasks
 {
   "version": 1,
-  "issueRef": "docs/issue/<work-item-key>",
-  "specRef": "docs/spec/<work-item-key>",
+  "issueRef": "https://github.com/<owner>/<repo>/issues/<number>",
   "tasks": [
     {
       "title": "<short imperative title>",
-      "prompt": "Implement the delivery spec in full. Read the paired issue and spec directories first, then complete every acceptance criterion. Report verification commands and results."
+      "prompt": "Implement the GitHub task in full. Complete every acceptance criterion, run the relevant repository verification commands, and report their results."
     }
   ]
 }
 ```
 
-The prompt stays this short on purpose: the issue/spec directories hold the
-detail, and repeating it here only creates a second copy that can drift. The
-server adds immutable snapshots of both directories when the user approves the
-draft.
+For prompt-only bundles, omit `issueRef` and `specRef`, and make `prompt`
+self-contained. For local snapshots, use the paired directory references and
+keep the prompt short; the server adds immutable snapshots of both directories
+when the user approves the draft.
 
 ### How many tasks
 
@@ -138,10 +151,12 @@ stages of one feature are not that case.
 
 ## How the snapshot works
 
-At approval time the server runs `git hash-object -w` on every regular file in
-both referenced directories and pins the task to those blob SHAs. The Worker
-reads those exact contents, so later edits to the issue or spec never silently
-change work that was already approved.
+At approval time, when local paired directories are referenced, the server runs
+`git hash-object -w` on every regular file in both directories and pins the task
+to those blob SHAs. The Worker reads those exact contents, so later edits to the
+issue or spec never silently change work that was already approved. GitHub
+references and prompt-only tasks are passed through as task content without a
+local snapshot.
 
 This writes into the git object database **without creating a commit** — the
 directories do not need to be committed, staged, or otherwise touched up before
@@ -150,11 +165,10 @@ whenever it suits the project's own workflow.
 
 ## Checklist before you emit
 
-- [ ] Paired issue and spec directories written or updated, using one stable key
-- [ ] Issue contains `README.md`; spec contains `requirements.md`
-- [ ] Issue record reflects the **final** state of Advisor discussion
-- [ ] Rejected alternatives recorded under Decisions, not silently dropped
-- [ ] Spec has concrete acceptance criteria and verification commands
+- [ ] GitHub reference is canonical, or the task prompt is self-contained
+- [ ] If local snapshots are used, paired directories use one stable key
+- [ ] If local snapshots are used, issue contains `README.md` and spec contains `requirements.md`
+- [ ] Acceptance criteria and verification commands are concrete
 - [ ] One `ads-tasks` block, normally one task covering the whole spec
-- [ ] `issueRef` and `specRef` use the same key and point at directories
-- [ ] `prompt` points at the paired directories — it does not restate their contents
+- [ ] Local `issueRef` and `specRef`, when present, use the same key and point at directories
+- [ ] A local-snapshot prompt points at the paired directories without restating their contents

--- a/server/web/server/api/routes/taskBundleDrafts.ts
+++ b/server/web/server/api/routes/taskBundleDrafts.ts
@@ -145,8 +145,8 @@ export async function handleTaskBundleDraftRoutes(ctx: ApiRouteContext, deps: Ap
       draftId,
       bundle: {
         ...normalizedBundle,
-        issueRef: workItemValidation.refs.issueRef,
-        specRef: workItemValidation.refs.specRef,
+        issueRef: workItemValidation.refs.issueRef || undefined,
+        specRef: workItemValidation.refs.specRef || undefined,
       },
     });
     if (!updated) {

--- a/server/web/server/planner/plannerPromptHandler.ts
+++ b/server/web/server/planner/plannerPromptHandler.ts
@@ -156,8 +156,8 @@ function createPlannerDraftPassProcessor(args: {
         }
         normalized = {
           ...normalized,
-          issueRef: workItemValidation.refs.issueRef,
-          specRef: workItemValidation.refs.specRef,
+          issueRef: workItemValidation.refs.issueRef || undefined,
+          specRef: workItemValidation.refs.specRef || undefined,
         };
 
         const requestId = String(normalized.requestId ?? "").trim();

--- a/server/web/server/planner/taskBundleApprover.ts
+++ b/server/web/server/planner/taskBundleApprover.ts
@@ -181,9 +181,6 @@ export function materializeTaskBundleTasks(args: {
     issueRef: workItemValidation.refs.issueRef,
     specRef: workItemValidation.refs.specRef,
   });
-  if (!workItemPin) {
-    throw new Error("Failed to resolve the issue/spec directories for this work item");
-  }
 
   for (let i = 0; i < args.tasks.length; i++) {
     const specTask = args.tasks[i]!;

--- a/server/web/server/planner/workItem.ts
+++ b/server/web/server/planner/workItem.ts
@@ -90,6 +90,17 @@ function normalizeDirectoryRef(rawValue: unknown, root: string): string | null {
   return normalized;
 }
 
+function isGitHubReference(rawValue: unknown): boolean {
+  const raw = String(rawValue ?? "").trim();
+  if (!raw) return false;
+  try {
+    const url = new URL(raw);
+    return url.protocol === "https:" && (url.hostname === "github.com" || url.hostname.endsWith(".github.com"));
+  } catch {
+    return false;
+  }
+}
+
 /** Normalizes an issue directory reference under docs/issue/<work-item-key>. */
 export function normalizeIssueRef(issueRef: unknown): string | null {
   return normalizeDirectoryRef(issueRef, ISSUE_ROOT);
@@ -177,19 +188,21 @@ export function validateWorkItemRefs(args: {
   issueRef: unknown;
   specRef: unknown;
 }): WorkItemRefValidation {
-  const issueRef = normalizeIssueRef(args.issueRef);
-  if (!issueRef) {
-    return {
-      ok: false,
-      error: `issueRef must be a relative directory under ${ISSUE_ROOT}/<work-item-key>/`,
-    };
+  const rawIssueRef = String(args.issueRef ?? "").trim();
+  const rawSpecRef = String(args.specRef ?? "").trim();
+  if (!rawIssueRef && !rawSpecRef) {
+    return { ok: true, refs: { issueRef: "", specRef: "", workItemKey: "" } };
   }
 
-  const specRef = normalizeSpecRef(args.specRef);
-  if (!specRef) {
+  const issueRef = normalizeIssueRef(rawIssueRef);
+  const specRef = normalizeSpecRef(rawSpecRef);
+  if (!issueRef || !specRef) {
+    if ((!rawIssueRef || isGitHubReference(rawIssueRef)) && (!rawSpecRef || isGitHubReference(rawSpecRef))) {
+      return { ok: true, refs: { issueRef: rawIssueRef, specRef: rawSpecRef, workItemKey: "" } };
+    }
     return {
       ok: false,
-      error: `specRef must be a relative directory under ${SPEC_ROOT}/<work-item-key>/`,
+      error: `issueRef/specRef must be paired local directories or GitHub URLs`,
     };
   }
 
@@ -286,7 +299,7 @@ export function resolveWorkItemPin(args: {
 
   const { issueRef, specRef, workItemKey } = validation.refs;
   const workspaceRoot = String(args.workspaceRoot ?? "").trim();
-  if (!workspaceRoot) return null;
+  if (!workspaceRoot || !issueRef || !specRef || !workItemKey) return null;
 
   let issueFiles: string[];
   let specFiles: string[];

--- a/tests/web/plannerSlashDraftCommand.test.ts
+++ b/tests/web/plannerSlashDraftCommand.test.ts
@@ -231,7 +231,7 @@ describe("web/ws/planner-slash-draft-command", () => {
     assert.equal(drafts[0]!.bundle!.autoApprove, undefined);
   });
 
-  it("rejects a draft without the paired issue/spec directories", async () => {
+  it("accepts a draft without local issue/spec directories", async () => {
     const chatMessages: unknown[] = [];
     const clientMessages: unknown[] = [];
     const historyStore = new MemoryHistoryStore();
@@ -260,13 +260,15 @@ describe("web/ws/planner-slash-draft-command", () => {
     assert.equal(orchestrator.invokeCount, 1);
 
     const drafts = listTaskBundleDrafts({ authUserId: "test-user", workspaceRoot, limit: 10 });
-    assert.equal(drafts.length, 0);
+    assert.equal(drafts.length, 1);
+    assert.equal(drafts[0]!.bundle!.issueRef, undefined);
+    assert.equal(drafts[0]!.bundle!.specRef, undefined);
     const result = chatMessages.find((message) => message && typeof message === "object" && (message as { type?: unknown }).type === "result");
     assert.ok(result);
-    assert.match(String((result as { output?: unknown }).output ?? ""), /issueRef must be/);
+    assert.match(String((result as { output?: unknown }).output ?? ""), /任务草稿已写入/);
   });
 
-  it("rejects task bundles emitted from the worker lane without a paired work item", async () => {
+  it("accepts worker task bundles without a local work item", async () => {
     const chatMessages: unknown[] = [];
     const clientMessages: unknown[] = [];
     const historyStore = new MemoryHistoryStore();
@@ -294,10 +296,12 @@ describe("web/ws/planner-slash-draft-command", () => {
 
     assert.equal(orchestrator.invokeCount, 1);
     const drafts = listTaskBundleDrafts({ authUserId: "test-user", workspaceRoot, limit: 10 });
-    assert.equal(drafts.length, 0);
+    assert.equal(drafts.length, 1);
+    assert.equal(drafts[0]!.bundle!.issueRef, undefined);
+    assert.equal(drafts[0]!.bundle!.specRef, undefined);
     const result = chatMessages.find((message) => message && typeof message === "object" && (message as { type?: unknown }).type === "result");
     assert.ok(result);
-    assert.match(String((result as { output?: unknown }).output ?? ""), /issueRef must be/);
+    assert.match(String((result as { output?: unknown }).output ?? ""), /Worker draft/);
   });
 
   it("rejects /draft output when tasks.length is not 1", async () => {

--- a/tests/web/specPin.test.ts
+++ b/tests/web/specPin.test.ts
@@ -43,6 +43,20 @@ function initRepoWithWorkItem(issueContent: string, requirementsContent: string)
 }
 
 describe("planner/workItem references", () => {
+  it("accepts GitHub references and prompt-only bundles without local directories", () => {
+    const remote = validateWorkItemRefs({
+      issueRef: "https://github.com/Andy963/ads/issues/85",
+    });
+    assert.equal(remote.ok, true);
+    if (remote.ok) {
+      assert.equal(remote.refs.issueRef, "https://github.com/Andy963/ads/issues/85");
+      assert.equal(remote.refs.workItemKey, "");
+    }
+
+    const promptOnly = validateWorkItemRefs({ issueRef: undefined, specRef: undefined });
+    assert.deepEqual(promptOnly, { ok: true, refs: { issueRef: "", specRef: "", workItemKey: "" } });
+  });
+
   it("accepts matching direct-child directories and rejects file references", () => {
     assert.equal(normalizeIssueRef("docs/issue/feature"), "docs/issue/feature");
     assert.equal(normalizeSpecRef("./docs/spec/feature/"), "docs/spec/feature");

--- a/tests/web/taskBundleApprover.test.ts
+++ b/tests/web/taskBundleApprover.test.ts
@@ -46,6 +46,50 @@ afterEach(() => {
 });
 
 describe("planner/taskBundleApprover", () => {
+  it("materializes prompt-only tasks without a local work-item snapshot", () => {
+    const created: Array<{ prompt: string }> = [];
+
+    const result = materializeTaskBundleTasks({
+      draftId: "draft-remote",
+      tasks: [{ title: "Implement GitHub issue", prompt: "Implement https://github.com/Andy963/ads/issues/85" }],
+      now: 123,
+      taskStore: {
+        createTask(input, now, options) {
+          const task = {
+            id: input.id ?? "task-remote",
+            title: input.title ?? "",
+            prompt: input.prompt,
+            model: input.model ?? "auto",
+            status: options.status,
+            priority: input.priority ?? 0,
+            queueOrder: 0,
+            inheritContext: input.inheritContext ?? false,
+            retryCount: 0,
+            maxRetries: input.maxRetries ?? 0,
+            createdAt: now,
+          };
+          created.push({ prompt: task.prompt });
+          return task;
+        },
+        getTask() {
+          return null;
+        },
+        deleteTask() {},
+      },
+      attachmentStore: {
+        assignAttachmentsToTask() {},
+        listAttachmentsForTask() {
+          return [];
+        },
+      },
+      metrics: createMetrics(),
+      metricReason: "planner_draft",
+    });
+
+    assert.equal(result.createdTaskIds.length, 1);
+    assert.deepEqual(created, [{ prompt: "Implement https://github.com/Andy963/ads/issues/85" }]);
+  });
+
   it("materializes attachments into task payloads and metrics", () => {
     const tasksById = new Map<string, any>();
     const attachmentsByTaskId = new Map<string, string[]>();


### PR DESCRIPTION
## Summary
- allow task bundles with GitHub Issue/PR URLs or self-contained prompts
- keep local paired issue/spec snapshots as an optional compatibility path
- preserve prompts without synthesizing a local work-item pin
- add regression coverage for prompt-only and remote-reference drafts
- document the GitHub-native task draft boundary

## Validation
- `npm test` (990/990)
- `npm run lint`
- `npm run build`
- targeted planner and task bundle tests (28/28)
- `git diff --check`

Closes #85