### PR TITLE
fix(codex): auto-recover missing provider thread sessions

### DIFF
--- a/server/agents/adapters/codexAppServerAdapter.ts
+++ b/server/agents/adapters/codexAppServerAdapter.ts
@@ -36,6 +36,10 @@ import {
   readAutoCompactConfig,
   resolveAutoCompactThresholdPercent,
 } from "./autoCompactConfig.js";
+import {
+  createProviderSessionFallbackEvent,
+  isMissingProviderSessionError,
+} from "./missingProviderSession.js";
 
 const logger = createLogger("CodexAppServerAdapter");
 
@@ -532,9 +536,44 @@ export class CodexAppServerAdapter implements AgentAdapter {
         : this.spawnEnv,
     };
     const client = await this.registry.getOrStart(this.projectId, daemonOptions);
+    const savedThreadId = this.threadId;
+    let missingThreadRecovered = false;
+
+    const recoverMissingThread = (error: unknown): boolean => {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        !savedThreadId ||
+        missingThreadRecovered ||
+        this.threadId !== savedThreadId ||
+        !isMissingProviderSessionError(message)
+      ) {
+        return false;
+      }
+
+      logger.warn(
+        `[CodexAppServerAdapter] Thread ${savedThreadId} is missing; auto-starting a new thread. cause=${message}`,
+      );
+      this.threadId = null;
+      this.latestContextUsage = null;
+      missingThreadRecovered = true;
+      this.emitEvent(
+        createProviderSessionFallbackEvent({
+          agentName: "Codex app-server",
+          previousSessionId: savedThreadId,
+          message,
+        }),
+      );
+      return true;
+    };
 
     if (this.threadId) {
-      await this.maybeCompactThread(client, this.threadId, options?.signal);
+      try {
+        await this.maybeCompactThread(client, this.threadId, options?.signal);
+      } catch (error) {
+        if (!recoverMissingThread(error)) {
+          throw error;
+        }
+      }
     }
 
     const state: TurnState = {
@@ -753,31 +792,53 @@ export class CodexAppServerAdapter implements AgentAdapter {
       }
     }
 
-    try {
-      let threadId = this.threadId;
-      if (!threadId) {
-        const startResult = await client.request<Record<string, unknown>, { thread?: { id?: string } }>(
-          "thread/start",
-          this.buildThreadStartParams(),
-          { timeoutMs: this.turnTimeoutMs > 0 ? this.turnTimeoutMs : undefined },
-        );
-        const newId = startResult?.thread?.id;
-        if (typeof newId === "string" && newId.length > 0) {
-          threadId = newId;
-          this.threadId = newId;
-        } else if (state.threadIdFromStarted) {
-          threadId = state.threadIdFromStarted;
-          this.threadId = state.threadIdFromStarted;
-        } else {
-          throw new Error("codex app-server did not return a thread id");
-        }
+    const startThread = async (): Promise<string> => {
+      const startResult = await client.request<Record<string, unknown>, { thread?: { id?: string } }>(
+        "thread/start",
+        this.buildThreadStartParams(),
+        { timeoutMs: this.turnTimeoutMs > 0 ? this.turnTimeoutMs : undefined },
+      );
+      const newId = startResult?.thread?.id;
+      if (typeof newId === "string" && newId.length > 0) {
+        this.threadId = newId;
+        return newId;
       }
+      if (state.threadIdFromStarted) {
+        this.threadId = state.threadIdFromStarted;
+        return state.threadIdFromStarted;
+      }
+      throw new Error("codex app-server did not return a thread id");
+    };
 
+    const startTurn = async (threadId: string): Promise<void> => {
       await client.request(
         "turn/start",
         this.buildTurnStartParams(threadId, userInput),
         { timeoutMs: this.turnTimeoutMs > 0 ? this.turnTimeoutMs : undefined },
       );
+    };
+
+    try {
+      let threadId = this.threadId;
+      if (!threadId) {
+        threadId = await startThread();
+      }
+
+      try {
+        await startTurn(threadId);
+      } catch (error) {
+        if (!recoverMissingThread(error)) {
+          throw error;
+        }
+
+        state.threadIdFromStarted = null;
+        state.turnId = null;
+        state.failed = false;
+        state.failureMessage = null;
+
+        threadId = await startThread();
+        await startTurn(threadId);
+      }
 
       await turnPromise;
 
@@ -1008,7 +1069,13 @@ export class CodexAppServerAdapter implements AgentAdapter {
       );
       const firstError = await Promise.race([requestOutcome, completionOutcome]);
       if (firstError && !settled) {
-        requestStop(firstError);
+        if (isMissingProviderSessionError(firstError.message)) {
+          // A missing thread cannot have started a compaction turn, so it is
+          // safe to fail immediately and let sendOnce create a fresh thread.
+          finish(firstError);
+        } else {
+          requestStop(firstError);
+        }
       }
       await completion;
     } finally {

--- a/tests/codex/appServer/codexAppServerAdapter.test.ts
+++ b/tests/codex/appServer/codexAppServerAdapter.test.ts
@@ -27,7 +27,10 @@ interface FakeServer {
   requests: RpcLine[];
 }
 
-function buildFakeServer(opts?: { autoReplies?: Record<string, (msg: RpcLine) => Record<string, unknown>> }): FakeServer {
+function buildFakeServer(opts?: {
+  autoReplies?: Record<string, (msg: RpcLine) => Record<string, unknown>>;
+  autoErrors?: Record<string, (msg: RpcLine) => { code: number; message: string } | undefined>;
+}): FakeServer {
   const stdin = new PassThrough();
   const stdout = new PassThrough();
   const stderr = new PassThrough();
@@ -36,6 +39,7 @@ function buildFakeServer(opts?: { autoReplies?: Record<string, (msg: RpcLine) =>
 
   const requests: RpcLine[] = [];
   const autoReplies = opts?.autoReplies ?? {};
+  const autoErrors = opts?.autoErrors ?? {};
 
   let buf = "";
   stdin.on("data", (chunk: Buffer | string) => {
@@ -52,6 +56,11 @@ function buildFakeServer(opts?: { autoReplies?: Record<string, (msg: RpcLine) =>
         continue;
       }
       const replier = msg.method ? autoReplies[msg.method] : undefined;
+      const error = msg.method ? autoErrors[msg.method]?.(msg) : undefined;
+      if (error) {
+        stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id: msg.id, error })}\n`);
+        continue;
+      }
       if (replier) {
         const result = replier(msg);
         stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id: msg.id, result })}\n`);
@@ -226,6 +235,141 @@ describe("CodexAppServerAdapter", () => {
 
     const startsAfter = fake.requests.filter((r) => r.method === "thread/start").length;
     assert.equal(startsAfter, startsBefore, "thread/start must not be issued again");
+
+    await registry.stopAll();
+  });
+
+  it("recreates a missing resumed thread and retries the turn", async () => {
+    let turnStartAttempts = 0;
+    const fake = buildFakeServer({
+      autoReplies: {
+        "thread/start": () => ({ thread: { id: "thread-recreated" } }),
+        "turn/start": () => ({}),
+      },
+      autoErrors: {
+        "turn/start": () => {
+          turnStartAttempts += 1;
+          return turnStartAttempts === 1
+            ? { code: -32600, message: "thread not found: thread-missing" }
+            : undefined;
+        },
+      },
+    });
+    const registry = new CodexAppServerDaemonRegistry({ factory: () => fake.client });
+    const adapter = new CodexAppServerAdapter({
+      projectId: "missing-thread",
+      resumeThreadId: "thread-missing",
+      registry,
+    });
+    const events: unknown[] = [];
+    adapter.onEvent((event) => events.push(event));
+
+    const sendPromise = adapter.send("recover this thread");
+    await waitForRequestCount(fake, "turn/start", 2);
+    fake.notify("item/completed", {
+      item: { type: "agentMessage", id: "m-recovered", text: "Recovered" },
+      threadId: "thread-recreated",
+      turnId: "turn-recreated",
+    });
+    fake.notify("turn/completed", { threadId: "thread-recreated", turn: { id: "turn-recreated" } });
+
+    const result = await sendPromise;
+    assert.equal(result.response, "Recovered");
+    assert.equal(adapter.getThreadId(), "thread-recreated");
+    assert.equal(turnStartAttempts, 2);
+    assert.equal(fake.requests.filter((request) => request.method === "thread/start").length, 1);
+    assert.equal(
+      (fake.requests.filter((request) => request.method === "turn/start")[1]?.params as any).threadId,
+      "thread-recreated",
+    );
+    const fallbackEvent = events.find(
+      (event): event is { sessionFallback?: unknown } =>
+        typeof event === "object" && event !== null && "sessionFallback" in event,
+    );
+    assert(fallbackEvent, "expected a session fallback event");
+    assert.deepEqual(fallbackEvent.sessionFallback, {
+      reason: "missing_provider_session",
+      previousSessionId: "thread-missing",
+    });
+
+    await registry.stopAll();
+  });
+
+  it("recovers when auto-compaction discovers that the resumed thread is missing", async () => {
+    let threadStarts = 0;
+    const fake = buildFakeServer({
+      autoReplies: {
+        "thread/start": () => ({
+          thread: { id: threadStarts++ === 0 ? "thread-old" : "thread-fresh" },
+        }),
+        "turn/start": () => ({}),
+      },
+      autoErrors: {
+        "thread/compact/start": () => ({
+          code: -32600,
+          message: "thread not found: thread-old",
+        }),
+      },
+    });
+    const registry = new CodexAppServerDaemonRegistry({ factory: () => fake.client });
+    const adapter = new CodexAppServerAdapter({ projectId: "missing-compact-thread", registry });
+
+    const firstSend = adapter.send("seed context usage");
+    await waitForRequestCount(fake, "turn/start", 1);
+    fake.notify("thread/tokenUsage/updated", {
+      threadId: "thread-old",
+      turnId: "turn-old",
+      tokenUsage: {
+        total: { totalTokens: 800 },
+        last: { totalTokens: 800 },
+        modelContextWindow: 1_000,
+      },
+    });
+    fake.notify("turn/completed", { threadId: "thread-old", turn: { id: "turn-old" } });
+    await firstSend;
+
+    const secondSend = adapter.send("recover after compaction failure");
+    await waitForRequestCount(fake, "thread/compact/start", 1);
+    await waitForRequestCount(fake, "turn/start", 2);
+    fake.notify("item/completed", {
+      item: { type: "agentMessage", id: "m-fresh", text: "Recovered after compaction" },
+      threadId: "thread-fresh",
+      turnId: "turn-fresh",
+    });
+    fake.notify("turn/completed", { threadId: "thread-fresh", turn: { id: "turn-fresh" } });
+
+    const result = await secondSend;
+    assert.equal(result.response, "Recovered after compaction");
+    assert.equal(adapter.getThreadId(), "thread-fresh");
+    assert.equal(fake.requests.filter((request) => request.method === "thread/start").length, 2);
+
+    await registry.stopAll();
+  });
+
+  it("preserves non-missing resumed thread errors", async () => {
+    const fake = buildFakeServer({
+      autoErrors: {
+        "turn/start": () => ({ code: -32000, message: "upstream connection error" }),
+      },
+    });
+    const registry = new CodexAppServerDaemonRegistry({ factory: () => fake.client });
+    const adapter = new CodexAppServerAdapter({
+      projectId: "non-missing-thread-error",
+      resumeThreadId: "thread-still-valid",
+      registry,
+    });
+    const events: unknown[] = [];
+    adapter.onEvent((event) => events.push(event));
+
+    await assert.rejects(adapter.send("keep the saved thread"), /upstream connection error/);
+    assert.equal(fake.requests.filter((request) => request.method === "thread/start").length, 0);
+    assert.equal(fake.requests.filter((request) => request.method === "turn/start").length, 1);
+    assert.equal(
+      events.some(
+        (event) => typeof event === "object" && event !== null && "sessionFallback" in event,
+      ),
+      false,
+    );
 
     await registry.stopAll();
   });


### PR DESCRIPTION
## Summary

- Recover Codex app-server turns when a saved provider thread no longer exists.
- Emit the existing session fallback event so Web and Worker transports clear the stale saved thread and inject history on the next turn.
- Cover missing-thread errors discovered during automatic compaction as well as turn startup.

## Root Cause

CodexAppServerAdapter reused a persisted threadId and propagated thread not found errors from turn/start. The existing missing-session fallback was available to Claude CLI but was not wired into the unified Codex app-server adapter. Automatic compaction could also fail before turn/start and bypass recovery.

## Implementation

- Match only the shared missing-provider-session error classification.
- Clear the adapter thread and cached context usage, emit session_fallback, create a fresh thread, and retry the current turn once.
- Preserve non-missing errors and avoid a second recovery attempt for the newly created thread.
- Add regression coverage for turn startup, automatic compaction, event metadata, and non-missing failures.

## Verification

- npm run lint
- ./node_modules/.bin/tsc -p tsconfig.build.json --noEmit
- npm run build
- npm test — 974/974 passed before the review-driven regression cases and 976/976 passed after them
- Codex adapter tests — 21/21 passed

Closes #104