### PR TITLE
fix(ui): remove redundant create-task action from chat lane menus

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -298,7 +298,6 @@ const mobileContextActions = computed<MobileContextAction[]>(() => {
     return [{ id: "create-task", label: "新增任务" }];
   }
   return [
-    { id: "create-task", label: "新增任务" },
     {
       id: "resume",
       label: "恢复会话",

--- a/client/src/__tests__/mobile-navigation-behavior.test.ts
+++ b/client/src/__tests__/mobile-navigation-behavior.test.ts
@@ -162,7 +162,7 @@ describe("mobile navigation behavior", () => {
     await wrapper.find('[data-testid="mobile-context-menu-toggle"]').trigger("click");
     expect(wrapper.find('[data-testid="mobile-context-action-resume"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="mobile-context-action-new-session"]').exists()).toBe(true);
-    expect(wrapper.find('[data-testid="mobile-context-action-create-task"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="mobile-context-action-create-task"]').exists()).toBe(false);
     expect(wrapper.find('[data-testid="mobile-context-action-create-rule"]').exists()).toBe(false);
     await wrapper.find('[data-testid="mobile-context-menu-toggle"]').trigger("click");
 
@@ -171,7 +171,7 @@ describe("mobile navigation behavior", () => {
     expect(wrapper.find('[data-testid="lane-panel-planner"]').isVisible()).toBe(true);
     expect(wrapper.find('[data-testid="lane-panel-worker"]').isVisible()).toBe(false);
     await wrapper.find('[data-testid="mobile-context-menu-toggle"]').trigger("click");
-    expect(wrapper.find('[data-testid="mobile-context-action-create-task"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="mobile-context-action-create-task"]').exists()).toBe(false);
     expect(wrapper.find('[data-testid="mobile-context-action-resume"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="mobile-context-action-new-session"]').exists()).toBe(true);
     await wrapper.find('[data-testid="mobile-context-menu-toggle"]').trigger("click");
@@ -187,6 +187,11 @@ describe("mobile navigation behavior", () => {
     await wrapper.find('[data-testid="lane-tab-worker"]').trigger("click");
     await settleUi(wrapper);
     expect(localStorage.getItem("ads.mobileWorkspaceTab.default")).toBe("worker");
+    await wrapper.find('[data-testid="mobile-context-menu-toggle"]').trigger("click");
+    expect(wrapper.find('[data-testid="mobile-context-action-create-task"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="mobile-context-action-resume"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="mobile-context-action-new-session"]').exists()).toBe(true);
+    await wrapper.find('[data-testid="mobile-context-menu-toggle"]').trigger("click");
 
     await wrapper.find('[data-testid="mobile-drawer-toggle"]').trigger("click");
     await settleUi(wrapper);


### PR DESCRIPTION
Fixes #131

## Summary of Changes
- In client/src/App.vue, removed the leaked create-task action from the fallback mobileContextActions list.
- create-task is now strictly confined to the Tasks view when mobileTaskTabActive.value === true.
- In client/src/__tests__/mobile-navigation-behavior.test.ts, updated assertions so that both Advisor and Worker lane menus assert absence of create-task, and verified it remains available on the Tasks tab.

## Validation
- npm run lint: passed
- npm run build: passed
- npm run test:web: passed
- npm test: passed