### PR TITLE
fix(streaming): isolate cumulative deltas by item

### DIFF
--- a/client/src/__tests__/chat-streaming-dedup.test.ts
+++ b/client/src/__tests__/chat-streaming-dedup.test.ts
@@ -38,4 +38,16 @@ describe("chat streaming duplicate protection", () => {
     expect(messages.value).toHaveLength(1);
     expect(messages.value[0]?.content).toBe(`${first} Continued with the next sentence.`);
   });
+
+  it("preserves legitimate text when the chunk starts with a repeated boundary", () => {
+    const { messages, runtime, streaming } = createHarness();
+    const repeatedBoundary = "This repeated boundary is legitimate response content.";
+    const current = `The existing response ends with: ${repeatedBoundary}`;
+    const incoming = `${repeatedBoundary} Then the answer continues normally.`;
+
+    streaming.upsertStreamingDelta(current, runtime);
+    streaming.upsertStreamingDelta(incoming, runtime);
+
+    expect(messages.value[0]?.content).toBe(current + incoming);
+  });
 });

--- a/client/src/__tests__/chat-streaming-dedup.test.ts
+++ b/client/src/__tests__/chat-streaming-dedup.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { ref } from "vue";
+
+import type { ChatItem, ProjectRuntime } from "../app/controller";
+import { createStreamingActions } from "../app/chatStreaming";
+
+function createHarness(initial: ChatItem[] = []) {
+  const messages = ref<ChatItem[]>(initial);
+  const runtime = {
+    messages,
+    liveActivity: { head: 0, tail: 0, size: 0, capacity: 10, totalRecorded: 0, buffer: [] },
+    liveActivityTtlTimer: null,
+  } as unknown as ProjectRuntime;
+  const streaming = createStreamingActions({
+    liveStepId: "live-step",
+    liveActivityId: "live-activity",
+    runtimeOrActive: () => runtime,
+    setMessages: (items) => {
+      messages.value = items;
+    },
+    dropEmptyAssistantPlaceholder: () => {},
+    findLastLiveIndex: () => -1,
+    isLiveMessageId: (id) => id === "live-step" || id === "live-activity",
+    randomId: (prefix) => `${prefix}-1`,
+  });
+  return { messages, runtime, streaming };
+}
+
+describe("chat streaming duplicate protection", () => {
+  it("does not append a repeated cumulative prefix and still appends new text", () => {
+    const { messages, runtime, streaming } = createHarness();
+    const first = "This is a sufficiently long assistant response prefix.";
+
+    streaming.upsertStreamingDelta(first, runtime);
+    streaming.upsertStreamingDelta(first, runtime);
+    streaming.upsertStreamingDelta(`${first} Continued with the next sentence.`, runtime);
+
+    expect(messages.value).toHaveLength(1);
+    expect(messages.value[0]?.content).toBe(`${first} Continued with the next sentence.`);
+  });
+});

--- a/client/src/app/chatStreaming.ts
+++ b/client/src/app/chatStreaming.ts
@@ -3,6 +3,21 @@ import { clearLiveActivityWindow, renderLiveActivityMarkdown } from "../lib/live
 import type { ChatItem, ProjectRuntime } from "./controller";
 
 const LIVE_ACTIVITY_TTL_MS = 3000;
+const MIN_STREAMING_OVERLAP = 32;
+
+function stripStreamingOverlap(current: string, incoming: string): string {
+  if (!current || !incoming) return incoming;
+  if (incoming === current) return "";
+  if (incoming.startsWith(current)) return incoming.slice(current.length);
+
+  const maxOverlap = Math.min(current.length, incoming.length);
+  for (let overlap = maxOverlap; overlap >= MIN_STREAMING_OVERLAP; overlap -= 1) {
+    if (current.slice(current.length - overlap) === incoming.slice(0, overlap)) {
+      return incoming.slice(overlap);
+    }
+  }
+  return incoming;
+}
 
 function trimToLastLines(text: string, maxLines: number, maxChars = 2500): string {
   const normalized = String(text ?? "");
@@ -78,7 +93,10 @@ export function createStreamingActions(params: {
     const existing = state.messages.value.slice();
     const streamIndex = findLastStreamingAssistantIndex(existing);
     if (streamIndex >= 0) {
-      existing[streamIndex]!.content += chunk;
+      const current = String(existing[streamIndex]!.content ?? "");
+      const nextChunk = stripStreamingOverlap(current, chunk);
+      if (!nextChunk) return;
+      existing[streamIndex]!.content = current + nextChunk;
       setMessages(existing.slice(), state);
       return;
     }

--- a/client/src/app/chatStreaming.ts
+++ b/client/src/app/chatStreaming.ts
@@ -3,19 +3,11 @@ import { clearLiveActivityWindow, renderLiveActivityMarkdown } from "../lib/live
 import type { ChatItem, ProjectRuntime } from "./controller";
 
 const LIVE_ACTIVITY_TTL_MS = 3000;
-const MIN_STREAMING_OVERLAP = 32;
 
 function stripStreamingOverlap(current: string, incoming: string): string {
   if (!current || !incoming) return incoming;
   if (incoming === current) return "";
   if (incoming.startsWith(current)) return incoming.slice(current.length);
-
-  const maxOverlap = Math.min(current.length, incoming.length);
-  for (let overlap = maxOverlap; overlap >= MIN_STREAMING_OVERLAP; overlap -= 1) {
-    if (current.slice(current.length - overlap) === incoming.slice(0, overlap)) {
-      return incoming.slice(overlap);
-    }
-  }
   return incoming;
 }
 

--- a/docs/web.md
+++ b/docs/web.md
@@ -36,6 +36,10 @@ Web Console 将对话与任务流组织为三大工作区：
   - 输入框模型选择器严格联动：仅展示当前 Agent 兼容且已启用的模型，切换 Agent 时自动恢复对应兼容偏好。页面加载或模型列表刷新不会覆盖已有的自定义模型选择。
   - 所有模型配置持久化于全局 SQLite 状态库 (`state.db`)。
 
+### 2.1 流式回复增量
+
+WebSocket 流式回复按 Provider 的消息 `itemId` 隔离累计文本；多个 agent message、工具调用和 reasoning item 交错时，不会把其他 item 的完整快照重复追加到当前回复。前端还会忽略已接收的重复累计前缀，作为传输异常时的最后一道保护。
+
 ### 3. 全局规则系统 (Global Rules)
 - 跨项目、跨 Channel（Web Console / Telegram Bot）以及跨 Agent（Codex / Claude）统一生效的规则引擎。
 - 规则分为四种级别：`advisory`（建议）、`required`（必须遵守）、`approval_required`（需审批）、`blocked`（阻断）。

--- a/server/web/server/ws/workerPromptHandler.ts
+++ b/server/web/server/ws/workerPromptHandler.ts
@@ -108,7 +108,7 @@ export function attachWorkerPromptHandler(args: {
   handleExploredEntry: (entry: ExploredEntry) => void;
   getStepTraceText: () => string;
 } {
-  let lastRespondingText = "";
+  const lastRespondingTextByItemId = new Map<string, string>();
   let lastReasoningText = "";
   let stepTraceText = "";
   const lastCommandOutputsByKey = new Map<string, string>();
@@ -178,7 +178,7 @@ export function attachWorkerPromptHandler(args: {
     if (raw.type === "turn.started") {
       logicalPlanId = null;
       latestPlan = null;
-      lastRespondingText = "";
+      lastRespondingTextByItemId.clear();
       lastReasoningText = "";
       stepTraceText = "";
     }
@@ -219,13 +219,16 @@ export function attachWorkerPromptHandler(args: {
     }
     if (event.phase === "responding" && typeof event.delta === "string" && event.delta) {
       const next = event.delta;
-      let delta = next;
-      if (lastRespondingText && next.startsWith(lastRespondingText)) {
-        delta = next.slice(lastRespondingText.length);
+      const rawItem = (raw as { item?: { id?: unknown } }).item;
+      const itemId = rawItem && typeof rawItem === "object" ? String(rawItem.id ?? "").trim() || "__unknown__" : "__unknown__";
+      const previous = lastRespondingTextByItemId.get(itemId) ?? "";
+      if (previous && !next.startsWith(previous)) {
+        // App-server agent-message updates are cumulative per item. A shorter or
+        // unrelated snapshot is a reset, not a new delta to append to the chat.
+        return;
       }
-      if (next.length >= lastRespondingText.length) {
-        lastRespondingText = next;
-      }
+      const delta = previous ? next.slice(previous.length) : next;
+      lastRespondingTextByItemId.set(itemId, next);
       if (delta) {
         args.sendToChat({ type: "delta", delta });
       }

--- a/tests/web/workerPromptHandler.test.ts
+++ b/tests/web/workerPromptHandler.test.ts
@@ -65,7 +65,35 @@ function commandEvent(args: {
   };
 }
 
+function respondingEvent(itemId: string, text: string) {
+  return {
+    phase: "responding",
+    title: "生成回复",
+    timestamp: Date.now(),
+    delta: text,
+    raw: {
+      type: "item.updated",
+      item: { type: "agent_message", id: itemId, text },
+    },
+  };
+}
+
 describe("web/server/ws/workerPromptHandler", () => {
+  it("slices cumulative responding text independently for each agent message item", () => {
+    const { emit, sent } = createHarness();
+
+    emit(respondingEvent("message-a", "First response"));
+    emit(respondingEvent("message-b", "Second response"));
+    emit(respondingEvent("message-a", "First response continued"));
+    emit(respondingEvent("message-b", "Second response continued"));
+    emit(respondingEvent("message-a", "First"));
+
+    const deltas = sent
+      .filter((payload) => (payload as { type?: unknown }).type === "delta")
+      .map((payload) => (payload as { delta?: unknown }).delta);
+    assert.deepEqual(deltas, ["First response", "Second response", " continued", " continued"]);
+  });
+
   it("forwards live agent command output without persisting replayable history", () => {
     const { emit, history, sent } = createHarness();
 


### PR DESCRIPTION
## Summary
- Track cumulative responding text independently for each provider itemId.
- Ignore non-monotonic snapshots instead of broadcasting them as fresh deltas.
- Add frontend overlap protection for repeated cumulative prefixes.
- Add backend and frontend regression tests and document the streaming contract.

## Validation
- npm run lint
- npm run typecheck
- npm run build
- npm test (969 passed)
- npm run test:web (463 passed)

Closes #101