### PR TITLE
fix(ui): preserve connected lane tab color

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -644,8 +644,7 @@
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
 }
 
-.laneTab.active.laneTab--connected,
-.laneTab--connected {
+.laneTab.active.laneTab--connected {
   color: #059669;
 }
 

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -644,6 +644,11 @@
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
 }
 
+.laneTab.active.laneTab--connected,
+.laneTab--connected {
+  color: #059669;
+}
+
 .laneTab:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.14);

--- a/client/src/__tests__/lane-connection-status.test.ts
+++ b/client/src/__tests__/lane-connection-status.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { isLaneConnected } from "../lib/laneConnectionStatus";
+
+function readAppCss(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return fs.readFileSync(path.resolve(here, "../App.css"), "utf8");
+}
 
 describe("lane connection status", () => {
   it("maps the Advisor and Worker tabs to their independent runtime states", () => {
@@ -12,5 +20,13 @@ describe("lane connection status", () => {
 
   it("does not mark the Task tab as connected", () => {
     expect(isLaneConnected("tasks", { planner: true, worker: true })).toBe(false);
+  });
+
+  it("keeps connected lane text green when the tab is active", () => {
+    const css = readAppCss();
+
+    expect(css).toMatch(
+      /\.laneTab\.active\.laneTab--connected,\s*\.laneTab--connected\s*\{[\s\S]*?color:\s*#059669\s*;/,
+    );
   });
 });

--- a/client/src/__tests__/lane-connection-status.test.ts
+++ b/client/src/__tests__/lane-connection-status.test.ts
@@ -26,7 +26,7 @@ describe("lane connection status", () => {
     const css = readAppCss();
 
     expect(css).toMatch(
-      /\.laneTab\.active\.laneTab--connected,\s*\.laneTab--connected\s*\{[\s\S]*?color:\s*#059669\s*;/,
+      /\.laneTab\.active\.laneTab--connected\s*\{[\s\S]*?color:\s*#059669\s*;/,
     );
   });
 });


### PR DESCRIPTION
## Summary
- preserve green text for connected lane tabs when active
- add a CSS regression test for the active connected selector

## Validation
- `npm run test:web` (101 files, 462 tests passed)
- `npm test` (978 tests passed)
- `npm run lint`
- `npm run build`
- `git diff --check`

Closes #91
