### PR TITLE
feat(ui): add session boundary divider and clean context notice (#128)

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -28,6 +28,7 @@ import {
 import {
   CirclePlus,
   ChatDotRound,
+  Delete,
   Document,
   MoreFilled,
   Setting,
@@ -219,6 +220,7 @@ const {
   activeLaneHasResume,
   activeLaneNewSessionBlocked,
   handleLaneNewSession,
+  handleLaneClearChat,
   handleLaneResumeThread,
   sessionPickerOpen,
   openSessionPicker,
@@ -236,6 +238,7 @@ const {
   queuedPrompts,
   pendingImages,
   agentBusy,
+  clearActiveChat,
   clearPlannerChat,
   startNewChatSession,
   resumePlannerThread,
@@ -923,6 +926,17 @@ const plannerConnectionStatus = computed(() => {
             @click.stop="handleLaneNewSession"
           >
             <el-icon :size="16" aria-hidden="true"><ChatDotRound /></el-icon>
+          </button>
+          <button
+            v-if="!isMobile"
+            class="laneTabIconBtn"
+            type="button"
+            title="清空会话"
+            :disabled="activeLaneBusy"
+            data-testid="lane-clear-chat"
+            @click.stop="handleLaneClearChat"
+          >
+            <el-icon :size="15" aria-hidden="true"><Delete /></el-icon>
           </button>
         </div>
 

--- a/client/src/__tests__/session-boundary-divider.test.ts
+++ b/client/src/__tests__/session-boundary-divider.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createAppContext, type AppContext } from "../app/controller";
+import { createChatActions } from "../app/chat";
+import { createProjectActions } from "../app/projectsWs/projectActions";
+import { createTaskActions } from "../app/tasks";
+import { createWsMessageHandler } from "../app/projectsWs/wsMessage";
+
+describe("session boundary divider and status feedback", () => {
+  it("inserts a session boundary divider and retains prior messages when starting a new session", async () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const deps = {
+      activateProject: vi.fn(async () => {}),
+    };
+    const projects = createProjectActions({ ...ctx, ...chat } as AppContext & ReturnType<typeof createChatActions>, deps);
+
+    ctx.loggedIn.value = true;
+    projects.initializeProjects();
+
+    const rt = ctx.activeRuntime.value;
+    rt.messages.value = [
+      { id: "u1", role: "user", kind: "text", content: "Previous user request" },
+      { id: "a1", role: "assistant", kind: "text", content: "Previous model response" },
+    ];
+
+    await projects.startNewChatSession();
+
+    // Messages should be retained with divider appended
+    expect(rt.messages.value).toHaveLength(3);
+    expect(rt.messages.value[0]?.content).toBe("Previous user request");
+    expect(rt.messages.value[1]?.content).toBe("Previous model response");
+
+    const divider = rt.messages.value[2]!;
+    expect(divider.role).toBe("system");
+    expect(divider.kind).toBe("divider");
+    expect(divider.content).toBe(
+      "Previous messages above are retained for review only and are NOT injected into model prompt context.",
+    );
+
+    // Composer status feedback
+    expect(rt.laneStatus.value).toEqual({
+      kind: "info",
+      message: "New session active: clean context (previous history is not included).",
+    });
+  });
+
+  it("does not insert duplicate consecutive dividers on repeated new session calls", async () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const deps = {
+      activateProject: vi.fn(async () => {}),
+    };
+    const projects = createProjectActions({ ...ctx, ...chat } as AppContext & ReturnType<typeof createChatActions>, deps);
+
+    ctx.loggedIn.value = true;
+    projects.initializeProjects();
+
+    const rt = ctx.activeRuntime.value;
+    rt.messages.value = [
+      { id: "u1", role: "user", kind: "text", content: "Initial prompt" },
+    ];
+
+    await projects.startNewChatSession();
+    expect(rt.messages.value).toHaveLength(2);
+    expect(rt.messages.value[1]?.kind).toBe("divider");
+
+    await projects.startNewChatSession();
+    expect(rt.messages.value).toHaveLength(2);
+    expect(rt.messages.value[1]?.kind).toBe("divider");
+  });
+
+  it("does not insert a divider if messages are empty", async () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const deps = {
+      activateProject: vi.fn(async () => {}),
+    };
+    const projects = createProjectActions({ ...ctx, ...chat } as AppContext & ReturnType<typeof createChatActions>, deps);
+
+    ctx.loggedIn.value = true;
+    projects.initializeProjects();
+
+    const rt = ctx.activeRuntime.value;
+    rt.messages.value = [];
+
+    await projects.startNewChatSession();
+    expect(rt.messages.value).toHaveLength(0);
+    expect(rt.laneStatus.value).toEqual({
+      kind: "info",
+      message: "New session active: clean context (previous history is not included).",
+    });
+  });
+
+  it("replays session_divider from history bootstrap and sets fresh session status", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const projects = createProjectActions({ ...ctx, ...chat } as AppContext & ReturnType<typeof createChatActions>, {
+      activateProject: vi.fn(async () => {}),
+    });
+    ctx.loggedIn.value = true;
+    projects.initializeProjects();
+    const rt = ctx.activeRuntime.value;
+
+    const handler = createWsMessageHandler({
+      rt,
+      project: { id: "default", sessionId: "default", chatSessionId: "main" } as any,
+      projects: ctx.projects,
+      activeProjectId: ctx.activeProjectId,
+      activeProject: ctx.activeProject,
+      cancelPendingResume: chat.cancelPendingResume,
+      clearPendingPrompt: vi.fn(),
+      clearStepLive: vi.fn(),
+      finalizeAssistant: vi.fn(),
+      finalizeCommandBlock: vi.fn(),
+      flushQueuedPrompts: vi.fn(),
+      pushMessageBeforeLive: vi.fn(),
+      threadReset: vi.fn(),
+      updateProject: vi.fn(),
+      applyResumeHistory: chat.applyResumeHistory,
+      randomId: (p) => `${p}-1`,
+    });
+
+    handler({
+      type: "history",
+      items: [
+        { role: "user", text: "past prompt", ts: 100 },
+        { role: "ai", text: "past reply", ts: 101 },
+        {
+          role: "status",
+          kind: "session_divider",
+          text: "Previous messages above are retained for review only and are NOT injected into model prompt context.",
+          ts: 102,
+        },
+      ],
+    });
+
+    expect(rt.messages.value).toHaveLength(3);
+    expect(rt.messages.value[0]?.content).toBe("past prompt");
+    expect(rt.messages.value[1]?.content).toBe("past reply");
+    expect(rt.messages.value[2]?.kind).toBe("divider");
+    expect(rt.laneStatus.value).toEqual({
+      kind: "info",
+      message: "New session active: clean context (previous history is not included).",
+    });
+  });
+
+  it("positions divider correctly when history includes both past and new turns on reload", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const projects = createProjectActions({ ...ctx, ...chat } as AppContext & ReturnType<typeof createChatActions>, {
+      activateProject: vi.fn(async () => {}),
+    });
+    ctx.loggedIn.value = true;
+    projects.initializeProjects();
+    const rt = ctx.activeRuntime.value;
+
+    const handler = createWsMessageHandler({
+      rt,
+      project: { id: "default", sessionId: "default", chatSessionId: "main" } as any,
+      projects: ctx.projects,
+      activeProjectId: ctx.activeProjectId,
+      activeProject: ctx.activeProject,
+      cancelPendingResume: chat.cancelPendingResume,
+      clearPendingPrompt: vi.fn(),
+      clearStepLive: vi.fn(),
+      finalizeAssistant: vi.fn(),
+      finalizeCommandBlock: vi.fn(),
+      flushQueuedPrompts: vi.fn(),
+      pushMessageBeforeLive: vi.fn(),
+      threadReset: vi.fn(),
+      updateProject: vi.fn(),
+      applyResumeHistory: chat.applyResumeHistory,
+      randomId: (p) => `${p}-1`,
+    });
+
+    handler({
+      type: "history",
+      items: [
+        { role: "user", text: "past prompt", ts: 100 },
+        { role: "ai", text: "past reply", ts: 101 },
+        {
+          role: "status",
+          kind: "session_divider",
+          text: "Previous messages above are retained for review only and are NOT injected into model prompt context.",
+          ts: 102,
+        },
+        { role: "user", text: "new turn prompt", ts: 103 },
+        { role: "ai", text: "new turn reply", ts: 104 },
+      ],
+    });
+
+    expect(rt.messages.value).toHaveLength(5);
+    expect(rt.messages.value[0]?.content).toBe("past prompt");
+    expect(rt.messages.value[1]?.content).toBe("past reply");
+    expect(rt.messages.value[2]?.kind).toBe("divider");
+    expect(rt.messages.value[3]?.content).toBe("new turn prompt");
+    expect(rt.messages.value[4]?.content).toBe("new turn reply");
+
+    // Since turns ran in the new session, laneStatus fresh session notice should be cleared
+    expect(rt.laneStatus.value).toBeNull();
+  });
+
+  it("clears laneStatus fresh session notice when first turn completes with result", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const projects = createProjectActions({ ...ctx, ...chat } as AppContext & ReturnType<typeof createChatActions>, {
+      activateProject: vi.fn(async () => {}),
+    });
+    ctx.loggedIn.value = true;
+    projects.initializeProjects();
+    const rt = ctx.activeRuntime.value;
+
+    const handler = createWsMessageHandler({
+      rt,
+      project: { id: "default", sessionId: "default", chatSessionId: "main" } as any,
+      projects: ctx.projects,
+      activeProjectId: ctx.activeProjectId,
+      activeProject: ctx.activeProject,
+      cancelPendingResume: chat.cancelPendingResume,
+      clearPendingPrompt: vi.fn(),
+      clearStepLive: vi.fn(),
+      finalizeAssistant: vi.fn(),
+      finalizeCommandBlock: vi.fn(),
+      flushQueuedPrompts: vi.fn(),
+      pushMessageBeforeLive: vi.fn(),
+      threadReset: vi.fn(),
+      updateProject: vi.fn(),
+      applyResumeHistory: chat.applyResumeHistory,
+      randomId: (p) => `${p}-1`,
+    });
+
+    rt.laneStatus.value = {
+      kind: "info",
+      message: "New session active: clean context (previous history is not included).",
+    };
+
+    handler({
+      type: "result",
+      output: "Completed turn output",
+    });
+
+    expect(rt.laneStatus.value).toBeNull();
+  });
+
+  it("handles /clear slash command in sendMainPrompt and sendPlannerPrompt by executing full clear", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const projects = createProjectActions({ ...ctx, ...chat } as AppContext & ReturnType<typeof createChatActions>, {
+      activateProject: vi.fn(async () => {}),
+    });
+    const tasks = createTaskActions({ ...ctx, ...chat } as AppContext & ReturnType<typeof createChatActions>, {
+      connectWs: vi.fn(async () => {}),
+      connectPlannerWs: vi.fn(async () => {}),
+    });
+
+    ctx.loggedIn.value = true;
+    projects.initializeProjects();
+
+    const workerRt = ctx.activeRuntime.value;
+    const plannerRt = ctx.activePlannerRuntime.value;
+    workerRt.ws = { clearHistory: vi.fn() } as any;
+    plannerRt.ws = { clearHistory: vi.fn() } as any;
+
+    workerRt.messages.value = [
+      { id: "m1", role: "user", kind: "text", content: "something" },
+    ];
+    plannerRt.messages.value = [
+      { id: "p1", role: "user", kind: "text", content: "planner something" },
+    ];
+
+    tasks.sendMainPrompt("/clear");
+    expect(workerRt.messages.value).toHaveLength(0);
+    expect(workerRt.ws?.clearHistory).toHaveBeenCalled();
+
+    tasks.sendPlannerPrompt("  /CLEAR  ");
+    expect(plannerRt.messages.value).toHaveLength(0);
+    expect(plannerRt.ws?.clearHistory).toHaveBeenCalled();
+  });
+});

--- a/client/src/app/controllerTypes.ts
+++ b/client/src/app/controllerTypes.ts
@@ -112,7 +112,7 @@ export type ChatPlan = {
 export type ChatItem = {
   id: string;
   role: "user" | "assistant" | "system";
-  kind: "text" | "command" | "execute" | "patch" | "error" | "plan" | "thought";
+  kind: "text" | "command" | "execute" | "patch" | "error" | "plan" | "thought" | "divider";
   content: string;
   fullContent?: string;
   patch?: ChatPatch;

--- a/client/src/app/projectsWs/projectActions.defaultChatSession.test.ts
+++ b/client/src/app/projectsWs/projectActions.defaultChatSession.test.ts
@@ -23,7 +23,10 @@ describe("projectActions.loadProjectsFromServer", () => {
     await projects.startNewChatSession();
 
     expect(ctx.activeRuntime.value.inputLocked.value).toBe(false);
-    expect(ctx.activeRuntime.value.laneStatus.value).toBeNull();
+    expect(ctx.activeRuntime.value.laneStatus.value).toEqual({
+      kind: "info",
+      message: "New session active: clean context (previous history is not included).",
+    });
 
     const before = ctx.projects.value.find((p) => p.id === "default")?.chatSessionId ?? null;
     expect(before).not.toBeNull();

--- a/client/src/app/projectsWs/projectActions.ts
+++ b/client/src/app/projectsWs/projectActions.ts
@@ -421,7 +421,42 @@ export function createProjectActions(ctx: AppContext & ChatActions, deps: Projec
     activeRuntime.value.ignoreNextHistory = false;
     activeRuntime.value.suppressNextClearHistoryResult = false;
 
-    clearChatState();
+    busy.value = false;
+    activeRuntime.value.inputLocked.value = false;
+    activeRuntime.value.pendingCdRequestedPath = null;
+    queuedPrompts.value = [];
+    pendingImages.value = [];
+    recentCommands.value = [];
+    activeRuntime.value.turnCommands = [];
+    activeRuntime.value.turnCommandCount = 0;
+    activeRuntime.value.executePreviewByKey?.clear?.();
+    activeRuntime.value.executeOrder = [];
+    activeRuntime.value.turnInFlight = false;
+    threadWarning.value = null;
+    activeThreadId.value = null;
+    ctx.clearStepLive();
+    ctx.finalizeCommandBlock();
+
+    const existingMessages = Array.isArray(activeRuntime.value.messages.value)
+      ? activeRuntime.value.messages.value
+      : [];
+    if (existingMessages.length > 0 && existingMessages[existingMessages.length - 1]?.kind !== "divider") {
+      ctx.setMessages([
+        ...existingMessages,
+        {
+          id: `divider:${newChatSessionId}`,
+          role: "system",
+          kind: "divider",
+          content: "Previous messages above are retained for review only and are NOT injected into model prompt context.",
+          ts: Date.now(),
+        },
+      ]);
+    }
+
+    activeRuntime.value.laneStatus.value = {
+      kind: "info",
+      message: "New session active: clean context (previous history is not included).",
+    };
 
     const currentWs = activeRuntime.value.ws as { switchChatSession?: (id: string) => boolean; close?: () => void } | null;
     if (activeRuntime.value.connected.value && typeof currentWs?.switchChatSession === "function") {

--- a/client/src/app/projectsWs/wsMessage.ts
+++ b/client/src/app/projectsWs/wsMessage.ts
@@ -1201,6 +1201,20 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
           });
           continue;
         }
+        if (kind === "session_divider" || (role === "status" && kind === "session_divider") || (role === "system" && kind === "divider")) {
+          restoredHistoryStatus = {
+            kind: "info",
+            message: "New session active: clean context (previous history is not included).",
+          };
+          next.push({
+            id: `h-div-${idx}`,
+            role: "system",
+            kind: "divider",
+            content: historyText || "Previous messages above are retained for review only and are NOT injected into model prompt context.",
+            ts: ts ?? undefined,
+          });
+          continue;
+        }
         if (role === "status") {
           restoredHistoryStatus = replayedLaneStatus(kind, historyText);
           continue;

--- a/client/src/app/tasks.ts
+++ b/client/src/app/tasks.ts
@@ -471,6 +471,10 @@ export function createTaskActions(ctx: AppContext & ChatActions, deps: TaskDeps)
     const text = String(content ?? "");
     const images = pendingImages.value.slice();
     pendingImages.value = [];
+    if (text.trim().toLowerCase() === "/clear") {
+      clearActiveChat();
+      return;
+    }
     enqueueMainPrompt(text, images);
   };
 
@@ -480,6 +484,10 @@ export function createTaskActions(ctx: AppContext & ChatActions, deps: TaskDeps)
     const planner = activePlannerRuntime.value;
     const images = planner.pendingImages.value.slice();
     planner.pendingImages.value = [];
+    if (text.trim().toLowerCase() === "/clear") {
+      clearPlannerChat();
+      return;
+    }
     enqueuePrompt(text, images, planner);
   };
 

--- a/client/src/components/MainChat.vue
+++ b/client/src/components/MainChat.vue
@@ -29,6 +29,7 @@ const props = defineProps<{
   runningTaskCount?: number;
   workspaceRoot?: string | null;
   headerAction?: { title: string; ariaLabel?: string; testId?: string };
+  headerClearAction?: { title: string; ariaLabel?: string; testId?: string };
   headerResumeAction?: { title: string; ariaLabel?: string; testId?: string; disabled?: boolean };
   threadWarning?: string | null;
   connectionStatusKind?: "info" | "progress" | "disconnected" | "error" | null;
@@ -340,9 +341,11 @@ onBeforeUnmount(() => {
       :title="title"
       :busy="busy"
       :header-action="headerAction"
+      :header-clear-action="headerClearAction"
       :header-resume-action="headerResumeAction"
       :thread-warning="threadWarning"
       @new-session="emit('newSession')"
+      @clear="emit('clear')"
       @resume-thread="emit('resumeThread')"
     />
     <div ref="listRef" class="chat" @scroll="handleScroll">

--- a/client/src/components/MainChatHeader.vue
+++ b/client/src/components/MainChatHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ChatDotRound, Refresh } from "@element-plus/icons-vue";
+import { ChatDotRound, Delete, Refresh } from "@element-plus/icons-vue";
 
 type HeaderAction = { title: string; ariaLabel?: string; testId?: string };
 type HeaderResumeAction = { title: string; ariaLabel?: string; testId?: string; disabled?: boolean };
@@ -8,12 +8,14 @@ const props = defineProps<{
   title: string;
   busy: boolean;
   headerAction?: HeaderAction;
+  headerClearAction?: HeaderAction;
   headerResumeAction?: HeaderResumeAction;
   threadWarning?: string | null;
 }>();
 
 const emit = defineEmits<{
   (e: "newSession"): void;
+  (e: "clear"): void;
   (e: "resumeThread"): void;
 }>();
 </script>
@@ -53,6 +55,20 @@ const emit = defineEmits<{
       >
         <el-icon :size="16" aria-hidden="true">
           <ChatDotRound />
+        </el-icon>
+      </button>
+      <button
+        v-if="props.headerClearAction"
+        class="paneHeaderIconBtn"
+        type="button"
+        :title="props.headerClearAction.title || '清空会话'"
+        :aria-label="props.headerClearAction.ariaLabel || props.headerClearAction.title || '清空会话'"
+        :disabled="props.busy"
+        :data-testid="props.headerClearAction.testId || 'main-chat-header-clear'"
+        @click.stop="emit('clear')"
+      >
+        <el-icon :size="15" aria-hidden="true">
+          <Delete />
         </el-icon>
       </button>
     </div>

--- a/client/src/components/MainChatMessageList.vue
+++ b/client/src/components/MainChatMessageList.vue
@@ -338,7 +338,7 @@ function caretPath(open: boolean): string {
 
 function shouldShowMsgActions(m: RenderMessage): boolean {
   if (m.streaming && m.content.length === 0) return false;
-  if (m.kind === "patch" || m.kind === "thought") return false;
+  if (m.kind === "patch" || m.kind === "thought" || m.kind === "divider") return false;
   return true;
 }
 
@@ -507,6 +507,14 @@ function closeFilePreview(): void {
         </button>
         <div v-if="isThoughtExpanded(m.id)" class="thoughtCardBody">
           <MarkdownContent :content="m.content" :enable-file-preview="Boolean(workspaceRoot)" @open-file-preview="openFilePreview" />
+        </div>
+      </div>
+      <div v-else-if="m.kind === 'divider'" class="sessionBoundaryDivider" data-testid="session-boundary-divider">
+        <div class="sessionBoundaryLine">
+          <span class="sessionBoundaryTag">⚡ New Session Initialized</span>
+        </div>
+        <div class="sessionBoundaryNotice">
+          {{ m.content || "Previous messages above are retained for review only and are NOT injected into model prompt context." }}
         </div>
       </div>
       <div
@@ -1263,5 +1271,63 @@ function closeFilePreview(): void {
   to {
     width: 1.35em;
   }
+}
+
+.msg[data-kind="divider"] {
+  width: 100%;
+  margin: 18px 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.sessionBoundaryDivider {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  user-select: none;
+  padding: 2px 0;
+}
+
+.sessionBoundaryLine {
+  position: relative;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sessionBoundaryLine::before,
+.sessionBoundaryLine::after {
+  content: "";
+  flex: 1;
+  border-bottom: 1px dashed var(--border, #cbd5e1);
+}
+
+.sessionBoundaryTag {
+  padding: 3px 12px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #b45309;
+  background: rgba(245, 158, 11, 0.12);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: 9999px;
+  margin: 0 12px;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.sessionBoundaryNotice {
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--muted, #64748b);
+  text-align: center;
+  max-width: 90%;
+  word-break: break-word;
 }
 </style>

--- a/client/src/composables/app/useLaneRuntimeBridge.ts
+++ b/client/src/composables/app/useLaneRuntimeBridge.ts
@@ -59,6 +59,7 @@ export function useLaneRuntimeBridge(params: {
   queuedPrompts: Ref<Array<{ id: string; text: string; images: unknown[] }>>;
   pendingImages: Ref<unknown[]>;
   agentBusy: Ref<boolean>;
+  clearActiveChat?: () => void;
   clearPlannerChat: () => void;
   startNewChatSession: () => void;
   resumePlannerThread: () => void;
@@ -154,6 +155,12 @@ export function useLaneRuntimeBridge(params: {
     else params.startNewChatSession();
   }
 
+  function handleLaneClearChat(): void {
+    if (activeLaneBusy.value) return;
+    if (activeChatLane.value === "planner") params.clearPlannerChat();
+    else params.clearActiveChat?.();
+  }
+
   function handleLaneResumeThread(): void {
     if (activeChatLane.value === "planner") params.resumePlannerThread();
     else if (activeChatLane.value === "worker") params.resumeTaskThread();
@@ -240,6 +247,7 @@ export function useLaneRuntimeBridge(params: {
     activeLaneHasResume,
     activeLaneNewSessionBlocked,
     handleLaneNewSession,
+    handleLaneClearChat,
     handleLaneResumeThread,
     sessionPickerOpen,
     sessionPickerSupported,

--- a/server/web/server/ws/commandBuiltins.ts
+++ b/server/web/server/ws/commandBuiltins.ts
@@ -123,6 +123,25 @@ export function handleBuiltinCommand(args: {
     };
   }
 
+  if (args.request.slash?.command === "clear") {
+    args.historyStore.clear(args.historyKey);
+    const output = "已清空当前会话历史";
+    args.sendToCommandScope({ type: "result", ok: true, output, kind: "clear_history" });
+    if (!isCurrent()) {
+      return {
+        handled: true,
+        currentCwd: args.currentCwd,
+        orchestrator: args.orchestrator,
+      };
+    }
+    args.sessionLogger?.logOutput(output);
+    return {
+      handled: true,
+      currentCwd: args.currentCwd,
+      orchestrator: args.orchestrator,
+    };
+  }
+
   if (args.request.slash?.command !== "cd") {
     return {
       handled: false,

--- a/server/web/server/ws/promptModelConfig.ts
+++ b/server/web/server/ws/promptModelConfig.ts
@@ -168,8 +168,10 @@ function collectUnansweredUserEntries(entries: HistoryInjectionEntry[]): Set<His
 }
 
 export function buildHistoryInjectionDetails(entries: HistoryInjectionEntry[]): HistoryInjectionDetails | null {
-  const unanswered = collectUnansweredUserEntries(entries);
-  const relevant = entries
+  const lastDividerIndex = entries.map((e) => e.kind).lastIndexOf("session_divider");
+  const effectiveEntries = lastDividerIndex >= 0 ? entries.slice(lastDividerIndex + 1) : entries;
+  const unanswered = collectUnansweredUserEntries(effectiveEntries);
+  const relevant = effectiveEntries
     .map((entry) => ({ entry, label: labelForHistoryInjectionEntry(entry) }))
     .filter((item): item is { entry: HistoryInjectionEntry; label: string } => Boolean(item.label));
   if (relevant.length === 0) {

--- a/server/web/server/ws/server.ts
+++ b/server/web/server/ws/server.ts
@@ -840,6 +840,27 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
             registerSessionCacheBinding();
             orchestrator = sessionManager.getOrCreate(userId, currentCwd, true);
 
+            if (
+              previousLane.historyKey !== nextIdentity.historyKey &&
+              nextLaneNamespace === WEB_WORKER_NAMESPACE
+            ) {
+              const prevEntries = previousLane.historyStore.get(previousLane.historyKey);
+              const nextExistingEntries = nextLaneRes.historyStore.get(nextIdentity.historyKey);
+              if (prevEntries.length > 0 && nextExistingEntries.length === 0) {
+                for (const entry of prevEntries) {
+                  nextLaneRes.historyStore.add(nextIdentity.historyKey, entry);
+                }
+                if (prevEntries[prevEntries.length - 1]?.kind !== "session_divider") {
+                  nextLaneRes.historyStore.add(nextIdentity.historyKey, {
+                    role: "status",
+                    kind: "session_divider",
+                    text: "Previous messages above are retained for review only and are NOT injected into model prompt context.",
+                    ts: Date.now(),
+                  });
+                }
+              }
+            }
+
             const nextSyncLaneKeys = resolveSyncLaneKeys({
               authUserId,
               sessionId,

--- a/server/web/server/ws/taskResumeConversation.ts
+++ b/server/web/server/ws/taskResumeConversation.ts
@@ -50,8 +50,10 @@ export function buildHistoryStoreResumeTranscript(
   entries: readonly HistoryEntry[],
   maxChars = TASK_RESUME_TRANSCRIPT_MAX_CHARS,
 ): string {
+  const lastDividerIndex = entries.map((e) => e.kind).lastIndexOf("session_divider");
+  const effectiveEntries = lastDividerIndex >= 0 ? entries.slice(lastDividerIndex + 1) : entries;
   const rawTranscript = buildResumeTranscriptLines(
-    entries
+    effectiveEntries
       .filter((entry) => entry.role === "user" || entry.role === "ai")
       .map((entry) => ({
         speaker: entry.role === "user" ? "User" : "Assistant",

--- a/tests/web/sessionBoundary.test.ts
+++ b/tests/web/sessionBoundary.test.ts
@@ -1,0 +1,111 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildHistoryInjectionDetails } from "../../server/web/server/ws/promptModelConfig.js";
+import { buildHistoryStoreResumeTranscript } from "../../server/web/server/ws/taskResumeConversation.js";
+import { handleBuiltinCommand, parseCommandRequest } from "../../server/web/server/ws/commandBuiltins.js";
+
+describe("web/ws/sessionBoundary", () => {
+  it("excludes pre-divider entries from history injection to protect clean model context", () => {
+    const details = buildHistoryInjectionDetails([
+      { role: "user", text: "secret prompt from old session", ts: 100 },
+      { role: "ai", text: "old response", ts: 200 },
+      {
+        role: "status",
+        kind: "session_divider",
+        text: "Previous messages above are retained for review only and are NOT injected into model prompt context.",
+        ts: 300,
+      },
+      { role: "user", text: "fresh prompt in new session", ts: 400 },
+      { role: "ai", text: "fresh response", ts: 500 },
+    ]);
+
+    assert.ok(details);
+    assert.equal(details.entryCount, 2);
+    assert.ok(!details.text.includes("secret prompt from old session"));
+    assert.ok(!details.text.includes("old response"));
+    assert.ok(details.text.includes("fresh prompt in new session"));
+    assert.ok(details.text.includes("fresh response"));
+  });
+
+  it("returns null history injection details when all entries precede the divider", () => {
+    const details = buildHistoryInjectionDetails([
+      { role: "user", text: "old user prompt", ts: 100 },
+      { role: "ai", text: "old ai reply", ts: 200 },
+      {
+        role: "status",
+        kind: "session_divider",
+        text: "Previous messages above are retained for review only and are NOT injected into model prompt context.",
+        ts: 300,
+      },
+    ]);
+
+    assert.equal(details, null);
+  });
+
+  it("excludes pre-divider entries from task resume transcript", () => {
+    const transcript = buildHistoryStoreResumeTranscript([
+      { role: "user", text: "old task command", ts: 100 },
+      { role: "ai", text: "old task output", ts: 200 },
+      {
+        role: "status",
+        kind: "session_divider",
+        text: "Previous messages above are retained for review only and are NOT injected into model prompt context.",
+        ts: 300,
+      },
+      { role: "user", text: "new task command", ts: 400 },
+      { role: "ai", text: "new task output", ts: 500 },
+    ]);
+
+    assert.ok(!transcript.includes("old task command"));
+    assert.ok(!transcript.includes("old task output"));
+    assert.ok(transcript.includes("new task command"));
+    assert.ok(transcript.includes("new task output"));
+  });
+
+  it("handles /clear builtin command by wiping historyStore and sending result", () => {
+    const cleared: string[] = [];
+    const sent: unknown[] = [];
+    const logged: string[] = [];
+
+    const mockHistoryStore = {
+      clear: (key: string) => {
+        cleared.push(key);
+      },
+      add: () => true,
+    };
+
+    const parsed = parseCommandRequest({
+      payload: "/clear",
+      sanitizeInput: (p) => String(p ?? ""),
+    });
+    assert.ok(parsed.ok);
+
+    const result = handleBuiltinCommand({
+      request: parsed.request,
+      userId: 123,
+      historyKey: "test-history-key",
+      currentCwd: "/workspace",
+      orchestrator: {} as any,
+      state: {} as any,
+      sessionManager: {} as any,
+      historyStore: mockHistoryStore as any,
+      sendToCommandScope: (payload) => sent.push(payload),
+      transport: {
+        ws: {} as any,
+        sendWorkspaceState: () => {},
+        broadcastWorkspaceState: () => {},
+      },
+      logger: { warn: () => {} } as any,
+      sessionLogger: { logOutput: (msg: string) => logged.push(msg) } as any,
+      syncWorkspaceTemplates: () => {},
+    });
+
+    assert.equal(result.handled, true);
+    assert.deepEqual(cleared, ["test-history-key"]);
+    assert.deepEqual(sent, [
+      { type: "result", ok: true, output: "已清空当前会话历史", kind: "clear_history" },
+    ]);
+    assert.deepEqual(logged, ["已清空当前会话历史"]);
+  });
+});


### PR DESCRIPTION
## Overview

Resolves #128.

In the Web Console Worker lane, starting a new chat session via startNewChatSession() retains prior workspace execution history on screen so users do not lose sight of recent shell outputs, test logs, or file modifications. Because the backend initiates a fresh model thread, a clear visual boundary and status feedback are added to make the runtime transition explicit:

1. **Session Boundary Divider Component**:
   - Inserts an explicit visual boundary in the message list when starting a new session:
     ─────────────── ⚡ New Session Initialized ───────────────
     Previous messages above are retained for review only and are NOT injected into model prompt context.
   - Deduplicated so consecutive new-session triggers do not stack multiple dividers.
   - Styled responsively across desktop and mobile layouts.

2. **Composer Status Feedback**:
   - Surfaces a clean context notice in composer laneStatus:
     New session active: clean context (previous history is not included).
   - Automatically cleared when the first turn completes.

3. **Explicit Full Clear Action**:
   - Added /clear command handling in main and planner prompt dispatch to clear conversation history.
   - Added explicit clear button to the lane header actions toolbar.

4. **Persistence & Model Isolation**:
   - Carries forward previous history with session_divider during in-band session switches on the server so the boundary survives page reload in the new session.
   - Excludes pre-divider history in buildHistoryInjectionDetails and buildHistoryStoreResumeTranscript so preceding messages are never injected into model prompt context.

## Validation

- npm run test:web passed (104 files, 499 tests).
- npm test passed (1002 backend tests).
- npm run lint passed without errors.
- npm run build passed.

Closes #128.
