### PR TITLE
fix(tasks): allow prompt-only task drafts

### DIFF
--- a/client/src/__tests__/task-bundle-drafts-panel.test.ts
+++ b/client/src/__tests__/task-bundle-drafts-panel.test.ts
@@ -50,9 +50,7 @@ describe("TaskBundleDraftPanel", () => {
     expect((wrapper.get('[data-testid="task-bundle-draft-approve"]').element as HTMLButtonElement).disabled).toBe(false);
   });
 
-  it("warns when a draft is not bound to any spec", async () => {
-    // The prompt only points at a spec section, so an unbound draft is not
-    // reviewable — the gap has to be visible before approval, not after.
+  it("allows prompt-only drafts without local work-item references", async () => {
     const { default: TaskBundleDraftPanel } = await import("../components/TaskBundleDraftPanel.vue");
 
     const draft: TaskBundleDraft = {
@@ -79,7 +77,9 @@ describe("TaskBundleDraftPanel", () => {
     await flushPromises();
 
     expect(wrapper.find('[data-testid="task-bundle-draft-spec-ref"]').exists()).toBe(false);
-    expect(wrapper.get('[data-testid="task-bundle-draft-missing-spec"]').text()).toContain("未绑定成对的 issue/spec 目录");
+    expect(wrapper.find('[data-testid="task-bundle-draft-missing-spec"]').exists()).toBe(false);
+    expect((wrapper.get('[data-testid="task-bundle-draft-approve"]').element as HTMLButtonElement).disabled).toBe(false);
+    expect((wrapper.get('[data-testid="task-bundle-draft-approve-run"]').element as HTMLButtonElement).disabled).toBe(false);
   });
 
   it("shows the bound spec filename in the draft list", async () => {

--- a/client/src/__tests__/task-bundle-drafts-panel.test.ts
+++ b/client/src/__tests__/task-bundle-drafts-panel.test.ts
@@ -72,6 +72,7 @@ describe("TaskBundleDraftPanel", () => {
     await wrapper.vm.$nextTick();
 
     expect(wrapper.find('[data-testid="task-bundle-draft-row-spec"]').exists()).toBe(false);
+    expect(wrapper.get('[data-testid="task-bundle-draft-row-prompt-only"]').text()).toContain("自包含任务");
 
     await wrapper.get('[data-testid="task-bundle-draft-d-nospec"]').trigger("click");
     await flushPromises();

--- a/client/src/components/TaskBundleDraftPanel.vue
+++ b/client/src/components/TaskBundleDraftPanel.vue
@@ -43,9 +43,7 @@ const canApproveDraft = computed(
     !editorBusy.value &&
     !taskDirty.value &&
     !taskNormalizationPending.value &&
-    selectedDraft.value?.status === "draft" &&
-    Boolean(selectedDraft.value?.bundle?.issueRef?.trim()) &&
-    Boolean(selectedDraft.value?.bundle?.specRef?.trim()),
+    selectedDraft.value?.status === "draft",
 );
 const canSaveTask = computed(
   () =>

--- a/client/src/components/taskBundleDraft/TaskBundleDraftEditor.vue
+++ b/client/src/components/taskBundleDraft/TaskBundleDraftEditor.vue
@@ -19,8 +19,6 @@ const props = defineProps<{
   draftTitle: (draft: TaskBundleDraft) => string;
 }>();
 
-// The prompt is intentionally short, so the reviewer must see the paired
-// directories before approving the task.
 const issueRef = computed(() => String(props.selectedDraft.bundle?.issueRef ?? "").trim());
 const specRef = computed(() => String(props.selectedDraft.bundle?.specRef ?? "").trim());
 
@@ -71,9 +69,6 @@ const emit = defineEmits<{
       </div>
 
       <div v-if="editingError" class="modalError" data-testid="task-bundle-draft-error">{{ editingError }}</div>
-      <div v-if="!issueRef || !specRef" class="modalWarning" data-testid="task-bundle-draft-missing-spec">
-        ⚠️ 此草稿未绑定成对的 issue/spec 目录。补齐引用后才能批准交给 Worker 执行。
-      </div>
       <div v-if="selectedDraft.degradeReason" class="modalWarning" data-testid="task-bundle-draft-degrade-reason">
         ⚠️ 此草稿已从自动入队降级：{{ selectedDraft.degradeReason }}
       </div>

--- a/client/src/components/taskBundleDraft/TaskBundleDraftList.vue
+++ b/client/src/components/taskBundleDraft/TaskBundleDraftList.vue
@@ -11,6 +11,14 @@ function specRefOf(draft: TaskBundleDraft): string {
   return String(draft.bundle?.specRef ?? "").trim();
 }
 
+function hasAnyRef(draft: TaskBundleDraft): boolean {
+  return Boolean(issueRefOf(draft) || specRefOf(draft));
+}
+
+function refSummaryOf(draft: TaskBundleDraft): string {
+  return [issueRefOf(draft), specRefOf(draft)].filter(Boolean).join(" ↔ ");
+}
+
 function workItemKeyOf(draft: TaskBundleDraft): string {
   const ref = issueRefOf(draft) || specRefOf(draft);
   return ref ? (ref.split("/").pop() ?? ref) : "";
@@ -84,7 +92,22 @@ const emit = defineEmits<{
             >
               📁 {{ workItemKeyOf(draft) }}
             </span>
-            <span v-else class="draftRowNoSpec" title="缺少成对的 issue/spec 目录引用">⚠️ issue/spec 不完整</span>
+            <span
+              v-else-if="hasAnyRef(draft)"
+              class="draftRowSpec"
+              :title="refSummaryOf(draft)"
+              data-testid="task-bundle-draft-row-ref"
+            >
+              🔗 {{ workItemKeyOf(draft) || "GitHub 引用" }}
+            </span>
+            <span
+              v-else
+              class="draftRowSpec"
+              title="此草稿不要求本地 issue/spec 目录引用"
+              data-testid="task-bundle-draft-row-prompt-only"
+            >
+              📝 自包含任务
+            </span>
             <span v-if="draft.degradeReason" class="draftRowDegraded" :title="draft.degradeReason">⚠️ 已降级</span>
           </div>
           <div class="draftRowRight">

--- a/docs/web.md
+++ b/docs/web.md
@@ -16,7 +16,7 @@ Web Console 将对话与任务流组织为三大工作区：
   - 集成 **Task Bundle Drafts（任务草稿箱）**：查看 Advisor 生成的结构化任务束，支持在线编辑子任务与一键审批入队。
 - **Advisor (规划 Lane)**：
   - 默认对话 Lane，用于方案讨论、代码架构设计与任务拆解。
-  - Task Bundle 可直接引用 GitHub Issue/PR URL，或只携带自包含的任务 prompt；不要求先创建本地 `docs/issue/` 与 `docs/spec/` 目录。
+  - Task Bundle 可直接引用 GitHub Issue/PR URL，或只携带自包含的任务 prompt；不要求先创建本地 `docs/issue/` 与 `docs/spec/` 目录，审批也不以这两个目录为前提。
   - 显式使用本地 `/draft` 快照时，仍可携带匹配的 `issueRef` / `specRef` 目录并在批准时固定内容；本地快照是兼容能力，不是 GitHub-native 流程的前置条件。
   - 支持输出 `ads-schedule` 定时指令或生成 Task Bundle 任务草稿。
   - 任务带有 `development`（开发）、`review`（审核）和 `rework`（返工）分类；待执行任务按 `priority` 降序、队列顺序升序领取。

--- a/server/web/server/planner/taskBundle.ts
+++ b/server/web/server/planner/taskBundle.ts
@@ -208,8 +208,6 @@ export function formatTaskBundleSummaryMarkdown(
   lines.push("");
   if (issue && spec) {
     lines.push(`工作项：\`${issue}\` ↔ \`${spec}\``);
-  } else {
-    lines.push("⚠️ 未绑定成对的 issue/spec 目录，Worker 任务不会被批准执行");
   }
   for (let i = 0; i < normalized.length; i += 1) {
     const task = normalized[i]!;

--- a/tests/web/taskBundleChatFormatting.test.ts
+++ b/tests/web/taskBundleChatFormatting.test.ts
@@ -76,11 +76,9 @@ describe("planner task bundle chat formatting", () => {
     assert.ok(markdown.includes("docs/spec/feature"), "summary must name the spec");
   });
 
-  it("flags a bundle that is not bound to a paired work item", () => {
-    // A task saying "implement Stage 1" with no paired directories is
-    // unactionable, so the absence has to be loud rather than invisible.
+  it("does not add a local work-item warning to prompt-only bundles", () => {
     const markdown = formatTaskBundleSummaryMarkdown([{ title: "Stage 1", prompt: "Implement stage 1." }]);
-    assert.ok(markdown.includes("未绑定成对的 issue/spec 目录"), "missing work-item refs must be called out");
+    assert.ok(!markdown.includes("未绑定成对的 issue/spec 目录"), "prompt-only bundles must not require local work-item refs");
   });
 
   it("normalizes escaped newlines in task prompts", () => {

--- a/tests/web/taskBundleDraftsRoute.test.ts
+++ b/tests/web/taskBundleDraftsRoute.test.ts
@@ -293,7 +293,7 @@ describe("web/api/task-bundle-drafts", () => {
   });
 
 
-  it("approves paired drafts idempotently and can run the queue", async () => {
+  it("approves paired and prompt-only drafts idempotently and can run the queue", async () => {
     const auth = { userId: "u-1", username: "u" };
     const workspaceRoot = createWorkspaceRoot("ws-2");
 
@@ -514,6 +514,50 @@ describe("web/api/task-bundle-drafts", () => {
     assert.equal(setModeCalled, 1);
     assert.equal(resumeCalled, 1);
     assert.equal(promoteCalled, 1);
+
+    const promptOnlyDraft = upsertTaskBundleDraft({
+      authUserId: auth.userId,
+      workspaceRoot,
+      sourceChatSessionId: "planner",
+      sourceHistoryKey: "hk-prompt-only",
+      bundle: {
+        version: 1,
+        requestId: "r2-prompt-only",
+        tasks: [{ prompt: "p4" }],
+      },
+      now: 30,
+    });
+    const promptOnlyApproveRes = createRes();
+    const promptOnlyApproveUrl = new URL(
+      `http://localhost/api/task-bundle-drafts/${promptOnlyDraft.id}/approve?workspace=${encodeURIComponent(workspaceRoot)}`,
+    );
+    assert.equal(
+      await handleTaskBundleDraftRoutes(
+        {
+          req: createReq("POST", { runQueue: true }) as any,
+          res: promptOnlyApproveRes as any,
+          url: promptOnlyApproveUrl,
+          pathname: `/api/task-bundle-drafts/${promptOnlyDraft.id}/approve`,
+          auth,
+        } as any,
+        deps as any,
+      ),
+      true,
+    );
+    assert.equal(promptOnlyApproveRes.statusCode, 200);
+    const promptOnlyPayload = parseJson<{
+      success: boolean;
+      createdTaskIds: string[];
+      draft: { status: string; approvedTaskIds: string[] };
+    }>(promptOnlyApproveRes.body);
+    assert.equal(promptOnlyPayload.success, true);
+    assert.equal(promptOnlyPayload.createdTaskIds.length, 1);
+    assert.equal(promptOnlyPayload.draft.status, "approved");
+    assert.deepEqual(promptOnlyPayload.draft.approvedTaskIds, promptOnlyPayload.createdTaskIds);
+    assert.equal(tasksById.size, 4);
+    assert.equal(setModeCalled, 2);
+    assert.equal(resumeCalled, 2);
+    assert.equal(promoteCalled, 2);
   });
 
   it("approves drafts without acquiring the workspace lock", async () => {


### PR DESCRIPTION
## Summary
- allow valid task drafts to be approved without local issue/spec directories
- remove the obsolete blocking editor warning and markdown warning
- cover prompt-only approval and summary behavior with tests and documentation

## Validation
- npm run lint
- npm run build
- npm test: 967 passed, 1 unrelated pre-existing cliRunner idle-timeout failure
- npm run test:web: 444 passed, 2 unrelated pre-existing project-switch timeout/worker-start failures
- targeted frontend tests: 4 passed
- targeted backend summary tests: 6 passed

Closes #97