### PR TITLE
fix(step-trace): simplify file change labels

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -24,7 +24,7 @@ Web Console 将对话与任务流组织为三大工作区：
 - **Worker (执行 Lane)**：
   - 专注于代码执行、命令运行与文件修改的执行 Lane。
   - 若任务带有本地 issue/spec 快照，执行时先读取批准时固定的内容；没有快照时直接以任务 prompt 及其 GitHub 引用作为执行依据。
-  - 实时展示任务阶段 trace（如 `[analysis]`、`[tool]`、`[editing]`）与命令执行输出（最新命令预览），自动收起长文本输出。
+  - 实时展示任务阶段 trace（如 `[analysis]`、`[tool]`、`[editing]`）与命令执行输出（最新命令预览），阶段 trace 只显示简洁语义标签；文件路径和变更明细由 Patch 卡片展示，自动收起长文本输出。
   - Plan 卡片按单轮逻辑计划合并 provider 更新，并在任务完成与历史重连时保持唯一且状态一致。
 
 ### 2. Provider CLI 与全局模型配置 (Provider & Models)

--- a/server/codex/events.ts
+++ b/server/codex/events.ts
@@ -278,19 +278,13 @@ function mapCommandExecution(event: ItemEvent, item: CommandExecutionItem, times
   };
 }
 
-function mapFileChange(event: ItemEvent, item: FileChangeItem, timestamp: number): AgentEvent | null {
+function mapFileChange(event: ItemEvent, _item: FileChangeItem, timestamp: number): AgentEvent | null {
   if (event.type === "item.updated") {
     return null;
   }
-  const changes = item.changes
-    .slice(0, 3)
-    .map((change) => `${change.kind}:${change.path}`)
-    .join(", ");
-  const detail = item.changes.length > 3 ? `${changes} 等` : changes;
   return {
     phase: "editing",
-    title: event.type === "item.completed" ? "应用文件修改" : "准备文件修改",
-    detail: detail || undefined,
+    title: event.type === "item.completed" ? "应用文件修改完成" : "准备文件修改",
     timestamp,
     raw: event,
   };

--- a/tests/agents/claudeStreamParser.test.ts
+++ b/tests/agents/claudeStreamParser.test.ts
@@ -68,7 +68,7 @@ describe("ClaudeStreamParser", () => {
     });
     assert.equal(completed.length, 1);
     assert.equal(completed[0]?.phase, "editing");
-    assert.equal(completed[0]?.title, "应用文件修改");
+    assert.equal(completed[0]?.title, "应用文件修改完成");
   });
 
   it("maps result error into error event and exposes lastError", () => {

--- a/tests/codex/events.test.ts
+++ b/tests/codex/events.test.ts
@@ -47,6 +47,43 @@ describe("mapThreadEventToAgentEvent", () => {
     assert.equal(mapped.detail, undefined);
   });
 
+  it("maps file changes to concise editing stages without file paths", () => {
+    const started = mapThreadEventToAgentEvent(
+      {
+        type: "item.started",
+        item: {
+          type: "file_change",
+          id: "file-1",
+          changes: [
+            { kind: "update", path: "src/one.ts" },
+            { kind: "update", path: "src/two.ts" },
+          ],
+        },
+      },
+      0,
+    );
+    assert(started);
+    assert.equal(started.phase, "editing");
+    assert.equal(started.title, "准备文件修改");
+    assert.equal(started.detail, undefined);
+
+    const completed = mapThreadEventToAgentEvent(
+      {
+        type: "item.completed",
+        item: {
+          type: "file_change",
+          id: "file-1",
+          changes: [{ kind: "update", path: "src/one.ts" }],
+        },
+      },
+      0,
+    );
+    assert(completed);
+    assert.equal(completed.phase, "editing");
+    assert.equal(completed.title, "应用文件修改完成");
+    assert.equal(completed.detail, undefined);
+  });
+
   it("maps reconnect errors to connection phase", () => {
     const event = {
       type: "error" as const,


### PR DESCRIPTION
## Summary
- keep file-change live traces focused on concise editing stage labels
- remove raw file path enumerations from intermediate step text
- preserve detailed file changes in patch cards
- update event, Claude parser, and Web documentation tests

## Validation
- `npm test` (979 passed)
- `npm run test:web` (101 files, 461 tests passed)
- `npm run lint`
- `npm run build`
- `git diff --check`

Closes #87
