### PR TITLE
feat: configure reviewer model explicitly

### DIFF
--- a/client/src/__tests__/model-manager.test.ts
+++ b/client/src/__tests__/model-manager.test.ts
@@ -50,26 +50,28 @@ describe("ModelManager", () => {
 
   it("lists every CLI as one row and creates a codex model from that row", async () => {
     const createdModel = makeModel("model-generated", "gpt-5.2", "openai", "codex", "gpt-5.2");
+    const initialModels = [
+      makeModel("claude-sonnet", "Claude Sonnet", "anthropic", "claude"),
+      {
+        id: "local-model",
+        displayName: "Local Model",
+        provider: "local",
+        isEnabled: true,
+        isDefault: false,
+        configJson: null,
+      } satisfies ModelConfig,
+    ];
     const api = {
-      get: vi
-        .fn()
-        .mockResolvedValueOnce([
-          makeModel("claude-sonnet", "Claude Sonnet", "anthropic", "claude"),
-          {
-            id: "local-model",
-            displayName: "Local Model",
-            provider: "local",
-            isEnabled: true,
-            isDefault: false,
-            configJson: null,
-          } satisfies ModelConfig,
-        ])
-        .mockResolvedValueOnce([makeModel("claude-sonnet", "Claude Sonnet", "anthropic", "claude"), createdModel]),
+      get: vi.fn().mockImplementation((path: string) => {
+        if (path === "/api/reviewer-model") return Promise.resolve({ modelConfigId: null, modelId: null, model: null });
+        return Promise.resolve(apiConfigResponses.shift() ?? [makeModel("claude-sonnet", "Claude Sonnet", "anthropic", "claude"), createdModel]);
+      }),
       post: vi.fn().mockResolvedValue(createdModel),
       patch: vi.fn(),
       put: vi.fn(),
       delete: vi.fn(),
     };
+    const apiConfigResponses: ModelConfig[][] = [initialModels];
 
     const wrapper = mount(ModelManager, {
       props: { api: api as any },
@@ -88,7 +90,8 @@ describe("ModelManager", () => {
     // A model only ever renders under its own CLI, and unknown CLIs are dropped.
     expect(groups[0]!.text()).not.toContain("Claude Sonnet");
     expect(groups[1]!.text()).toContain("Claude Sonnet");
-    expect(wrapper.text()).not.toContain("Local Model");
+    expect(groups[0]!.text()).not.toContain("Local Model");
+    expect(groups[1]!.text()).not.toContain("Local Model");
 
     // Adding starts from the CLI row, so the dialog never asks which CLI again.
     await wrapper.find('[data-testid="model-manager-add-codex"]').trigger("click");
@@ -141,7 +144,7 @@ describe("ModelManager", () => {
     expect(wrapper.findAll(".cliGroup")).toHaveLength(1);
     expect(wrapper.text()).toContain("模型");
     expect(wrapper.text()).toContain("Claude Sonnet");
-    expect(wrapper.text()).not.toContain("GPT 5.2");
+    expect(wrapper.find(".cliGroup").text()).not.toContain("GPT 5.2");
     expect(wrapper.find(".cliRow").exists()).toBe(false);
     expect(wrapper.find('[data-testid="model-manager-cli-claude"]').exists()).toBe(false);
     expect(wrapper.find('[data-testid="model-manager-add-claude"]').exists()).toBe(false);
@@ -172,7 +175,7 @@ describe("ModelManager", () => {
     expect(wrapper.text()).toContain("Claude Sonnet");
 
     await wrapper.find('[data-testid="model-manager-cli-codex"]').trigger("click");
-    expect(wrapper.text()).not.toContain("GPT 5.2");
+    expect(wrapper.findAll(".cliGroup")[0]!.text()).not.toContain("GPT 5.2");
     expect(wrapper.text()).toContain("Claude Sonnet");
     expect(wrapper.find('[data-testid="model-manager-cli-codex"]').attributes("aria-expanded")).toBe("false");
     // The CLI row itself stays visible when collapsed.
@@ -335,6 +338,42 @@ describe("ModelManager", () => {
     expect(api.patch).toHaveBeenLastCalledWith("/api/model-configs/gpt-5.2", { isDefault: true });
     expect(wrapper.emitted("changed")).toHaveLength(2);
     expect(wrapper.find('[data-testid="model-manager-dialog"]').exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it("selects and persists an enabled concrete reviewer model", async () => {
+    const reviewer = makeModel("reviewer-model", "GPT Reviewer", "openai", "codex", "gpt-5.6-sol");
+    const auto = makeModel("auto-model", "Auto", "openai", "codex", "auto");
+    const api = {
+      get: vi.fn().mockImplementation((path: string) => {
+        if (path === "/api/reviewer-model") {
+          return Promise.resolve({ modelConfigId: null, modelId: null, model: null });
+        }
+        return Promise.resolve([reviewer, auto]);
+      }),
+      post: vi.fn(),
+      patch: vi.fn().mockResolvedValue({ modelConfigId: reviewer.id, modelId: reviewer.modelId, model: reviewer }),
+      put: vi.fn(),
+      delete: vi.fn(),
+    };
+
+    const wrapper = mount(ModelManager, {
+      props: { api: api as any },
+      global: { stubs: { "el-icon": true } },
+    });
+    await settle(wrapper);
+
+    const select = wrapper.find('[data-testid="reviewer-model-select"]');
+    expect(select.exists()).toBe(true);
+    expect(select.findAll("option").map((option) => option.attributes("value"))).toEqual(["", reviewer.id]);
+    expect(select.text()).not.toContain("Auto");
+
+    await select.setValue(reviewer.id);
+    await settle(wrapper);
+
+    expect(api.patch).toHaveBeenCalledWith("/api/reviewer-model", { modelConfigId: reviewer.id });
+    expect(wrapper.find('[data-testid="reviewer-model-panel"]').text()).toContain("已配置");
 
     wrapper.unmount();
   });

--- a/client/src/api/types.ts
+++ b/client/src/api/types.ts
@@ -121,6 +121,12 @@ export interface ModelConfig {
   configJson?: Record<string, unknown> | null;
 }
 
+export interface ReviewerModelSelection {
+  modelConfigId: string | null;
+  modelId: string | null;
+  model: ModelConfig | null;
+}
+
 export type RuleSeverity = "advisory" | "required" | "approval_required" | "blocked";
 
 export interface RuleMatch {

--- a/client/src/components/ModelManager.vue
+++ b/client/src/components/ModelManager.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, reactive, ref } from "vue";
 import { ArrowRight, Close, Delete, EditPen, Plus, Refresh, StarFilled } from "@element-plus/icons-vue";
 
 import type { ApiClient } from "../api/client";
-import type { ModelConfig } from "../api/types";
+import type { ModelConfig, ReviewerModelSelection } from "../api/types";
 import { MODEL_AGENT_GROUPS, resolveModelAgentId, type AgentKind } from "../lib/model_agent";
 
 type ModelForm = {
@@ -42,6 +42,8 @@ const editingId = ref<string | null>(null);
 const dialogOpen = ref(false);
 const pendingDeleteId = ref<string | null>(null);
 const selectedModelId = ref<string | null>(null);
+const reviewerModelId = ref<string | null>(null);
+const reviewerSaving = ref(false);
 const expanded = reactive<Record<AgentKind, boolean>>({ codex: true, claude: true });
 
 const emptyForm = (agent: AgentKind = "codex"): ModelForm => ({
@@ -121,11 +123,23 @@ const visibleGroups = computed(() =>
   props.agent ? MODEL_AGENT_GROUPS.filter((group) => group.kind === props.agent) : MODEL_AGENT_GROUPS,
 );
 
+const reviewerModels = computed(() =>
+  modelConfigs.value.filter((model) => {
+    const modelId = String(model.modelId ?? model.id ?? "").trim();
+    return model.isEnabled && modelId && modelId.toLowerCase() !== "auto";
+  }),
+);
+
+const reviewerModelSelection = computed(() => {
+  const selected = reviewerModelId.value;
+  return selected && reviewerModels.value.some((model) => model.id === selected) ? selected : null;
+});
+
 function enabledCount(agent: AgentKind): number {
   return groupedModels.value[agent].filter((model) => model.isEnabled).length;
 }
 
-const busy = computed(() => saving.value || loading.value || busyRowId.value !== null);
+const busy = computed(() => saving.value || loading.value || reviewerSaving.value || busyRowId.value !== null);
 const isEditing = computed(() => Boolean(editingId.value));
 const managerTitle = computed(() => (props.agent ? "模型" : "模型管理"));
 // Each CLI scope keeps an enabled default; selecting a new default replaces only that CLI's default.
@@ -153,10 +167,29 @@ async function loadModelConfigs(): Promise<void> {
   selectedModelId.value = null;
   try {
     modelConfigs.value = await props.api.get<ModelConfig[]>("/api/model-configs");
+    const selection = await props.api.get<ReviewerModelSelection>("/api/reviewer-model");
+    reviewerModelId.value = selection.modelConfigId;
   } catch (err) {
     error.value = err instanceof Error ? err.message : String(err);
   } finally {
     loading.value = false;
+  }
+}
+
+async function saveReviewerModel(event: Event): Promise<void> {
+  const modelConfigId = String((event.target as HTMLSelectElement | null)?.value ?? "").trim();
+  if (!modelConfigId || !reviewerModels.value.some((model) => model.id === modelConfigId) || reviewerSaving.value) return;
+  reviewerSaving.value = true;
+  error.value = null;
+  try {
+    const selection = await props.api.patch<ReviewerModelSelection>("/api/reviewer-model", { modelConfigId });
+    reviewerModelId.value = selection.modelConfigId;
+    statusMessage.value = "Reviewer 模型已保存";
+    emit("changed");
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err);
+  } finally {
+    reviewerSaving.value = false;
   }
 }
 
@@ -354,6 +387,30 @@ defineExpose({
     </div>
 
     <div class="cliList">
+      <section class="reviewerModelPanel" data-testid="reviewer-model-panel">
+        <div class="reviewerModelHeading">
+          <div>
+            <div class="modelLabel">Reviewer 模型</div>
+            <div class="modelHelp">审核任务必须使用这里明确选择的模型，不会继承 Worker 模型。</div>
+          </div>
+          <span v-if="reviewerModelSelection" class="modelPill default">已配置</span>
+        </div>
+        <select
+          class="modelInput reviewerModelSelect"
+          :value="reviewerModelSelection ?? ''"
+          :disabled="busy || reviewerModels.length === 0"
+          data-testid="reviewer-model-select"
+          @change="saveReviewerModel"
+        >
+          <option value="" disabled>选择启用的 Reviewer 模型</option>
+          <option v-for="model in reviewerModels" :key="model.id" :value="model.id">
+            {{ modelLabel(model) }} ({{ model.modelId || model.id }})
+          </option>
+        </select>
+        <div v-if="reviewerModels.length === 0" class="modelHelp invalid">没有可用的启用模型，请先启用一个具体模型。</div>
+        <div v-else-if="!reviewerModelSelection" class="modelHelp invalid">尚未配置；审核任务不会自动继承 Worker 模型。</div>
+      </section>
+
       <section
         v-for="group in visibleGroups"
         :key="group.kind"
@@ -699,6 +756,28 @@ defineExpose({
   flex-direction: column;
   gap: 10px;
   padding: 14px 16px 18px;
+}
+
+.reviewerModelPanel {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 12px;
+  border: 1px solid rgba(37, 99, 235, 0.24);
+  border-radius: 13px;
+  background: rgba(239, 246, 255, 0.64);
+}
+
+.reviewerModelHeading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.reviewerModelSelect {
+  max-width: 520px;
 }
 
 .cliGroup {

--- a/docs/web.md
+++ b/docs/web.md
@@ -33,8 +33,9 @@ Web Console 将对话与任务流组织为三大工作区：
   - 左侧导航可切换 Provider，右侧维护各 Provider 的模型列表。
 - **模型管理**：
   - 在线启用/停用模型、按 CLI 设置默认模型、编辑与新增模型；Codex 与 Claude 的默认模型彼此独立。
+  - 在模型管理顶部单独选择 Reviewer 模型；下拉只展示启用的具体模型，审核任务不会继承 Worker 模型。未配置 Reviewer 模型时，任务完成后的审核子任务不会创建，并会在任务事件中报告配置错误。
   - 输入框模型选择器严格联动：仅展示当前 Agent 兼容且已启用的模型，切换 Agent 时自动恢复对应兼容偏好。页面加载或模型列表刷新不会覆盖已有的自定义模型选择。
-  - 所有模型配置持久化于全局 SQLite 状态库 (`state.db`)。
+  - 所有模型配置和 Reviewer 模型选择持久化于全局 SQLite 状态库 (`state.db`)。
 
 ### 3. 全局规则系统 (Global Rules)
 - 跨项目、跨 Channel（Web Console / Telegram Bot）以及跨 Agent（Codex / Claude）统一生效的规则引擎。

--- a/server/state/reviewerModelStore.ts
+++ b/server/state/reviewerModelStore.ts
@@ -1,0 +1,81 @@
+import type { Database as DatabaseType } from "better-sqlite3";
+
+import type { AgentIdentifier } from "../agents/types.js";
+import { selectAgentForModel } from "../tasks/agentSelection.js";
+import type { ModelConfig, ReviewerModelSelection } from "../tasks/types.js";
+import { createGlobalModelConfigStore, type GlobalModelConfigStore } from "./globalModelConfigStore.js";
+
+function normalizeString(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function isConcreteModel(model: ModelConfig | null | undefined): model is ModelConfig & { modelId: string } {
+  const modelId = normalizeString(model?.modelId ?? model?.id);
+  return Boolean(model && model.isEnabled && modelId && modelId.toLowerCase() !== "auto");
+}
+
+function resolveReviewerAgent(model: ModelConfig, modelId: string): AgentIdentifier {
+  const allowedAgents = model.configJson?.allowedAgents;
+  if (Array.isArray(allowedAgents)) {
+    const configuredAgent = allowedAgents.map((value) => normalizeString(value)).find(Boolean);
+    if (configuredAgent) return configuredAgent;
+  }
+  return selectAgentForModel(modelId);
+}
+
+export function createReviewerModelStore(
+  db: DatabaseType,
+  modelStore: GlobalModelConfigStore = createGlobalModelConfigStore(db),
+) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS reviewer_model_settings (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      model_config_id TEXT,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  const getSelectionStmt = db.prepare("SELECT model_config_id AS modelConfigId FROM reviewer_model_settings WHERE id = 1");
+  const setSelectionStmt = db.prepare(`
+    INSERT INTO reviewer_model_settings (id, model_config_id, updated_at)
+    VALUES (1, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+      model_config_id = excluded.model_config_id,
+      updated_at = excluded.updated_at
+  `);
+
+  const getReviewerModelConfigId = (): string | null => {
+    const row = getSelectionStmt.get() as { modelConfigId?: unknown } | undefined;
+    const modelConfigId = normalizeString(row?.modelConfigId);
+    return modelConfigId || null;
+  };
+
+  const getConfiguredReviewerModel = (): ReviewerModelSelection | null => {
+    const modelConfigId = getReviewerModelConfigId();
+    if (!modelConfigId) return null;
+    const model = modelStore.getModelConfig(modelConfigId);
+    if (!isConcreteModel(model)) return null;
+    const modelId = normalizeString(model.modelId ?? model.id);
+    return {
+      model: modelId,
+      agentId: resolveReviewerAgent(model, modelId),
+      modelConfigId,
+    };
+  };
+
+  const setReviewerModel = (modelConfigId: string | null, now = Date.now()): ReviewerModelSelection | null => {
+    const normalizedId = modelConfigId == null ? null : normalizeString(modelConfigId);
+    if (normalizedId) {
+      const model = modelStore.getModelConfig(normalizedId);
+      if (!isConcreteModel(model)) {
+        throw new Error("Reviewer model must be an enabled concrete model");
+      }
+    }
+    setSelectionStmt.run(normalizedId, now);
+    return getConfiguredReviewerModel();
+  };
+
+  return { getReviewerModelConfigId, getConfiguredReviewerModel, setReviewerModel };
+}
+
+export type ReviewerModelStore = ReturnType<typeof createReviewerModelStore>;

--- a/server/state/schemaMigrations.ts
+++ b/server/state/schemaMigrations.ts
@@ -335,4 +335,17 @@ export const stateSchemaMigrations: StateSchemaMigration[] = [
     description: "Reserved legacy migration; obsolete secondary CLI model seeding removed",
     up: () => {},
   },
+  {
+    version: 11,
+    description: "Persist the explicitly selected reviewer model",
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS reviewer_model_settings (
+          id INTEGER PRIMARY KEY CHECK (id = 1),
+          model_config_id TEXT,
+          updated_at INTEGER NOT NULL
+        );
+      `);
+    },
+  },
 ];

--- a/server/tasks/reviewWorkflow.ts
+++ b/server/tasks/reviewWorkflow.ts
@@ -1,4 +1,4 @@
-import type { CreateTaskInput, Task, TaskCategory } from "./types.js";
+import type { CreateTaskInput, ReviewerModelSelection, Task, TaskCategory } from "./types.js";
 
 export type PullRequestReference = {
   number: number;
@@ -77,6 +77,7 @@ export function buildReviewTaskInput(args: {
   source: Task;
   pullRequest: PullRequestReference;
   issueNumber?: number | null;
+  reviewerModel: ReviewerModelSelection;
 }): CreateTaskInput {
   const issueSuffix = args.issueNumber == null ? "" : ` for Issue #${args.issueNumber}`;
   const pullRequestLabel = `PR #${args.pullRequest.number}`;
@@ -100,8 +101,8 @@ export function buildReviewTaskInput(args: {
       "REVIEW_STATUS: rejected",
       "When rejected, also include one REVIEW_FEEDBACK: line with the concrete fixes required.",
     ].join("\n"),
-    model: args.source.model,
-    agentId: args.source.agentId,
+    model: args.reviewerModel.model,
+    agentId: args.reviewerModel.agentId,
     category: "review",
     priority: 10,
     parentTaskId: args.source.id,

--- a/server/tasks/types.ts
+++ b/server/tasks/types.ts
@@ -174,3 +174,9 @@ export interface ModelConfig {
   configJson?: Record<string, unknown> | null;
   updatedAt?: number | null;
 }
+
+export type ReviewerModelSelection = {
+  model: string;
+  agentId: string;
+  modelConfigId?: string;
+};

--- a/server/web/server/api/routes/models.ts
+++ b/server/web/server/api/routes/models.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 
 import { getStateDatabase } from "../../../../state/database.js";
 import { createGlobalModelConfigStore, type GlobalModelConfigStore } from "../../../../state/globalModelConfigStore.js";
+import { createReviewerModelStore, type ReviewerModelStore } from "../../../../state/reviewerModelStore.js";
 import type { ModelConfig } from "../../../../tasks/types.js";
 import type { ApiRouteContext } from "../types.js";
 import { readJsonBody, sendJson } from "../../http.js";
@@ -41,6 +42,7 @@ type UpdateModelConfigInput = z.infer<typeof updateModelConfigSchema>;
 
 type ModelRouteDeps = {
   modelStore?: GlobalModelConfigStore;
+  reviewerModelStore?: ReviewerModelStore;
 };
 
 function normalizeString(value: unknown): string {
@@ -80,11 +82,58 @@ function buildModelConfigPayload(
 export async function handleModelRoutes(ctx: ApiRouteContext, deps: ModelRouteDeps = {}): Promise<boolean> {
   const { req, res, pathname } = ctx;
   const getModelStore = () => deps.modelStore ?? createGlobalModelConfigStore(getStateDatabase());
+  const getReviewerModelStore = () =>
+    deps.reviewerModelStore ?? createReviewerModelStore(getStateDatabase(), getModelStore());
 
   if (req.method === "GET" && pathname === "/api/models") {
     const modelStore = getModelStore();
     const configured = modelStore.listModelConfigs();
     sendJson(res, 200, configured.filter((model) => model.isEnabled));
+    return true;
+  }
+
+  if (req.method === "GET" && pathname === "/api/reviewer-model") {
+    const configured = getReviewerModelStore().getConfiguredReviewerModel();
+    const modelStore = getModelStore();
+    const model = configured?.modelConfigId ? modelStore.getModelConfig(configured.modelConfigId) : null;
+    sendJson(res, 200, {
+      modelConfigId: configured?.modelConfigId ?? null,
+      modelId: configured?.model ?? null,
+      model: model ?? null,
+    });
+    return true;
+  }
+
+  if (req.method === "PATCH" && pathname === "/api/reviewer-model") {
+    const body = await readJsonBody(req);
+    const parsed = z
+      .object({
+        modelConfigId: z.string().trim().min(1).nullable().optional(),
+        modelId: z.string().trim().min(1).nullable().optional(),
+      })
+      .refine((value) => value.modelConfigId !== undefined || value.modelId !== undefined)
+      .safeParse(body ?? {});
+    if (!parsed.success) {
+      sendJson(res, 400, { error: "modelConfigId or modelId must be a non-empty string or null" });
+      return true;
+    }
+    try {
+      const modelStore = getModelStore();
+      const requestedId = parsed.data.modelConfigId ?? parsed.data.modelId;
+      const modelConfigId =
+        requestedId == null
+          ? null
+          : modelStore.getModelConfig(requestedId)?.id ?? modelStore.getModelConfigByAgentModelId(requestedId)?.id ?? requestedId;
+      const configured = getReviewerModelStore().setReviewerModel(modelConfigId);
+      const model = configured?.modelConfigId ? modelStore.getModelConfig(configured.modelConfigId) : null;
+      sendJson(res, 200, {
+        modelConfigId: configured?.modelConfigId ?? null,
+        modelId: configured?.model ?? null,
+        model: model ?? null,
+      });
+    } catch (error) {
+      sendJson(res, 400, { error: error instanceof Error ? error.message : String(error) });
+    }
     return true;
   }
 

--- a/server/web/server/taskQueue/context.ts
+++ b/server/web/server/taskQueue/context.ts
@@ -8,6 +8,8 @@ import { TaskQueue } from "../../../tasks/queue.js";
 import { TaskStore as QueueTaskStore } from "../../../tasks/store.js";
 import { TaskRunController } from "../../taskRunController.js";
 import { deriveProjectSessionId } from "../projectSessionId.js";
+import { getStateDatabase } from "../../../state/database.js";
+import { createReviewerModelStore } from "../../../state/reviewerModelStore.js";
 import type { AsyncLock } from "../../../utils/asyncLock.js";
 import type { TaskQueueContext } from "./types.js";
 import {
@@ -61,6 +63,7 @@ export function createTaskQueueContext(args: {
     getLock,
   });
   const taskQueue = new TaskQueue({ store: taskStore, executor });
+  const reviewerModelStore = createReviewerModelStore(getStateDatabase());
 
   return {
     workspaceRoot,
@@ -76,5 +79,6 @@ export function createTaskQueueContext(args: {
     runController: new TaskRunController(),
     getStatusOrchestrator,
     getTaskQueueOrchestrator,
+    getReviewerModel: () => reviewerModelStore.getConfiguredReviewerModel(),
   };
 }

--- a/server/web/server/taskQueue/runtime.ts
+++ b/server/web/server/taskQueue/runtime.ts
@@ -140,11 +140,24 @@ export function createTaskWorkflowFollowup(args: {
     if (!pullRequest) {
       return;
     }
+    const reviewerModel = ctx.getReviewerModel();
+    if (!reviewerModel) {
+      const message = "Reviewer model is not configured. Select an enabled concrete Reviewer model before reviewing tasks.";
+      logger.warn(`[Web][TaskReview] ${message} taskId=${task.id}`);
+      args.broadcastToSession(ctx.sessionId, {
+        type: "task:event",
+        event: "task:error",
+        data: { taskId: task.id, error: message },
+        ts: Date.now(),
+      });
+      return;
+    }
     const review = ctx.taskStore.createTask(
       buildReviewTaskInput({
         source: task,
         pullRequest,
         issueNumber: findIssueNumberInTaskChain(task, (id) => ctx.taskStore.getTask(id)),
+        reviewerModel,
       }),
       Date.now(),
       { status: "pending" },

--- a/server/web/server/taskQueue/types.ts
+++ b/server/web/server/taskQueue/types.ts
@@ -4,6 +4,7 @@ import type { TaskStore as QueueTaskStore } from "../../../tasks/store.js";
 import type { AsyncLock } from "../../../utils/asyncLock.js";
 import type { TaskRunController } from "../../taskRunController.js";
 import type { SessionManager } from "../../../telegram/utils/sessionManager.js";
+import type { ReviewerModelSelection } from "../../../tasks/types.js";
 
 export type TaskQueueMetricName =
   | "TASK_ADDED"
@@ -38,4 +39,5 @@ export type TaskQueueContext = {
   runController: TaskRunController;
   getStatusOrchestrator: () => ReturnType<SessionManager["getOrCreate"]>;
   getTaskQueueOrchestrator: (task: { id: string; goalMode?: boolean }) => ReturnType<SessionManager["getOrCreate"]>;
+  getReviewerModel: () => ReviewerModelSelection | null;
 };

--- a/tests/tasks/reviewWorkflow.test.ts
+++ b/tests/tasks/reviewWorkflow.test.ts
@@ -44,10 +44,14 @@ describe("tasks/reviewWorkflow", () => {
       source,
       pullRequest: { number: 85, url: "https://github.com/acme/project/pull/85" },
       issueNumber: 80,
+      reviewerModel: { model: "gpt-5.6-sol", agentId: "codex" },
     });
     assert.equal(review.category, "review");
     assert.equal(review.priority, 10);
     assert.equal(review.parentTaskId, "development-1");
+    assert.equal(review.model, "gpt-5.6-sol");
+    assert.equal(review.agentId, "codex");
+    assert.notEqual(review.model, source.model);
     assert.match(review.prompt, /REVIEW_STATUS: approved/);
 
     const rework = buildReworkTaskInput({
@@ -94,6 +98,7 @@ describe("tasks/reviewWorkflow", () => {
         taskStore: store,
         taskQueue,
         metrics: createTaskQueueMetrics(),
+        getReviewerModel: () => ({ model: "gpt-5.6-sol", agentId: "codex" }),
       } as never;
       const source = store.createTask({
         id: "development-1",
@@ -145,6 +150,53 @@ describe("tasks/reviewWorkflow", () => {
       assert.match(rework.prompt, /Fix the race/);
       store.createTask({ id: "normal-pending", prompt: "Normal work", priority: 0 });
       assert.equal(store.claimNextPendingTask()?.id, rework.id);
+    } finally {
+      resetDatabaseForTests();
+      if (previousDatabasePath === undefined) delete process.env.ADS_DATABASE_PATH;
+      else process.env.ADS_DATABASE_PATH = previousDatabasePath;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not inherit a worker model when the reviewer model is unset", () => {
+    const previousDatabasePath = process.env.ADS_DATABASE_PATH;
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ads-review-unconfigured-"));
+    process.env.ADS_DATABASE_PATH = path.join(tmpDir, "tasks.db");
+    resetDatabaseForTests();
+    try {
+      const store = new TaskStore();
+      const broadcasts: unknown[] = [];
+      const ctx = {
+        sessionId: "review-session",
+        taskStore: store,
+        taskQueue: { notifyNewTask: () => undefined },
+        metrics: createTaskQueueMetrics(),
+        getReviewerModel: () => null,
+      } as never;
+      const source = store.createTask({
+        id: "development-1",
+        title: "Implement Issue #80",
+        prompt: "Create PR #85",
+        model: "gpt-5.6-luna",
+        agentId: "codex",
+      });
+      const completedSource = store.updateTask(source.id, { status: "completed", result: "Created PR #85" }, 2);
+
+      createTaskWorkflowFollowup({
+        ctx,
+        task: completedSource,
+        logger: { warn: () => undefined } as never,
+        broadcastToSession: (_sessionId, payload) => broadcasts.push(payload),
+      });
+
+      assert.equal(store.findChildTask(source.id, "review"), null);
+      assert.equal(broadcasts.length, 1);
+      assert.deepEqual((broadcasts[0] as { type: string; event: string; data: unknown }).data, {
+        taskId: source.id,
+        error: "Reviewer model is not configured. Select an enabled concrete Reviewer model before reviewing tasks.",
+      });
+      assert.equal((broadcasts[0] as { type: string }).type, "task:event");
+      assert.equal((broadcasts[0] as { event: string }).event, "task:error");
     } finally {
       resetDatabaseForTests();
       if (previousDatabasePath === undefined) delete process.env.ADS_DATABASE_PATH;

--- a/tests/web/modelConfigRoutes.test.ts
+++ b/tests/web/modelConfigRoutes.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import DatabaseConstructor, { type Database as DatabaseType } from "better-sqlite3";
 
 import { createGlobalModelConfigStore } from "../../server/state/globalModelConfigStore.js";
+import { createReviewerModelStore } from "../../server/state/reviewerModelStore.js";
 import { handleModelRoutes } from "../../server/web/server/api/routes/models.js";
 
 type FakeReq = {
@@ -63,11 +64,13 @@ describe("web/model-config routes", () => {
   let tmpDir: string;
   let db: DatabaseType;
   let modelStore: ReturnType<typeof createGlobalModelConfigStore>;
+  let reviewerModelStore: ReturnType<typeof createReviewerModelStore>;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ads-model-config-routes-"));
     db = new DatabaseConstructor(path.join(tmpDir, "state.db"));
     modelStore = createGlobalModelConfigStore(db);
+    reviewerModelStore = createReviewerModelStore(db, modelStore);
   });
 
   afterEach(() => {
@@ -146,6 +149,88 @@ describe("web/model-config routes", () => {
     assert.equal(updated.isDefault, true);
     assert.deepEqual(updated.configJson, { temperature: 0.2 });
     assert.equal(typeof updated.updatedAt, "number");
+  });
+
+  it("reads and updates the explicit reviewer model without accepting disabled or auto models", async () => {
+    modelStore.upsertModelConfig({
+      id: "worker-model",
+      modelId: "gpt-5.6-luna",
+      displayName: "Worker",
+      provider: "openai",
+      isEnabled: true,
+      isDefault: true,
+      configJson: { allowedAgents: ["codex"] },
+    });
+    modelStore.upsertModelConfig({
+      id: "reviewer-model",
+      modelId: "gpt-5.6-sol",
+      displayName: "Reviewer",
+      provider: "openai",
+      isEnabled: true,
+      isDefault: false,
+      configJson: { allowedAgents: ["codex"] },
+    });
+
+    const getRes = createRes();
+    await handleModelRoutes({
+      req: createReq("GET") as any,
+      res: getRes as any,
+      url: new URL("http://localhost/api/reviewer-model"),
+      pathname: "/api/reviewer-model",
+    } as any, { modelStore, reviewerModelStore });
+    assert.equal(getRes.statusCode, 200);
+    assert.deepEqual(parseJson(getRes.body), { modelConfigId: null, modelId: null, model: null });
+
+    const patchRes = createRes();
+    await handleModelRoutes({
+      req: createReq("PATCH", { modelConfigId: "reviewer-model" }) as any,
+      res: patchRes as any,
+      url: new URL("http://localhost/api/reviewer-model"),
+      pathname: "/api/reviewer-model",
+    } as any, { modelStore, reviewerModelStore });
+    assert.equal(patchRes.statusCode, 200);
+    assert.deepEqual(parseJson(patchRes.body), {
+      modelConfigId: "reviewer-model",
+      modelId: "gpt-5.6-sol",
+      model: {
+        id: "reviewer-model",
+        modelId: "gpt-5.6-sol",
+        displayName: "Reviewer",
+        provider: "openai",
+        isEnabled: true,
+        isDefault: false,
+        configJson: { allowedAgents: ["codex"] },
+        updatedAt: parseJson<{ model: { updatedAt: number } }>(patchRes.body).model.updatedAt,
+      },
+    });
+
+    modelStore.upsertModelConfig({
+      id: "disabled-model",
+      modelId: "gpt-5.6-disabled",
+      displayName: "Disabled",
+      provider: "openai",
+      isEnabled: false,
+      isDefault: false,
+      configJson: null,
+    });
+    const invalidRes = createRes();
+    await handleModelRoutes({
+      req: createReq("PATCH", { modelConfigId: "disabled-model" }) as any,
+      res: invalidRes as any,
+      url: new URL("http://localhost/api/reviewer-model"),
+      pathname: "/api/reviewer-model",
+    } as any, { modelStore, reviewerModelStore });
+    assert.equal(invalidRes.statusCode, 400);
+
+    const aliasRes = createRes();
+    await handleModelRoutes({
+      req: createReq("PATCH", { modelId: "gpt-5.6-sol" }) as any,
+      res: aliasRes as any,
+      url: new URL("http://localhost/api/reviewer-model"),
+      pathname: "/api/reviewer-model",
+    } as any, { modelStore, reviewerModelStore });
+    assert.equal(aliasRes.statusCode, 200);
+    assert.equal(parseJson<{ modelConfigId: string }>(aliasRes.body).modelConfigId, "reviewer-model");
   });
 
   it("PATCH can update the agent model id without changing the row id", async () => {


### PR DESCRIPTION
Closes #98. Adds a persisted Reviewer model setting with GET/PATCH API support and Web UI selector; review tasks use only the explicit enabled concrete Reviewer model and report an error when it is unset. Validation: lint, typecheck, npm run build, targeted backend tests (13/13), and targeted frontend tests (9/9). Full backend run: 964 passed, 5 unrelated HTTP server path traversal environment failures.