### PR TITLE
fix(web): keep advisor process cards above commands

### DIFF
--- a/client/src/__tests__/chat-semantic-turn-order.test.ts
+++ b/client/src/__tests__/chat-semantic-turn-order.test.ts
@@ -113,4 +113,94 @@ describe("chat semantic card ordering (Issue #67)", () => {
     expect(firstExecuteIndex).toBeGreaterThan(planIndex); // execute after plan
     expect(items[planIndex]?.plan?.status).toBe("completed");
   });
+
+  it("keeps a process card above commands when the command arrives first", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const rt = ctx.activeRuntime.value;
+    const handler = createWsMessageHandler({
+      projects: ctx.projects,
+      pid: "default",
+      rt,
+      wsInstance: { sendPrompt: () => true } as any,
+      randomId: (p: string) => `${p}-mock`,
+      maxTurnCommands: 5,
+      updateProject: () => {},
+      ...chat,
+    });
+
+    chat.pushMessageBeforeLive({ id: "u-1", role: "user", kind: "text", content: "Inspect the build" }, rt);
+    handler({
+      type: "command",
+      command: { id: "cmd-1", command: "npm test", outputDelta: "$ npm test\nfirst line\n" },
+    });
+    handler({ type: "delta", source: "step", delta: "[tool] Inspecting the test output" });
+
+    const ids = rt.messages.value.map((item) => item.id);
+    expect(ids.indexOf("live-step")).toBeGreaterThan(ids.indexOf("u-1"));
+    expect(ids.indexOf("live-step")).toBeLessThan(ids.indexOf("exec:cmd-1:npm test"));
+    expect(rt.messages.value.filter((item) => item.id === "live-step")).toHaveLength(1);
+  });
+
+  it("keeps the process anchor stable when process arrives before commands and updates repeatedly", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const rt = ctx.activeRuntime.value;
+    const handler = createWsMessageHandler({
+      projects: ctx.projects,
+      pid: "default",
+      rt,
+      wsInstance: { sendPrompt: () => true } as any,
+      randomId: (p: string) => `${p}-mock`,
+      maxTurnCommands: 5,
+      updateProject: () => {},
+      ...chat,
+    });
+
+    chat.pushMessageBeforeLive({ id: "u-1", role: "user", kind: "text", content: "Run checks" }, rt);
+    handler({ type: "delta", source: "step", delta: "[tool] Inspecting" });
+    handler({ type: "command", command: { id: "cmd-1", command: "npm test", outputDelta: "first\n" } });
+    handler({ type: "delta", source: "step", delta: "[editing] Updating checks" });
+    handler({ type: "command", command: { id: "cmd-2", command: "git diff", outputDelta: "second\n" } });
+    handler({ type: "command", command: { id: "cmd-1", command: "npm test", outputDelta: "tail\n" } });
+
+    const messages = rt.messages.value;
+    const ids = messages.map((item) => item.id);
+    const liveIndex = ids.indexOf("live-step");
+    const firstExecuteIndex = messages.findIndex((item) => item.kind === "execute");
+    expect(messages.filter((item) => item.id === "live-step")).toHaveLength(1);
+    expect(messages.find((item) => item.id === "live-step")?.content).toBe("[editing] Updating checks");
+    expect(liveIndex).toBeLessThan(firstExecuteIndex);
+    expect(messages.filter((item) => item.kind === "execute").map((item) => item.command)).toEqual(["npm test", "git diff"]);
+    expect(messages.find((item) => item.command === "npm test")?.content).toContain("first");
+    expect(messages.find((item) => item.command === "npm test")?.content).toContain("tail");
+  });
+
+  it("reorders persisted history the same way as live events", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const rt = ctx.activeRuntime.value;
+    const handler = createWsMessageHandler({
+      projects: ctx.projects,
+      pid: "default",
+      rt,
+      wsInstance: { sendPrompt: () => true } as any,
+      randomId: (p: string) => `${p}-mock`,
+      maxTurnCommands: 5,
+      updateProject: () => {},
+      ...chat,
+    });
+
+    handler({
+      type: "history",
+      items: [
+        { role: "user", kind: "text", text: "Replay this turn" },
+        { role: "status", kind: "execute", text: "$ npm test\nall passed" },
+        { role: "thought", kind: "thought", text: "[tool] Inspecting" },
+        { role: "ai", kind: "text", text: "Done" },
+      ],
+    });
+
+    expect(rt.messages.value.map((item) => item.kind)).toEqual(["text", "thought", "execute", "text"]);
+  });
 });

--- a/client/src/__tests__/execute-stacking-and-command-collapse.test.ts
+++ b/client/src/__tests__/execute-stacking-and-command-collapse.test.ts
@@ -11,6 +11,41 @@ async function settleUi(wrapper: { vm: { $nextTick: () => Promise<void> } }): Pr
 }
 
 describe("chat execute stacking and command collapse", () => {
+  it("renders the live process card before an arrival-ordered execute block", async () => {
+    const wrapper = mount(MainChatMessageList, {
+      props: {
+        messages: [
+          { id: "u-1", role: "user", kind: "text", content: "run checks" },
+          { id: "exec:1", role: "system", kind: "execute", content: "output", command: "npm test", streaming: true },
+          { id: "live-step", role: "assistant", kind: "text", content: "[tool] Inspecting", streaming: true },
+          { id: "a-1", role: "assistant", kind: "text", content: "done" },
+        ],
+        copiedMessageId: null,
+        formatMessageTs: () => "",
+        liveStepExpanded: false,
+        liveStepHasOverflow: false,
+        liveStepCanToggleExpanded: false,
+        liveStepOutlineItems: [],
+        liveStepOutlineHiddenCount: 0,
+        liveStepCollapsedTrivialOutline: false,
+      },
+      global: {
+        stubs: {
+          MarkdownContent: true,
+          ChatFilePreviewModal: true,
+        },
+      },
+      attachTo: document.body,
+    });
+
+    await settleUi(wrapper);
+
+    const ids = wrapper.findAll(".msg").map((item) => item.attributes("data-id"));
+    expect(ids).toEqual(["u-1", "live-step", "exec:1", "a-1"]);
+
+    wrapper.unmount();
+  });
+
   it("emits copy events from execute blocks", async () => {
     const wrapper = mount(MainChatMessageList, {
       props: {

--- a/client/src/app/chat.ts
+++ b/client/src/app/chat.ts
@@ -527,7 +527,6 @@ export function createChatActions(ctx: AppContext) {
     randomId,
     maxExecutePreviewLines,
     maxTurnCommands,
-    isLiveMessageId,
   });
 
   const {
@@ -543,7 +542,6 @@ export function createChatActions(ctx: AppContext) {
     runtimeOrActive,
     setMessages,
     dropEmptyAssistantPlaceholder,
-    findLastLiveIndex,
     isLiveMessageId,
     randomId,
   });

--- a/client/src/app/chatExecute.ts
+++ b/client/src/app/chatExecute.ts
@@ -1,4 +1,5 @@
 import type { ChatItem, ProjectRuntime } from "./controller";
+import { findExecuteInsertIndex, normalizeTurnSemanticOrder } from "../lib/chat_sync";
 
 function trimRightLine(line: string): string {
   return String(line ?? "").replace(/\s+$/, "");
@@ -32,7 +33,8 @@ export function createExecuteActions(params: {
   randomId: (prefix: string) => string;
   maxExecutePreviewLines: number;
   maxTurnCommands: number;
-  isLiveMessageId: (id: string) => boolean;
+  /** Retained for compatibility with callers that still provide this helper. */
+  isLiveMessageId?: (id: string) => boolean;
 }) {
   const {
     runtimeOrActive,
@@ -41,7 +43,6 @@ export function createExecuteActions(params: {
     dropEmptyAssistantPlaceholder,
     maxExecutePreviewLines,
     maxTurnCommands,
-    isLiveMessageId,
   } = params;
 
   const commandKeyForWsEvent = (command: string, id: string | null): string | null => {
@@ -139,33 +140,11 @@ export function createExecuteActions(params: {
     const existingIdx = existing.findIndex((m) => m.id === itemId);
     if (existingIdx >= 0) {
       existing[existingIdx] = nextItem;
-      setMessages(existing.slice(), state);
+      setMessages(normalizeTurnSemanticOrder(existing), state);
       return;
     }
 
-    let insertAt = existing.length;
-    for (let i = existing.length - 1; i >= 0; i--) {
-      const m = existing[i]!;
-      if (isLiveMessageId(m.id)) continue;
-      if (m.role === "assistant" && m.streaming) {
-        insertAt = i;
-        continue;
-      }
-      if (m.role === "user") {
-        insertAt = Math.max(insertAt, i + 1);
-        break;
-      }
-    }
-
-    let lastExecuteIdx = -1;
-    for (let i = insertAt - 1; i >= 0; i--) {
-      if (existing[i]!.role === "user") break;
-      if (existing[i]!.kind === "execute") {
-        lastExecuteIdx = i;
-        break;
-      }
-    }
-    if (lastExecuteIdx >= 0) insertAt = lastExecuteIdx + 1;
+    const insertAt = findExecuteInsertIndex(existing);
 
     setMessages([...existing.slice(0, insertAt), nextItem, ...existing.slice(insertAt)], state);
 

--- a/client/src/app/chatStreaming.ts
+++ b/client/src/app/chatStreaming.ts
@@ -1,4 +1,5 @@
 import { clearLiveActivityWindow, renderLiveActivityMarkdown } from "../lib/live_activity";
+import { findAssistantInsertIndex, findProcessInsertIndex } from "../lib/chat_sync";
 
 import type { ChatItem, ProjectRuntime } from "./controller";
 
@@ -25,11 +26,12 @@ export function createStreamingActions(params: {
   runtimeOrActive: (rt?: ProjectRuntime) => ProjectRuntime;
   setMessages: (items: ChatItem[], rt?: ProjectRuntime) => void;
   dropEmptyAssistantPlaceholder: (rt?: ProjectRuntime) => void;
-  findLastLiveIndex: (items: ChatItem[]) => number;
+  /** Retained for compatibility with older callers; insertion uses shared anchors. */
+  findLastLiveIndex?: (items: ChatItem[]) => number;
   isLiveMessageId: (id: string) => boolean;
   randomId: (prefix: string) => string;
 }) {
-  const { liveStepId, liveActivityId, runtimeOrActive, setMessages, dropEmptyAssistantPlaceholder, findLastLiveIndex, isLiveMessageId, randomId } =
+  const { liveStepId, liveActivityId, runtimeOrActive, setMessages, dropEmptyAssistantPlaceholder, isLiveMessageId, randomId } =
     params;
 
   const findLastStreamingAssistantIndex = (items: ChatItem[]): number => {
@@ -40,11 +42,6 @@ export function createStreamingActions(params: {
       }
     }
     return -1;
-  };
-
-  const findInsertAtBeforeStreamingAssistant = (items: ChatItem[]): number => {
-    const index = findLastStreamingAssistantIndex(items);
-    return index >= 0 ? index : items.length;
   };
 
   const clearLiveActivityTimer = (state: ProjectRuntime): void => {
@@ -101,12 +98,7 @@ export function createStreamingActions(params: {
       streaming: true,
       ts: Date.now(),
     };
-    const lastLiveIndex = findLastLiveIndex(existing);
-    if (lastLiveIndex < 0) {
-      setMessages([...existing, nextItem], state);
-      return;
-    }
-    const insertAt = Math.min(existing.length, lastLiveIndex + 1);
+    const insertAt = findAssistantInsertIndex(existing);
     setMessages([...existing.slice(0, insertAt), nextItem, ...existing.slice(insertAt)], state);
   };
 
@@ -140,12 +132,7 @@ export function createStreamingActions(params: {
       streaming: true,
       ts: Date.now(),
     };
-    const lastLiveIndex = findLastLiveIndex(existing);
-    if (lastLiveIndex < 0) {
-      setMessages([...existing, nextItem], state);
-      return;
-    }
-    const insertAt = Math.min(existing.length, lastLiveIndex + 1);
+    const insertAt = findAssistantInsertIndex(existing);
     setMessages([...existing.slice(0, insertAt), nextItem, ...existing.slice(insertAt)], state);
   };
 
@@ -169,7 +156,7 @@ export function createStreamingActions(params: {
       ts: (idx >= 0 ? existing[idx]!.ts : null) ?? Date.now(),
     };
     const withoutStep = idx >= 0 ? [...existing.slice(0, idx), ...existing.slice(idx + 1)] : existing;
-    const insertAt = findInsertAtBeforeStreamingAssistant(withoutStep);
+    const insertAt = findProcessInsertIndex(withoutStep);
 
     const next = [...withoutStep.slice(0, insertAt), nextItem, ...withoutStep.slice(insertAt)];
     setMessages(next, state);
@@ -202,7 +189,7 @@ export function createStreamingActions(params: {
     const withoutActivity = idx >= 0 ? [...existing.slice(0, idx), ...existing.slice(idx + 1)] : existing;
 
     const stepIdx = withoutActivity.findIndex((m) => m.id === liveStepId);
-    const insertAt = stepIdx >= 0 ? stepIdx : findInsertAtBeforeStreamingAssistant(withoutActivity);
+    const insertAt = stepIdx >= 0 ? stepIdx : findProcessInsertIndex(withoutActivity);
 
     const next = [...withoutActivity.slice(0, insertAt), nextItem, ...withoutActivity.slice(insertAt)];
     setMessages(next, state);
@@ -233,13 +220,7 @@ export function createStreamingActions(params: {
           streaming: false,
           ts: stepMsg?.ts ?? Date.now(),
         };
-        let insertAt = next.length;
-        for (let i = next.length - 1; i >= 0; i--) {
-          if (next[i]?.role === "assistant") {
-            insertAt = i;
-            break;
-          }
-        }
+        const insertAt = findProcessInsertIndex(next);
         next.splice(insertAt, 0, thoughtItem);
       }
     }

--- a/client/src/app/projectsWs/webSocketActions.ts
+++ b/client/src/app/projectsWs/webSocketActions.ts
@@ -70,6 +70,7 @@ export function createWebSocketActions(ctx: AppContext & ChatActions, deps: WsDe
     ingestCommand,
     upsertExecuteBlock,
     ingestCommandActivity,
+    setMessages,
   } = ctx;
 
   const restoreReasoningEffort = (rt: ProjectRuntime): void => {
@@ -558,7 +559,7 @@ export function createWebSocketActions(ctx: AppContext & ChatActions, deps: WsDe
               () => {
                 clearStepLive(rt);
                 finalizeCommandBlock(rt);
-                rt.messages.value = [];
+                setMessages([], rt);
                 rt.recentCommands.value = [];
                 rt.seenCommandIds.clear();
                 rt.executePreviewByKey.clear();
@@ -717,7 +718,7 @@ export function createWebSocketActions(ctx: AppContext & ChatActions, deps: WsDe
       for (let i = items.length - 1; i >= 0; i--) {
         const item = items[i]!;
         if (item.role === "system" && item.kind === "text" && isReconnectNotice(String(item.content ?? ""))) {
-          rt.messages.value = [...items.slice(0, i), ...items.slice(i + 1)];
+          setMessages([...items.slice(0, i), ...items.slice(i + 1)], rt);
           return;
         }
       }

--- a/client/src/app/projectsWs/wsMessage.ts
+++ b/client/src/app/projectsWs/wsMessage.ts
@@ -692,7 +692,7 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
     });
   };
 
-  return (msg: unknown): void => {
+  const applyMessage = (msg: unknown): void => {
     if (!isRecord(msg)) return;
     const typeValue = msg.type;
     if (typeof typeValue !== "string") return;
@@ -1604,6 +1604,15 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
         upsertLiveActivity(rt);
       }
       return;
+    }
+  };
+
+  return (msg: unknown): void => {
+    applyMessage(msg);
+    const current = Array.isArray(rt.messages.value) ? rt.messages.value : [];
+    const normalized = normalizeTurnSemanticOrder(current);
+    if (normalized.length !== current.length || normalized.some((item, index) => item !== current[index])) {
+      rt.messages.value = normalized;
     }
   };
 }

--- a/client/src/components/MainChatMessageList.vue
+++ b/client/src/components/MainChatMessageList.vue
@@ -4,8 +4,9 @@ import { computed, ref, watch } from "vue";
 import MarkdownContent from "./MarkdownContent.vue";
 import ChatFilePreviewModal from "./ChatFilePreviewModal.vue";
 import type { ChatMessage, RenderMessage } from "./mainChat/types";
-import type { ChatPlan, ChatPlanItemStatus } from "../app/controllerTypes";
+import type { ChatItem, ChatPlan, ChatPlanItemStatus } from "../app/controllerTypes";
 import { PATCH_DIFF_FALLBACK_KEY, splitUnifiedDiffByPath } from "../lib/patchDiff";
+import { normalizeTurnSemanticOrder } from "../lib/chat_sync";
 import type { MarkdownFilePreviewLink } from "../lib/markdown";
 
 const LIVE_STEP_MESSAGE_ID = "live-step";
@@ -225,16 +226,20 @@ watch(
 );
 
 const renderMessages = computed<RenderMessage[]>(() => {
+  // Keep the DOM contract defensive: history replay and test/integration
+  // callers may provide an arrival-ordered snapshot instead of going through
+  // the chat action setter. Rendering must still be deterministic.
+  const ordered = normalizeTurnSemanticOrder(props.messages as ChatItem[]) as ChatMessage[];
   let latestExecuteId: string | null = null;
-  for (let i = props.messages.length - 1; i >= 0; i--) {
-    const m = props.messages[i]!;
+  for (let i = ordered.length - 1; i >= 0; i--) {
+    const m = ordered[i]!;
     if (m.kind === "execute") {
       latestExecuteId = m.id;
       break;
     }
   }
 
-  return props.messages.filter((m) => m.kind !== "command" && (m.kind !== "execute" || m.id === latestExecuteId));
+  return ordered.filter((m) => m.kind !== "command" && (m.kind !== "execute" || m.id === latestExecuteId));
 });
 
 function getCommands(content: string): string[] {

--- a/client/src/components/mainChat/types.ts
+++ b/client/src/components/mainChat/types.ts
@@ -3,7 +3,7 @@ import type { ChatPatch, ChatPlan } from "../../app/controllerTypes";
 export type ChatMessage = {
   id: string;
   role: "user" | "assistant" | "system";
-  kind: "text" | "command" | "execute" | "patch" | "error" | "plan";
+  kind: "text" | "command" | "execute" | "patch" | "error" | "plan" | "thought";
   content: string;
   fullContent?: string;
   patch?: ChatPatch;

--- a/client/src/lib/chat_sync.test.ts
+++ b/client/src/lib/chat_sync.test.ts
@@ -703,4 +703,17 @@ describe("chat_sync.normalizeTurnSemanticOrder", () => {
     const out = normalizeTurnSemanticOrder(raw);
     expect(out.map((m) => m.id)).toEqual(["u1", "p1", "live-step", "e1"]);
   });
+
+  it("keeps only the newest fixed live card when replay includes duplicates", () => {
+    const raw: ChatItem[] = [
+      msg({ id: "u1", role: "user", content: "Run task" }),
+      msg({ id: "live-step", role: "assistant", kind: "text", content: "old", streaming: true }),
+      msg({ id: "e1", role: "system", kind: "execute", content: "exec" }),
+      msg({ id: "live-step", role: "assistant", kind: "text", content: "new", streaming: true }),
+    ];
+
+    const out = normalizeTurnSemanticOrder(raw);
+    expect(out.map((m) => m.id)).toEqual(["u1", "live-step", "e1"]);
+    expect(out.find((m) => m.id === "live-step")?.content).toBe("new");
+  });
 });

--- a/client/src/lib/chat_sync.ts
+++ b/client/src/lib/chat_sync.ts
@@ -222,29 +222,114 @@ export function getSemanticCardRank(item: ChatItem): number {
   return 6;
 }
 
+type TurnBounds = { start: number; end: number };
+
+function getCurrentTurnBounds(messages: ChatItem[]): TurnBounds {
+  let start = -1;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.role === "user") {
+      start = index;
+      break;
+    }
+  }
+  if (start < 0) return { start: 0, end: messages.length };
+
+  let end = messages.length;
+  for (let index = start + 1; index < messages.length; index += 1) {
+    if (messages[index]?.role === "user") {
+      end = index;
+      break;
+    }
+  }
+  return { start, end };
+}
+
+/**
+ * Return the insertion point for the current process/live card.
+ *
+ * A process card is a mutable status snapshot. It belongs after plan/thought
+ * cards and every other live card, but before execute, patch, or assistant
+ * output. Keeping this anchor explicit means live updates remain ordered even
+ * when the caller's setter does not perform semantic normalization.
+ */
+export function findProcessInsertIndex(messages: ChatItem[]): number {
+  const { start, end } = getCurrentTurnBounds(messages);
+  let insertAt = Math.min(end, start + 1);
+  for (let index = start + 1; index < end; index += 1) {
+    const item = messages[index]!;
+    if (isLiveMessageId(item.id) || item.kind === "plan" || item.kind === "thought") {
+      insertAt = index + 1;
+      continue;
+    }
+    return index;
+  }
+  return insertAt;
+}
+
+/**
+ * Return the insertion point for a command execution card in the current turn.
+ * Commands follow process/thought cards and earlier commands, while remaining
+ * before patches and the final assistant response.
+ */
+export function findExecuteInsertIndex(messages: ChatItem[]): number {
+  const { start, end } = getCurrentTurnBounds(messages);
+  let insertAt = Math.min(end, start + 1);
+  for (let index = start + 1; index < end; index += 1) {
+    const item = messages[index]!;
+    if (
+      isLiveMessageId(item.id) ||
+      item.kind === "plan" ||
+      item.kind === "thought" ||
+      item.kind === "execute"
+    ) {
+      insertAt = index + 1;
+      continue;
+    }
+    return index;
+  }
+  return insertAt;
+}
+
+/** Return the end of the current turn for a newly-created assistant stream. */
+export function findAssistantInsertIndex(messages: ChatItem[]): number {
+  return getCurrentTurnBounds(messages).end;
+}
+
 export function normalizeTurnSemanticOrder(messages: ChatItem[]): ChatItem[] {
   if (!Array.isArray(messages) || messages.length <= 1) {
     return Array.isArray(messages) ? messages : [];
   }
 
+  // A reconnect or a legacy producer can replay the same fixed live id more
+  // than once. Keep the newest snapshot so the renderer never receives
+  // duplicate Vue keys or two visible process cards.
+  const latestLiveIndex = new Map<string, number>();
+  for (let index = 0; index < messages.length; index += 1) {
+    const id = messages[index]!.id;
+    if (isLiveMessageId(id)) latestLiveIndex.set(id, index);
+  }
+  const deduplicated = latestLiveIndex.size === 0
+    ? messages
+    : messages.filter((item, index) => !isLiveMessageId(item.id) || latestLiveIndex.get(item.id) === index);
+
   const result: ChatItem[] = [];
   let turnStart = -1;
 
-  for (let i = 0; i < messages.length; i++) {
-    if (messages[i]!.role === "user") {
+  for (let i = 0; i < deduplicated.length; i++) {
+    if (deduplicated[i]!.role === "user") {
       if (turnStart >= 0) {
-        result.push(...sortSingleTurn(messages.slice(turnStart, i)));
+        result.push(...sortSingleTurn(deduplicated.slice(turnStart, i)));
       } else if (i > 0) {
-        result.push(...messages.slice(0, i));
+        result.push(...deduplicated.slice(0, i));
       }
       turnStart = i;
     }
   }
 
   if (turnStart >= 0) {
-    result.push(...sortSingleTurn(messages.slice(turnStart)));
+    result.push(...sortSingleTurn(deduplicated.slice(turnStart)));
   } else {
-    result.push(...sortSingleTurn(messages));
+    result.push(...sortSingleTurn(deduplicated));
   }
 
   return result;

--- a/docs/web.md
+++ b/docs/web.md
@@ -58,7 +58,7 @@ WebSocket 流式回复按 Provider 的消息 `itemId` 隔离累计文本；多�
 - 新建聊天会话时，在线 WebSocket 通过原连接内协议切换 session；连接状态保持在线，离线时自动回退到完整重连。
 - 重连或后端重启后，只要持久化历史存在就会发送历史快照；即使后端上下文暂时是 fresh，客户端也保留本地聊天记录，只有显式线程重置才会清空历史。
 - Bootstrap 等待期间提交的提示会进入持久 outbox，待历史同步完成后继续发送；若历史帧丢失，5 秒兜底会解除等待锁，避免 Composer 永久冻结。
-- 清空或新建会话不会删除 Composer 中尚未提交的草稿文本；每轮消息中的 Plan、实时活动、Thought、Execute 与 Patch 卡片按稳定语义顺序展示，活动中的 live-step 只保留最新阶段快照，完成后该快照会作为可折叠 Thought 卡片保留在历史重放中。
+- 清空或新建会话不会删除 Composer 中尚未提交的草稿文本；Advisor 每轮消息遵循固定卡片契约：`User -> Plan -> 当前 Process/Thought -> Execute（按命令顺序） -> Patch -> Final assistant`。该顺序由前端按当前轮重新归一化，不依赖 WebSocket 事件到达顺序，因此 command-before-process、process-before-command、重连 catch-up 与历史回放都会保持一致；活动中的 live-step 只保留最新阶段快照，完成后该快照会作为可折叠 Thought 卡片保留在历史重放中。
 - Worker 与 Advisor 的清空操作默认只作用于发起操作的 chat lane；跨 lane 清理必须显式请求 shared scope，且 session reset 广播会校验来源 lane。
 
 ### 5. 多模态与文件联动


### PR DESCRIPTION
## Summary

- Centralize per-turn insertion anchors for process, execute, and assistant cards.
- Normalize live, replayed, and catch-up messages after every Advisor event.
- Deduplicate repeated fixed live-step cards and preserve command output/order.
- Add live WS, history replay, and DOM ordering regression coverage.
- Document the Advisor card ordering contract.

## Validation

- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:web`
- `git diff --check`

Fixes #123
