### PR TITLE
fix(history): stop persisting reasoning noise

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -24,7 +24,7 @@ Web Console 将对话与任务流组织为三大工作区：
 - **Worker (执行 Lane)**：
   - 专注于代码执行、命令运行与文件修改的执行 Lane。
   - 若任务带有本地 issue/spec 快照，执行时先读取批准时固定的内容；没有快照时直接以任务 prompt 及其 GitHub 引用作为执行依据。
-  - 实时展示任务阶段 trace（如 `[analysis]`、`[tool]`、`[editing]`）与命令执行输出（最新命令预览），阶段 trace 只显示简洁语义标签；文件路径和变更明细由 Patch 卡片展示，自动收起长文本输出。
+  - 实时展示任务阶段 trace（如 `[analysis]`、`[tool]`、`[editing]`）与命令执行输出（最新命令预览），阶段 trace 只显示简洁语义标签；重复的 reasoning 生命周期噪声不会写入历史 thought；文件路径和变更明细由 Patch 卡片展示，自动收起长文本输出。
   - Plan 卡片按单轮逻辑计划合并 provider 更新，并在任务完成与历史重连时保持唯一且状态一致。
 
 ### 2. Provider CLI 与全局模型配置 (Provider & Models)

--- a/server/codex/events.ts
+++ b/server/codex/events.ts
@@ -62,6 +62,9 @@ type ItemEvent = ItemStartedEvent | ItemUpdatedEvent | ItemCompletedEvent;
 
 const DEFAULT_DETAIL_LIMIT = 160;
 
+const NON_ACTIONABLE_ANALYSIS_TITLES = new Set(["开始处理请求"]);
+const STEP_TRACE_MARKER_REGEX = /\[(boot|analysis|context|editing|tool|connection)\]\s*/gi;
+
 export const STEP_TRACE_PHASES: ReadonlySet<string> = new Set([
   "boot",
   "analysis",
@@ -86,9 +89,23 @@ export function formatStepTraceLine(event: AgentEvent): string | null {
   if (!title) {
     return null;
   }
+  if (phase === "analysis" && (NON_ACTIONABLE_ANALYSIS_TITLES.has(title) || /^reasoning$/i.test(title))) {
+    return null;
+  }
   const prefix = `[${phase}] `;
   const detail = phase === "analysis" ? "" : String(event.detail ?? "").trim();
   return detail ? `${prefix}${title}: ${detail}\n` : `${prefix}${title}\n`;
+}
+
+/** Returns whether a trace contains a stage other than pure analysis/reasoning. */
+export function hasSubstantiveStepTrace(text: unknown): boolean {
+  const raw = String(text ?? "");
+  for (const match of raw.matchAll(STEP_TRACE_MARKER_REGEX)) {
+    if (String(match[1] ?? "").trim().toLowerCase() !== "analysis") {
+      return true;
+    }
+  }
+  return false;
 }
 
 const RECONNECTING_REGEX = /re-?connecting\.\.\.\s*(\d+)\/(\d+)/i;

--- a/server/web/server/ws/handlePrompt.ts
+++ b/server/web/server/ws/handlePrompt.ts
@@ -35,6 +35,7 @@ import { processPromptOutputBlocks } from "./promptOutputProcessing.js";
 import { handlePromptError } from "./promptErrorHandling.js";
 import { beginWsPromptRun, isWsPromptAbort, raceWsPromptAbort } from "./promptLifecycle.js";
 import { recordConversationMessage } from "../../../utils/conversationMessageRecorder.js";
+import { hasSubstantiveStepTrace } from "../../../codex/events.js";
 
 export { buildHistoryInjectionContext, prependContextToInput } from "./promptModelConfig.js";
 export { formatWriteExploredSummary } from "./workerPromptHandler.js";
@@ -373,7 +374,7 @@ export async function handlePromptMessage(deps: WsPromptHandlerDeps): Promise<{
         deps.observability.sessionLogger.logOutput(outputForChat);
       }
       const stepTraceText = getStepTraceText();
-      if (stepTraceText && stepTraceText.trim()) {
+      if (stepTraceText && stepTraceText.trim() && hasSubstantiveStepTrace(stepTraceText)) {
         deps.history.historyStore.add(deps.context.historyKey, {
           role: "assistant",
           kind: "thought",

--- a/tests/codex/events.test.ts
+++ b/tests/codex/events.test.ts
@@ -1,7 +1,11 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { mapThreadEventToAgentEvent } from "../../server/codex/events.js";
+import {
+  formatStepTraceLine,
+  hasSubstantiveStepTrace,
+  mapThreadEventToAgentEvent,
+} from "../../server/codex/events.js";
 
 describe("mapThreadEventToAgentEvent", () => {
   it("maps turn.started to analysis phase", () => {
@@ -10,6 +14,33 @@ describe("mapThreadEventToAgentEvent", () => {
     assert(mapped);
     assert.equal(mapped.phase, "analysis");
     assert.equal(mapped.title, "开始处理请求");
+  });
+
+  it("does not format generic reasoning lifecycle events as step traces", () => {
+    assert.equal(
+      formatStepTraceLine({
+        phase: "analysis",
+        title: "Reasoning",
+        timestamp: 0,
+        raw: { type: "item.completed", item: { type: "reasoning" } } as any,
+      }),
+      null,
+    );
+    assert.equal(
+      formatStepTraceLine({
+        phase: "analysis",
+        title: "开始处理请求",
+        timestamp: 0,
+        raw: { type: "turn.started" } as any,
+      }),
+      null,
+    );
+  });
+
+  it("recognizes only non-analysis stages as persistable trace content", () => {
+    assert.equal(hasSubstantiveStepTrace("[analysis] reasoning\n"), false);
+    assert.equal(hasSubstantiveStepTrace("[analysis] reasoning[tool] Running tool\n"), true);
+    assert.equal(hasSubstantiveStepTrace("[context] Loading context\n"), true);
   });
 
   it("maps command execution events to command phase", () => {


### PR DESCRIPTION
## Summary
- suppress generic reasoning lifecycle trace lines
- persist thought history only when a non-analysis stage is present
- cover trace filtering with backend tests and document the behavior

## Validation
- npm run lint
- ./node_modules/.bin/tsc -p tsconfig.build.json --noEmit
- targeted backend tests: 24 passed
- npm test: 964 passed, 6 unrelated pre-existing environment/timing failures (1 cliRunner idle-timeout test and 5 httpServerPathTraversal tests returning 503)

Closes #96