### PR TITLE
fix(web): keep live process steps current

### DIFF
--- a/client/src/__tests__/chat-streaming-dedup.test.ts
+++ b/client/src/__tests__/chat-streaming-dedup.test.ts
@@ -50,4 +50,45 @@ describe("chat streaming duplicate protection", () => {
 
     expect(messages.value[0]?.content).toBe(current + incoming);
   });
+
+  it("replaces the live process snapshot and preserves command cards", () => {
+    const { messages, runtime, streaming } = createHarness([
+      { id: "u-1", role: "user", kind: "text", content: "run the task" },
+      { id: "exec-1", role: "system", kind: "execute", content: "$ npm test\n", command: "npm test", streaming: false },
+    ]);
+
+    streaming.upsertStepLiveDelta("[tool] Inspecting workspace\n", runtime);
+    streaming.upsertStepLiveDelta("[editing] Updating source file\n", runtime);
+
+    const liveSteps = messages.value.filter((message) => message.id === "live-step");
+    expect(liveSteps).toHaveLength(1);
+    expect(liveSteps[0]?.content).toBe("[editing] Updating source file\n");
+    expect(liveSteps[0]?.content).not.toContain("Inspecting workspace");
+    expect(messages.value.find((message) => message.id === "exec-1")?.content).toBe("$ npm test\n");
+  });
+
+  it("does not replace a substantive snapshot with ignored analysis noise", () => {
+    const { messages, runtime, streaming } = createHarness();
+
+    streaming.upsertStepLiveDelta("[tool] Inspecting workspace\n", runtime);
+    streaming.upsertStepLiveDelta("[analysis] Reasoning\n", runtime);
+
+    expect(messages.value.find((message) => message.id === "live-step")?.content).toBe("[tool] Inspecting workspace\n");
+  });
+
+  it("promotes only the latest live snapshot when the turn completes", () => {
+    const { messages, runtime, streaming } = createHarness([
+      { id: "u-1", role: "user", kind: "text", content: "run the task" },
+      { id: "a-1", role: "assistant", kind: "text", content: "Done", streaming: true },
+    ]);
+
+    streaming.upsertStepLiveDelta("[tool] Inspecting workspace\n", runtime);
+    streaming.upsertStepLiveDelta("[editing] Updating source file\n", runtime);
+    streaming.clearStepLive(runtime);
+
+    expect(messages.value.find((message) => message.id === "live-step")).toBeUndefined();
+    expect(messages.value.filter((message) => message.kind === "thought")).toHaveLength(1);
+    expect(messages.value.find((message) => message.kind === "thought")?.content).toBe("[editing] Updating source file");
+    expect(messages.value.some((message) => message.content.includes("Inspecting workspace"))).toBe(false);
+  });
 });

--- a/client/src/__tests__/chat-streaming-dedup.test.ts
+++ b/client/src/__tests__/chat-streaming-dedup.test.ts
@@ -3,6 +3,8 @@ import { ref } from "vue";
 
 import type { ChatItem, ProjectRuntime } from "../app/controller";
 import { createStreamingActions } from "../app/chatStreaming";
+import { findLastLiveIndex, isLiveMessageId } from "../app/chatLive";
+import { normalizeTurnSemanticOrder } from "../lib/chat_sync";
 
 function createHarness(initial: ChatItem[] = []) {
   const messages = ref<ChatItem[]>(initial);
@@ -16,11 +18,11 @@ function createHarness(initial: ChatItem[] = []) {
     liveActivityId: "live-activity",
     runtimeOrActive: () => runtime,
     setMessages: (items) => {
-      messages.value = items;
+      messages.value = normalizeTurnSemanticOrder(items);
     },
     dropEmptyAssistantPlaceholder: () => {},
-    findLastLiveIndex: () => -1,
-    isLiveMessageId: (id) => id === "live-step" || id === "live-activity",
+    findLastLiveIndex,
+    isLiveMessageId,
     randomId: (prefix) => `${prefix}-1`,
   });
   return { messages, runtime, streaming };
@@ -65,6 +67,7 @@ describe("chat streaming duplicate protection", () => {
     expect(liveSteps[0]?.content).toBe("[editing] Updating source file\n");
     expect(liveSteps[0]?.content).not.toContain("Inspecting workspace");
     expect(messages.value.find((message) => message.id === "exec-1")?.content).toBe("$ npm test\n");
+    expect(messages.value.map((message) => message.id)).toEqual(["u-1", "live-step", "exec-1"]);
   });
 
   it("does not replace a substantive snapshot with ignored analysis noise", () => {

--- a/client/src/app/chatStreaming.ts
+++ b/client/src/app/chatStreaming.ts
@@ -11,7 +11,7 @@ function stripStreamingOverlap(current: string, incoming: string): string {
   return incoming;
 }
 
-function trimToLastLines(text: string, maxLines: number, maxChars = 2500): string {
+function trimLiveStepSnapshot(text: string, maxLines: number, maxChars = 2500): string {
   const normalized = String(text ?? "");
   const recent = normalized.length > maxChars ? normalized.slice(normalized.length - maxChars) : normalized;
   const lines = recent.split("\n");
@@ -151,13 +151,15 @@ export function createStreamingActions(params: {
 
   const upsertStepLiveDelta = (delta: string, rt?: ProjectRuntime): void => {
     const state = runtimeOrActive(rt);
-    dropEmptyAssistantPlaceholder(state);
     const chunk = String(delta ?? "");
-    if (!chunk) return;
+    if (!chunk || shouldIgnoreStepDelta(chunk)) return;
+    dropEmptyAssistantPlaceholder(state);
     const existing = state.messages.value.slice();
     const idx = existing.findIndex((m) => m.id === liveStepId);
-    const current = idx >= 0 ? existing[idx]!.content : "";
-    const nextText = trimToLastLines(current + chunk, 14);
+    // Step events are status snapshots. The wire field remains `delta` for
+    // protocol compatibility, but the live card must show only the newest
+    // substantive snapshot instead of an append-only transcript.
+    const nextText = trimLiveStepSnapshot(chunk, 14);
     const nextItem: ChatItem = {
       id: liveStepId,
       role: "assistant",
@@ -217,7 +219,7 @@ export function createStreamingActions(params: {
     clearLiveActivityWindow(state.liveActivity);
     const existing = state.messages.value.slice();
     const stepMsg = existing.find((m) => m.id === liveStepId);
-    const stepContent = String(stepMsg?.content ?? "").trim();
+    const stepContent = trimLiveStepSnapshot(String(stepMsg?.content ?? "").trim(), 14).trim();
 
     const next = existing.filter((m) => !isLiveMessageId(m.id));
     if (stepContent && !shouldIgnoreStepDelta(stepContent)) {

--- a/docs/web.md
+++ b/docs/web.md
@@ -27,7 +27,7 @@ Web Console 将对话与任务流组织为三大工作区：
 - **Worker (执行 Lane)**：
   - 专注于代码执行、命令运行与文件修改的执行 Lane。
   - 若任务带有本地 issue/spec 快照，执行时先读取批准时固定的内容；没有快照时直接以任务 prompt 及其 GitHub 引用作为执行依据。
-  - 实时展示任务阶段 trace（如 `[analysis]`、`[tool]`、`[editing]`）与命令执行输出（最新命令预览），阶段 trace 只显示简洁语义标签；重复的 reasoning 生命周期噪声不会写入历史 thought；文件路径和变更明细由 Patch 卡片展示，自动收起长文本输出。
+  - 实时展示任务阶段 trace（如 `[analysis]`、`[tool]`、`[editing]`）与命令执行输出（最新命令预览）；阶段 trace 使用单个可变过程卡片，只显示最新的实质阶段快照，不把历史步骤累积到同一块；重复的 reasoning 生命周期噪声不会写入历史 thought，完成后保留的 Thought 也只包含紧凑的最新阶段快照；文件路径和变更明细由 Patch 卡片展示，自动收起长文本输出。
   - Plan 卡片按单轮逻辑计划合并 provider 更新，并在任务完成与历史重连时保持唯一且状态一致。
 
 ### 2. Provider CLI 与全局模型配置 (Provider & Models)
@@ -58,7 +58,7 @@ WebSocket 流式回复按 Provider 的消息 `itemId` 隔离累计文本；多�
 - 新建聊天会话时，在线 WebSocket 通过原连接内协议切换 session；连接状态保持在线，离线时自动回退到完整重连。
 - 重连或后端重启后，只要持久化历史存在就会发送历史快照；即使后端上下文暂时是 fresh，客户端也保留本地聊天记录，只有显式线程重置才会清空历史。
 - Bootstrap 等待期间提交的提示会进入持久 outbox，待历史同步完成后继续发送；若历史帧丢失，5 秒兜底会解除等待锁，避免 Composer 永久冻结。
-- 清空或新建会话不会删除 Composer 中尚未提交的草稿文本；每轮消息中的 Plan、实时活动、Thought、Execute 与 Patch 卡片按稳定语义顺序展示，已完成的阶段 trace 会在历史重放时保留为可折叠 Thought 卡片。
+- 清空或新建会话不会删除 Composer 中尚未提交的草稿文本；每轮消息中的 Plan、实时活动、Thought、Execute 与 Patch 卡片按稳定语义顺序展示，活动中的 live-step 只保留最新阶段快照，完成后该快照会作为可折叠 Thought 卡片保留在历史重放中。
 - Worker 与 Advisor 的清空操作默认只作用于发起操作的 chat lane；跨 lane 清理必须显式请求 shared scope，且 session reset 广播会校验来源 lane。
 
 ### 5. 多模态与文件联动

--- a/server/web/server/ws/workerPromptHandler.ts
+++ b/server/web/server/ws/workerPromptHandler.ts
@@ -1,7 +1,7 @@
 import type { ThreadEvent } from "../../../agents/protocol/types.js";
 
 import { isTransientUpstreamModelError } from "../../../agents/adapters/transientModelRetry.js";
-import { formatStepTraceLine, isStepTracePhase, type AgentEvent } from "../../../codex/events.js";
+import { formatStepTraceLine, hasSubstantiveStepTrace, isStepTracePhase, type AgentEvent } from "../../../codex/events.js";
 import type { ExploredEntry } from "../../../utils/activityTracker.js";
 import { buildWorkspacePatch } from "../../gitPatch.js";
 import type { HistoryStore } from "../../../utils/historyStore.js";
@@ -110,7 +110,7 @@ export function attachWorkerPromptHandler(args: {
 } {
   const lastRespondingTextByItemId = new Map<string, string>();
   let lastReasoningText = "";
-  let stepTraceText = "";
+  let latestStepTraceText = "";
   const lastCommandOutputsByKey = new Map<string, string>();
   const announcedCommandKeys = new Set<string>();
   const terminalCommandKeys = new Set<string>();
@@ -180,7 +180,7 @@ export function attachWorkerPromptHandler(args: {
       latestPlan = null;
       lastRespondingTextByItemId.clear();
       lastReasoningText = "";
-      stepTraceText = "";
+      latestStepTraceText = "";
     }
     if (raw.type === "thread.started" && raw.thread_id) {
       args.onThreadStarted?.(raw.thread_id);
@@ -264,7 +264,6 @@ export function attachWorkerPromptHandler(args: {
       lastReasoningText = next;
       if (delta) {
         const payload = prev ? delta : `[analysis] ${delta}`;
-        stepTraceText += payload;
         args.sendToChat({ type: "delta", delta: payload, source: "step" });
       }
       return;
@@ -317,7 +316,11 @@ export function attachWorkerPromptHandler(args: {
     if (isStepTracePhase(event.phase)) {
       const line = formatStepTraceLine(event);
       if (line) {
-        stepTraceText += line;
+        // Keep the completion thought aligned with the live card: only the
+        // newest substantive stage is retained, never the full event history.
+        if (hasSubstantiveStepTrace(line)) {
+          latestStepTraceText = line;
+        }
         args.sendToChat({ type: "delta", delta: line, source: "step" });
       }
     }
@@ -407,6 +410,6 @@ export function attachWorkerPromptHandler(args: {
   return {
     unsubscribe,
     handleExploredEntry,
-    getStepTraceText: () => stepTraceText,
+    getStepTraceText: () => latestStepTraceText,
   };
 }

--- a/server/web/server/ws/workerPromptHandler.ts
+++ b/server/web/server/ws/workerPromptHandler.ts
@@ -263,7 +263,10 @@ export function attachWorkerPromptHandler(args: {
       }
       lastReasoningText = next;
       if (delta) {
-        const payload = prev ? delta : `[analysis] ${delta}`;
+        // Keep every reasoning fragment classified as analysis. The client
+        // intentionally filters this lifecycle noise so it cannot replace a
+        // substantive live step or diverge from the completion thought.
+        const payload = `[analysis] ${delta}`;
         args.sendToChat({ type: "delta", delta: payload, source: "step" });
       }
       return;

--- a/tests/web/workerPromptHandler.test.ts
+++ b/tests/web/workerPromptHandler.test.ts
@@ -78,6 +78,19 @@ function respondingEvent(itemId: string, text: string) {
   };
 }
 
+function reasoningEvent(text: string) {
+  return {
+    phase: "analysis",
+    title: "Reasoning",
+    timestamp: Date.now(),
+    delta: text,
+    raw: {
+      type: "item.updated",
+      item: { type: "reasoning", id: "reasoning-1", text },
+    },
+  };
+}
+
 describe("web/server/ws/workerPromptHandler", () => {
   it("slices cumulative responding text independently for each agent message item", () => {
     const { emit, sent } = createHarness();
@@ -154,6 +167,33 @@ describe("web/server/ws/workerPromptHandler", () => {
     ]);
     assert.equal(sent.filter((payload) => (payload as { type?: unknown }).type === "command").length, 1);
     assert.deepEqual(history, []);
+  });
+
+  it("keeps incremental reasoning classified as noise and preserves the completion snapshot", () => {
+    const { emit, handler, sent } = createHarness();
+
+    emit({
+      phase: "tool",
+      title: "Inspecting workspace",
+      detail: "bash",
+      timestamp: 1,
+      raw: { type: "item.started", item: { type: "tool_call" } },
+    });
+    emit(reasoningEvent("first reasoning"));
+    emit(reasoningEvent("first reasoning plus follow-up"));
+
+    const stepDeltas = sent
+      .filter((payload) => {
+        const item = payload as { type?: unknown; source?: unknown };
+        return item.type === "delta" && item.source === "step";
+      })
+      .map((payload) => (payload as { delta?: unknown }).delta);
+    assert.deepEqual(stepDeltas, [
+      "[tool] Inspecting workspace: bash\n",
+      "[analysis] first reasoning",
+      "[analysis]  plus follow-up",
+    ]);
+    assert.equal(handler.getStepTraceText(), "[tool] Inspecting workspace: bash\n");
   });
 
   it("forwards failed agent command completion without persisting replayable history", () => {

--- a/tests/web/workerPromptHandler.test.ts
+++ b/tests/web/workerPromptHandler.test.ts
@@ -122,31 +122,37 @@ describe("web/server/ws/workerPromptHandler", () => {
     assert.equal(sent.filter((payload) => (payload as { type?: unknown }).type === "command").length, 3);
   });
 
-  it("accumulates replayable step traces without mixing them into command history", () => {
-    const { emit, handler, history } = createHarness();
+  it("keeps only the latest substantive step snapshot without mixing it into command history", () => {
+    const { emit, handler, history, sent } = createHarness();
 
-    emit({
-      phase: "reasoning",
-      title: "Inspecting workspace",
-      timestamp: 1,
-      raw: { type: "item.started", item: { type: "reasoning" } },
-    });
-    emit({
-      phase: "reasoning",
-      title: "Inspecting workspace",
-      timestamp: 2,
-      raw: { type: "item.updated", item: { type: "reasoning" } },
-      delta: "first thought",
-    });
     emit({
       phase: "tool",
-      title: "Running tool",
+      title: "Inspecting workspace",
       detail: "bash",
-      timestamp: 3,
+      timestamp: 1,
       raw: { type: "item.started", item: { type: "tool_call" } },
     });
+    emit(commandEvent({ type: "item.started", id: "cmd-1", command: "npm test", status: "inProgress" }));
+    emit({
+      phase: "editing",
+      title: "Updating file",
+      detail: "src/index.ts",
+      timestamp: 2,
+      raw: { type: "item.started", item: { type: "file_change" } },
+    });
 
-    assert.equal(handler.getStepTraceText(), "[analysis] first thought[tool] Running tool: bash\n");
+    assert.equal(handler.getStepTraceText(), "[editing] Updating file: src/index.ts\n");
+    const stepDeltas = sent
+      .filter((payload) => {
+        const item = payload as { type?: unknown; source?: unknown };
+        return item.type === "delta" && item.source === "step";
+      })
+      .map((payload) => (payload as { delta?: unknown }).delta);
+    assert.deepEqual(stepDeltas, [
+      "[tool] Inspecting workspace: bash\n",
+      "[editing] Updating file: src/index.ts\n",
+    ]);
+    assert.equal(sent.filter((payload) => (payload as { type?: unknown }).type === "command").length, 1);
     assert.deepEqual(history, []);
   });
 


### PR DESCRIPTION
## Summary

- Replace the active live-step snapshot instead of concatenating prior substantive step events.
- Promote only the latest compact substantive step when the turn completes.
- Add focused frontend and server regression coverage and document the rendering contract.

## Scope

This PR is limited to Issue #119. It does not change thread recovery, lane status duplication, or command-above-process ordering.

## Validation

- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:web`
- `git diff --check`

Fixes #119