### PR TITLE
fix(web): isolate Worker and Advisor lane resets

### DIFF
--- a/client/src/__tests__/chat-composer-draft-preservation.test.ts
+++ b/client/src/__tests__/chat-composer-draft-preservation.test.ts
@@ -83,4 +83,30 @@ describe("composer draft preservation on session reset", () => {
     expect(workerRt.composerDraft.value).toBe("Worker reset draft");
     expect(plannerRt.composerDraft.value).toBe("Planner reset draft");
   });
+
+  it("scopes worker and planner backend clears to their originating lanes", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const projects = createProjectActions({ ...ctx, ...chat } as AppContext & ReturnType<typeof createChatActions>, {
+      activateProject: vi.fn(async () => {}),
+    });
+    const tasks = createTaskActions({ ...ctx, ...chat } as AppContext & ReturnType<typeof createChatActions>, {
+      connectWs: vi.fn(async () => {}),
+      connectPlannerWs: vi.fn(async () => {}),
+    });
+
+    ctx.loggedIn.value = true;
+    projects.initializeProjects();
+
+    const workerRt = ctx.activeRuntime.value;
+    const plannerRt = ctx.activePlannerRuntime.value;
+    workerRt.ws = { clearHistory: vi.fn() } as any;
+    plannerRt.ws = { clearHistory: vi.fn() } as any;
+
+    tasks.clearActiveChat();
+    tasks.clearPlannerChat();
+
+    expect(workerRt.ws?.clearHistory).toHaveBeenCalledWith({ scope: "lane", sourceChatSessionId: "main" });
+    expect(plannerRt.ws?.clearHistory).toHaveBeenCalledWith({ scope: "lane", sourceChatSessionId: "planner" });
+  });
 });

--- a/client/src/__tests__/ws-reconnect-preserve.test.ts
+++ b/client/src/__tests__/ws-reconnect-preserve.test.ts
@@ -1369,6 +1369,7 @@ describe("WS reconnect preserves UI unless thread_reset", () => {
     expect(localStorage.getItem("ads.outbox.default.main")).toBeNull();
     expect(lastWs).toBeTruthy();
     expect(lastWs!.clearHistory).toHaveBeenCalledTimes(1);
+    expect(lastWs!.clearHistory).toHaveBeenCalledWith({ scope: "lane", sourceChatSessionId: "main" });
     wrapper.unmount();
   });
 

--- a/client/src/__tests__/ws-workspace-project-sync.test.ts
+++ b/client/src/__tests__/ws-workspace-project-sync.test.ts
@@ -1021,6 +1021,24 @@ describe("ws workspace project sync", () => {
     expect(rt.activeThreadId.value).toBe("thread-keep");
   });
 
+  it("treats a reset without a scope as lane-local and requires its source lane", () => {
+    const rt = createRuntime();
+    rt.messages.value = [{ id: "u1", role: "user", kind: "text", content: "keep me" }];
+    rt.activeThreadId.value = "thread-keep";
+    const { handler, threadReset } = createHandler({
+      projects: [],
+      pid: "default",
+      rt,
+      updateProject: vi.fn(),
+    });
+
+    handler({ type: "session_reset", source: "clear_history", sourceChatSessionId: "planner" });
+
+    expect(threadReset).not.toHaveBeenCalled();
+    expect(rt.activeThreadId.value).toBe("thread-keep");
+    expect(rt.messages.value).toHaveLength(1);
+  });
+
   it("clears stale local continuity when a sibling chat lane explicitly resets the shared session", () => {
     const rt = createRuntime();
     rt.messages.value = [{ id: "u1", role: "user", kind: "text", content: "keep me" }];

--- a/client/src/app/chat.ts
+++ b/client/src/app/chat.ts
@@ -396,6 +396,21 @@ export function createChatActions(ctx: AppContext) {
     }
   };
 
+  const resolveClearHistoryPayload = (rt: ProjectRuntime, payload: unknown): unknown => {
+    const payloadRecord = payload && typeof payload === "object" && !Array.isArray(payload)
+      ? { ...(payload as Record<string, unknown>) }
+      : {};
+    const requestedScope = String(payloadRecord.scope ?? "").trim().toLowerCase();
+    if (requestedScope === "shared") {
+      return { ...payloadRecord, scope: "shared" };
+    }
+    return {
+      ...payloadRecord,
+      scope: "lane",
+      sourceChatSessionId: String(rt.chatSessionId ?? "").trim() || "main",
+    };
+  };
+
   const threadReset = (
     rt: ProjectRuntime,
     params: {
@@ -418,7 +433,7 @@ export function createChatActions(ctx: AppContext) {
     }
     if (params.clearBackendHistory) {
       rt.suppressNextClearHistoryResult = true;
-      rt.ws?.clearHistory(params.clearHistoryPayload);
+      rt.ws?.clearHistory(resolveClearHistoryPayload(rt, params.clearHistoryPayload));
     }
     recordChatClear("thread_reset", params.source ?? "unknown");
   };

--- a/client/src/app/projectsWs/wsMessage.ts
+++ b/client/src/app/projectsWs/wsMessage.ts
@@ -649,9 +649,9 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
 
   const handleSharedSessionReset = (payload: Record<string, unknown>): void => {
     const effectiveChatSessionId = String(rt.chatSessionId ?? "").trim() || "main";
-    const resetScope = String(payload.scope ?? "").trim().toLowerCase() || "shared";
+    const resetScope = String(payload.scope ?? "").trim().toLowerCase() || "lane";
     const sourceChatSessionId = String(payload.sourceChatSessionId ?? "").trim();
-    if (resetScope === "lane" && sourceChatSessionId && sourceChatSessionId !== effectiveChatSessionId) {
+    if (resetScope !== "shared" && sourceChatSessionId !== effectiveChatSessionId) {
       return;
     }
     const hasVisibleLocalContinuity =

--- a/client/src/app/tasks.ts
+++ b/client/src/app/tasks.ts
@@ -609,6 +609,11 @@ export function createTaskActions(ctx: AppContext & ChatActions, deps: TaskDeps)
     interruptRuntime(activePlannerRuntime.value);
   };
 
+  const laneClearHistoryPayload = (rt: ProjectRuntime): { scope: "lane"; sourceChatSessionId: string } => ({
+    scope: "lane",
+    sourceChatSessionId: String(rt.chatSessionId ?? "").trim() || "main",
+  });
+
   const clearActiveChat = (): void => {
     const rt = activeRuntime.value;
     rt.queuedPrompts.value = [];
@@ -618,6 +623,7 @@ export function createTaskActions(ctx: AppContext & ChatActions, deps: TaskDeps)
       warning: null,
       keepLatestTurn: false,
       clearBackendHistory: true,
+      clearHistoryPayload: laneClearHistoryPayload(rt),
       resetThreadId: true,
       source: "user_reset_thread",
     });
@@ -632,6 +638,7 @@ export function createTaskActions(ctx: AppContext & ChatActions, deps: TaskDeps)
       warning: null,
       keepLatestTurn: false,
       clearBackendHistory: true,
+      clearHistoryPayload: laneClearHistoryPayload(rt),
       resetThreadId: true,
       source: "user_clear_planner_context",
     });

--- a/docs/web.md
+++ b/docs/web.md
@@ -54,6 +54,7 @@ WebSocket 流式回复按 Provider 的消息 `itemId` 隔离累计文本；多�
 - 会话文件健康判定：断线或重连时若会话文件存在则原生恢复，缺失时平滑降级并友好提示。
 - 新建聊天会话时，在线 WebSocket 通过原连接内协议切换 session；连接状态保持在线，离线时自动回退到完整重连。
 - 清空或新建会话不会删除 Composer 中尚未提交的草稿文本；每轮消息中的 Plan、实时活动、Thought、Execute 与 Patch 卡片按稳定语义顺序展示，已完成的阶段 trace 会在历史重放时保留为可折叠 Thought 卡片。
+- Worker 与 Advisor 的清空操作默认只作用于发起操作的 chat lane；跨 lane 清理必须显式请求 shared scope，且 session reset 广播会校验来源 lane。
 
 ### 5. 多模态与文件联动
 - **多模态图片附件**：支持拖拽、粘贴与上传图片，MainChat 与任务创建表单均提供紧凑缩略图预览与大图查看器。


### PR DESCRIPTION
## Summary

Fixes #105. Worker and Advisor reset events are now explicitly scoped to their originating chat lane.

## Root cause

The server already defaulted clear_history to lane scope and filtered lane broadcasts, but the client reset handler treated a missing scope as shared. That made legacy or incomplete session_reset payloads clear every active runtime. User-triggered Worker and Advisor clear operations also omitted the lane identity, so the client and server had no end-to-end lane contract.

## Changes

- Treat missing reset scope as lane-local in the client.
- Ignore non-shared reset events unless sourceChatSessionId exactly matches the current runtime lane.
- Send explicit lane scope and source chat session ID for Worker and Advisor clear operations.
- Preserve explicit shared scope for intentional project-wide resets.
- Document the lane reset contract.

## Validation

- npm run lint
- npm run build
- npm run test:web -- --run client/src/__tests__/ws-workspace-project-sync.test.ts client/src/__tests__/chat-composer-draft-preservation.test.ts client/src/__tests__/ws-reconnect-preserve.test.ts
- npm test
- Direct WebSocket and path traversal tests: 11/11 passed
- Full server test suite: 973/973 passed

No deployment or service restart was performed.