### PR TITLE
fix(codex): resume persisted threads via thread/resume

### DIFF
--- a/server/agents/adapters/codexAppServerAdapter.ts
+++ b/server/agents/adapters/codexAppServerAdapter.ts
@@ -253,6 +253,7 @@ export class CodexAppServerAdapter implements AgentAdapter {
   private readonly listeners = new Set<(event: AgentEvent) => void>();
   private readonly goalUpdateHandlers = new Set<(goal: ThreadGoal) => void>();
   private readonly goalClearedHandlers = new Set<() => void>();
+  private readonly loadedThreadsByClient = new WeakMap<CodexAppServerClient, Set<string>>();
   private goalSubscriptionsAttached = false;
   private goalSubscriptionCleanup: Array<() => void> = [];
 
@@ -556,15 +557,40 @@ export class CodexAppServerAdapter implements AgentAdapter {
       this.threadId = null;
       this.latestContextUsage = null;
       missingThreadRecovered = true;
-      this.emitEvent(
-        createProviderSessionFallbackEvent({
-          agentName: "Codex app-server",
-          previousSessionId: savedThreadId,
-          message,
-        }),
+     this.emitEvent(
+       createProviderSessionFallbackEvent({
+         agentName: "Codex app-server",
+         previousSessionId: savedThreadId,
+         message,
+       }),
+     );
+     return true;
+   };
+
+    const resumeThread = async (id: string): Promise<string> => {
+      const resumeResult = await client.request<Record<string, unknown>, { thread?: { id?: string } }>(
+        "thread/resume",
+        this.buildThreadResumeParams(id),
+        { timeoutMs: this.turnTimeoutMs > 0 ? this.turnTimeoutMs : undefined },
       );
-      return true;
+      const resumedId =
+        typeof resumeResult?.thread?.id === "string" && resumeResult.thread.id.length > 0
+          ? resumeResult.thread.id
+          : id;
+      this.markThreadLoaded(client, resumedId);
+      this.threadId = resumedId;
+      return resumedId;
     };
+
+    if (this.threadId && !this.isThreadLoaded(client, this.threadId)) {
+      try {
+        await resumeThread(this.threadId);
+      } catch (error) {
+        if (!recoverMissingThread(error)) {
+          throw error;
+        }
+      }
+    }
 
     if (this.threadId) {
       try {
@@ -798,16 +824,18 @@ export class CodexAppServerAdapter implements AgentAdapter {
         this.buildThreadStartParams(),
         { timeoutMs: this.turnTimeoutMs > 0 ? this.turnTimeoutMs : undefined },
       );
-      const newId = startResult?.thread?.id;
-      if (typeof newId === "string" && newId.length > 0) {
-        this.threadId = newId;
-        return newId;
-      }
-      if (state.threadIdFromStarted) {
-        this.threadId = state.threadIdFromStarted;
-        return state.threadIdFromStarted;
-      }
-      throw new Error("codex app-server did not return a thread id");
+     const newId = startResult?.thread?.id;
+     if (typeof newId === "string" && newId.length > 0) {
+       this.threadId = newId;
+       this.markThreadLoaded(client, newId);
+       return newId;
+     }
+     if (state.threadIdFromStarted) {
+       this.threadId = state.threadIdFromStarted;
+       this.markThreadLoaded(client, state.threadIdFromStarted);
+       return state.threadIdFromStarted;
+     }
+     throw new Error("codex app-server did not return a thread id");
     };
 
     const startTurn = async (threadId: string): Promise<void> => {
@@ -1100,10 +1128,41 @@ export class CodexAppServerAdapter implements AgentAdapter {
       params.sandbox = "read-only";
     } else if (this.sandboxMode === "danger-full-access") {
       params.sandbox = "danger-full-access";
+   } else {
+     params.sandbox = "workspace-write";
+   }
+   return params;
+ }
+
+  private buildThreadResumeParams(threadId: string): Record<string, unknown> {
+    const params: Record<string, unknown> = {
+      threadId,
+      persistExtendedHistory: false,
+    };
+    if (this.workingDirectory) params.cwd = this.workingDirectory;
+    if (this.model) params.model = this.model;
+    if (this.developerInstructions) params.developerInstructions = this.developerInstructions;
+    if (this.sandboxMode === "read-only") {
+      params.sandbox = "read-only";
+    } else if (this.sandboxMode === "danger-full-access") {
+      params.sandbox = "danger-full-access";
     } else {
       params.sandbox = "workspace-write";
     }
     return params;
+  }
+
+  private isThreadLoaded(client: CodexAppServerClient, threadId: string): boolean {
+    return this.loadedThreadsByClient.get(client)?.has(threadId) ?? false;
+  }
+
+  private markThreadLoaded(client: CodexAppServerClient, threadId: string): void {
+    let set = this.loadedThreadsByClient.get(client);
+    if (!set) {
+      set = new Set();
+      this.loadedThreadsByClient.set(client, set);
+    }
+    set.add(threadId);
   }
 
   private buildTurnStartParams(threadId: string, input: UserInputPart[]): Record<string, unknown> {

--- a/tests/codex/appServer/codexAppServerAdapter.test.ts
+++ b/tests/codex/appServer/codexAppServerAdapter.test.ts
@@ -51,11 +51,21 @@ function buildFakeServer(opts?: {
       if (!line.trim()) continue;
       const msg = JSON.parse(line) as RpcLine;
       requests.push(msg);
-      if (msg.method === "initialize") {
-        stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: {} })}\n`);
-        continue;
-      }
-      const replier = msg.method ? autoReplies[msg.method] : undefined;
+     if (msg.method === "initialize") {
+       stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: {} })}\n`);
+       continue;
+     }
+     if (msg.method === "thread/resume" && !autoReplies["thread/resume"] && !autoErrors["thread/resume"]) {
+       stdout.write(
+         `${JSON.stringify({
+           jsonrpc: "2.0",
+           id: msg.id,
+           result: { thread: { id: msg.params?.threadId ?? "thread-resumed" } },
+         })}\n`,
+       );
+       continue;
+     }
+     const replier = msg.method ? autoReplies[msg.method] : undefined;
       const error = msg.method ? autoErrors[msg.method]?.(msg) : undefined;
       if (error) {
         stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id: msg.id, error })}\n`);
@@ -233,8 +243,119 @@ describe("CodexAppServerAdapter", () => {
     fake.notify("turn/completed", { threadId: "thread-1", turn: { id: "t2" } });
     await secondSend;
 
-    const startsAfter = fake.requests.filter((r) => r.method === "thread/start").length;
-    assert.equal(startsAfter, startsBefore, "thread/start must not be issued again");
+   const startsAfter = fake.requests.filter((r) => r.method === "thread/start").length;
+   assert.equal(startsAfter, startsBefore, "thread/start must not be issued again");
+
+   await registry.stopAll();
+ });
+
+  it("resumes an existing persisted thread via thread/resume before turn start", async () => {
+    let resumeCalls = 0;
+    const fake = buildFakeServer({
+      autoReplies: {
+        "thread/resume": (msg) => {
+          resumeCalls += 1;
+          return { thread: { id: msg.params?.threadId } };
+        },
+        "turn/start": () => ({}),
+      },
+    });
+    const registry = new CodexAppServerDaemonRegistry({ factory: () => fake.client });
+    const adapter = new CodexAppServerAdapter({
+      projectId: "resume-thread-test",
+      resumeThreadId: "thread-persisted-abc",
+      registry,
+    });
+    const events: unknown[] = [];
+    adapter.onEvent((event) => events.push(event));
+
+    const sendPromise = adapter.send("hello from resumed thread");
+    await waitForRequestCount(fake, "thread/resume", 1);
+    await waitForRequestCount(fake, "turn/start", 1);
+    fake.notify("item/completed", {
+      item: { type: "agentMessage", id: "m-resumed", text: "Welcome back" },
+      threadId: "thread-persisted-abc",
+      turnId: "turn-resumed",
+    });
+    fake.notify("turn/completed", { threadId: "thread-persisted-abc", turn: { id: "turn-resumed" } });
+
+    const result = await sendPromise;
+    assert.equal(result.response, "Welcome back");
+    assert.equal(adapter.getThreadId(), "thread-persisted-abc");
+    assert.equal(resumeCalls, 1);
+    assert.equal(fake.requests.filter((request) => request.method === "thread/start").length, 0);
+    assert.equal(
+      (fake.requests.find((request) => request.method === "turn/start")?.params as any)?.threadId,
+      "thread-persisted-abc",
+    );
+    const hasFallback = events.some(
+      (event) => typeof event === "object" && event !== null && "sessionFallback" in event,
+    );
+    assert.equal(hasFallback, false, "must not emit sessionFallback on successful resume");
+
+    // On second send, thread is already loaded in client, must not call thread/resume again
+    const secondSendPromise = adapter.send("second message");
+    await waitForRequestCount(fake, "turn/start", 2);
+    assert.equal(fake.requests.filter((request) => request.method === "thread/resume").length, 1);
+    fake.notify("item/completed", {
+      item: { type: "agentMessage", id: "m-second", text: "Second reply" },
+      threadId: "thread-persisted-abc",
+      turnId: "turn-second",
+    });
+    fake.notify("turn/completed", { threadId: "thread-persisted-abc", turn: { id: "turn-second" } });
+    await secondSendPromise;
+
+    await registry.stopAll();
+  });
+
+  it("recreates a missing thread when thread/resume reports no rollout found", async () => {
+    const fake = buildFakeServer({
+      autoReplies: {
+        "thread/start": () => ({ thread: { id: "thread-new-from-missing" } }),
+        "turn/start": () => ({}),
+      },
+      autoErrors: {
+        "thread/resume": () => ({
+          code: -32600,
+          message: "thread/resume: thread/resume failed: no rollout found for thread id thread-deleted",
+        }),
+      },
+    });
+    const registry = new CodexAppServerDaemonRegistry({ factory: () => fake.client });
+    const adapter = new CodexAppServerAdapter({
+      projectId: "missing-on-resume",
+      resumeThreadId: "thread-deleted",
+      registry,
+    });
+    const events: unknown[] = [];
+    adapter.onEvent((event) => events.push(event));
+
+    const sendPromise = adapter.send("recover from deleted thread");
+    await waitForRequestCount(fake, "thread/resume", 1);
+    await waitForRequestCount(fake, "thread/start", 1);
+    await waitForRequestCount(fake, "turn/start", 1);
+    fake.notify("item/completed", {
+      item: { type: "agentMessage", id: "m-recovered", text: "Recovered" },
+      threadId: "thread-new-from-missing",
+      turnId: "turn-recovered",
+    });
+    fake.notify("turn/completed", {
+      threadId: "thread-new-from-missing",
+      turn: { id: "turn-recovered" },
+    });
+
+    const result = await sendPromise;
+    assert.equal(result.response, "Recovered");
+    assert.equal(adapter.getThreadId(), "thread-new-from-missing");
+    const fallbackEvent = events.find(
+      (event): event is { sessionFallback?: unknown } =>
+        typeof event === "object" && event !== null && "sessionFallback" in event,
+    );
+    assert(fallbackEvent, "expected a session fallback event");
+    assert.deepEqual(fallbackEvent.sessionFallback, {
+      reason: "missing_provider_session",
+      previousSessionId: "thread-deleted",
+    });
 
     await registry.stopAll();
   });


### PR DESCRIPTION
## Summary
- Resume persisted thread IDs via `thread/resume` before starting turns in `CodexAppServerAdapter`.
- Track whether a thread has already been loaded in the active daemon client to avoid duplicate resume calls.
- Fall back to fresh thread creation only when `thread/resume` confirms the session is missing on disk.
- Add unit tests verifying successful thread resume and fallback on missing rollout.

## Root Cause
When `CodexAppServerAdapter` was initialized with a persisted `resumeThreadId`, it previously called `turn/start` directly without loading the thread via `thread/resume`. When the daemon restarted or was spawned anew, the thread was not present in memory, causing `turn/start` to return `thread not found`, which triggered a self-destructive fallback that cleared the saved ID and degraded into history text injection.

## Verification
- `npm run lint` — passed
- `./node_modules/.bin/tsc -p tsconfig.build.json --noEmit` — passed
- `npm run build` — passed
- `node --import tsx/esm --test tests/codex/appServer/codexAppServerAdapter.test.ts` — 23/23 passed

Closes #115