### PR TITLE
fix(web): deduplicate lane warnings and stabilize tab row layout

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -581,14 +581,6 @@
   flex: 1 1 auto;
 }
 
-.laneTabWarning {
-  font-size: 12px;
-  line-height: 1.35;
-  color: #c2410c;
-  word-break: break-word;
-  min-width: 0;
-}
-
 .laneTabIconBtn {
   flex: 0 0 auto;
   width: 28px;
@@ -623,6 +615,8 @@
   padding: 8px 14px;
   border-radius: 12px;
   cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
   transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
 
@@ -1041,5 +1035,6 @@
   .laneTab {
     flex: 1 1 0;
     min-width: 0;
+    white-space: nowrap;
   }
 }

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -216,7 +216,6 @@ const {
   resumableSessionsNextCursor,
   resumeThreadBlocked,
   activeLaneBusy,
-  activeLaneThreadWarning,
   activeLaneHasResume,
   activeLaneNewSessionBlocked,
   handleLaneNewSession,
@@ -903,9 +902,6 @@ const plannerConnectionStatus = computed(() => {
           >
             {{ tab.label }}
           </button>
-          <span v-if="activeWorkspaceTab !== 'tasks' && activeLaneThreadWarning" class="laneTabWarning" data-testid="lane-thread-warning">
-            {{ activeLaneThreadWarning }}
-          </span>
           <span v-if="!isMobile" class="laneTabSpacer" />
           <button
             v-if="!isMobile && activeLaneHasResume"

--- a/client/src/__tests__/mobile-pane-tabs.test.ts
+++ b/client/src/__tests__/mobile-pane-tabs.test.ts
@@ -77,4 +77,11 @@ describe("mobile navigation shell", () => {
     expect(sfc).toContain('v-if="!isMobile && activeLaneHasResume"');
     expect(sfc).toContain('v-if="!isMobile"\n            class="laneTabIconBtn"');
   });
+
+  it("keeps lane tab row free of duplicate warning banners", async () => {
+    const sfc = await readSfc("../App.vue", import.meta.url);
+    expect(sfc).not.toContain('class="laneTabWarning"');
+    expect(sfc).not.toContain('data-testid="lane-thread-warning"');
+    expect(sfc).not.toContain("activeLaneThreadWarning");
+  });
 });

--- a/client/src/__tests__/ws-workspace-project-sync.test.ts
+++ b/client/src/__tests__/ws-workspace-project-sync.test.ts
@@ -1124,6 +1124,28 @@ describe("ws workspace project sync", () => {
     expect(rt.threadWarning.value).toContain("下一轮将注入聊天历史");
   });
 
+  it("routes session_fallback to laneStatus without duplicating into threadWarning", () => {
+    const rt = createRuntime();
+    const updateProject = vi.fn();
+    const { handler } = createHandler({
+      projects: [],
+      pid: "default",
+      rt,
+      updateProject,
+    });
+
+    handler({
+      type: "session_fallback",
+      message: "原生会话已不存在，已改用新会话继续（not found）。",
+    });
+
+    expect(rt.laneStatus.value).toEqual({
+      kind: "info",
+      message: "原生会话已不存在，已改用新会话继续（not found）。",
+    });
+    expect(rt.threadWarning.value).toBeNull();
+  });
+
   it("renders a plan WS broadcast as a plan chat item with checklist", () => {
     const rt = createRuntime();
     const updateProject = vi.fn();

--- a/client/src/app/projectsWs/wsMessage.ts
+++ b/client/src/app/projectsWs/wsMessage.ts
@@ -1031,14 +1031,14 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
 
     if (type === "session_fallback") {
       // The provider lost the session mid-turn: this turn already ran without
-      // the old context, so say so instead of leaving the thread looking resumed.
+      // the old context, so say so in the composer status surface.
       const rec = msg as Record<string, unknown>;
       const message = String(rec.message ?? "").trim();
       rt.laneStatus.value = {
         kind: "info",
-        message: message || "原生会话已不存在，已改用新会话继续。",
+        message: message || "原生会话已不存在，已改用新会话继续；下一轮会带上最近聊天历史。",
       };
-      rt.threadWarning.value = "原生会话已不存在，本轮已改用新会话；下一轮会带上最近聊天历史。";
+      rt.threadWarning.value = null;
       return;
     }
 


### PR DESCRIPTION
## Summary
- Consolidate session fallback notices into the composer status surface (`rt.laneStatus`).
- Remove duplicate inline warning text (`laneTabWarning`) from the top workspace tab row.
- Stabilize `Advisor` and `Worker` tab layout to prevent compression or overlap on narrow/mobile viewports.
- Add regression coverage for deduplicated warning dispatch and clean tab-row markup.

## Root Cause
When session fallback occurred, `wsMessage.ts` set both `rt.laneStatus` (rendered above the composer) and `rt.threadWarning` (rendered directly inside the top `.laneTabs` bar). The long text warning squeezed the horizontal flex space of the navigation tabs, causing text overlap and wrapping on small widths while showing the same message twice.

## Verification
- `npm run lint` — passed
- `./node_modules/.bin/tsc -p tsconfig.build.json --noEmit` — passed
- `npm run build` — passed
- `npx vitest --config client/vitest.config.ts run client/src/__tests__/mobile-pane-tabs.test.ts client/src/__tests__/ws-workspace-project-sync.test.ts` — 45/45 passed

Closes #114