### PR TITLE
fix(web): support interleaved turn streaming and eliminate monolithic bubble concatenation

### DIFF
--- a/client/src/__tests__/issue-129-thought-action-unification.test.ts
+++ b/client/src/__tests__/issue-129-thought-action-unification.test.ts
@@ -99,12 +99,13 @@ describe("Issue #129: Thought/Action decoupling, command ordering, and lane pari
     expect(getSemanticCardRank(user)).toBe(0);
     expect(getSemanticCardRank(plan)).toBe(1);
     expect(getSemanticCardRank(thought)).toBe(2);
+    // Action & dialogue items share rank 3 to preserve chronological interleaving (Issue #141)
     expect(getSemanticCardRank(exec)).toBe(3);
-    expect(getSemanticCardRank(patch)).toBe(4);
-    expect(getSemanticCardRank(assistant)).toBe(5);
+    expect(getSemanticCardRank(patch)).toBe(3);
+    expect(getSemanticCardRank(assistant)).toBe(3);
 
-    // Even if messages arrive in inverted or scrambled order within the turn:
-    const randomOrder: ChatItem[] = [user, assistant, exec, patch, thought, plan];
+    // Cognitive tier (User -> Plan -> Thought) precedes the action/dialogue stream:
+    const randomOrder: ChatItem[] = [user, exec, patch, assistant, thought, plan];
     const sorted = normalizeTurnSemanticOrder(randomOrder);
     expect(sorted.map((m) => m.id)).toEqual(["u1", "pl1", "th1", "ex1", "pa1", "as1"]);
   });

--- a/client/src/__tests__/issue-141-interleaved-turn-streaming.test.ts
+++ b/client/src/__tests__/issue-141-interleaved-turn-streaming.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import { createAppContext, type AppContext } from "../app/controller";
+import { createChatActions } from "../app/chat";
+import { createWsMessageHandler } from "../app/projectsWs/wsMessage";
+import MainChat from "../components/MainChat.vue";
+
+describe("Issue #141: Interleaved turn streaming and elimination of monolithic bubble concatenation", () => {
+  it("interleaves explanations and commands chronologically without monolithic bubble concatenation", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const rt = ctx.activeRuntime.value;
+
+    const handler = createWsMessageHandler({
+      projects: ctx.projects,
+      pid: "default",
+      rt,
+      wsInstance: { sendPrompt: () => true } as any,
+      randomId: (p: string) => `${p}-mock`,
+      maxTurnCommands: 5,
+      updateProject: () => {},
+      ...chat,
+    });
+
+    // 1. User initiates prompt
+    chat.pushMessageBeforeLive({ id: "user-1", role: "user", kind: "text", content: "Implement feature X" }, rt);
+
+    // 2. Model streams Step 1 explanation
+    handler({ type: "delta", delta: "Step 1: Inspecting the workspace." });
+    handler({ type: "delta", delta: " Looking for package configuration..." });
+
+    let messages = rt.messages.value;
+    const step1Bubble = messages.find((m) => m.role === "assistant" && m.kind === "text");
+    expect(step1Bubble).toBeDefined();
+    expect(step1Bubble?.content).toBe("Step 1: Inspecting the workspace. Looking for package configuration...");
+    expect(step1Bubble?.streaming).toBe(true);
+
+    // 3. Command 1 begins executing
+    handler({
+      type: "command",
+      command: { id: "cmd-1", command: "ls -la", outputDelta: "$ ls -la\nfile1.ts\nfile2.ts\n" },
+    });
+
+    messages = rt.messages.value;
+    // Step 1 explanation must now be sealed (streaming: false)
+    expect(messages[1]?.id).toBe(step1Bubble?.id);
+    expect(messages[1]?.streaming).toBe(false);
+
+    // Command 1 execute card must follow Step 1 explanation
+    const cmd1Card = messages.find((m) => m.kind === "execute" && m.command === "ls -la");
+    expect(cmd1Card).toBeDefined();
+    expect(cmd1Card?.streaming).toBe(true);
+    expect(messages.indexOf(cmd1Card!)).toBeGreaterThan(messages.indexOf(step1Bubble!));
+
+    // 4. Step 1 command finishes, agent streams Step 2 explanation
+    handler({ type: "delta", delta: "Step 2: Modifying configuration files..." });
+
+    messages = rt.messages.value;
+    // Step 2 must be an independent bubble, NOT concatenated onto Step 1
+    const textBubbles = messages.filter((m) => m.role === "assistant" && m.kind === "text");
+    expect(textBubbles).toHaveLength(2);
+    expect(textBubbles[0]?.content).toBe("Step 1: Inspecting the workspace. Looking for package configuration...");
+    expect(textBubbles[1]?.content).toBe("Step 2: Modifying configuration files...");
+    expect(textBubbles[1]?.streaming).toBe(true);
+
+    // Step 2 bubble must be placed AFTER Command 1
+    expect(messages.indexOf(textBubbles[1]!)).toBeGreaterThan(messages.indexOf(cmd1Card!));
+
+    // 5. Command 2 begins executing
+    handler({
+      type: "command",
+      command: { id: "cmd-2", command: "npm test", outputDelta: "$ npm test\nPASS\n" },
+    });
+
+    messages = rt.messages.value;
+    // Step 2 bubble is now sealed
+    const updatedBubbles = messages.filter((m) => m.role === "assistant" && m.kind === "text");
+    expect(updatedBubbles[1]?.streaming).toBe(false);
+
+    const cmd2Card = messages.find((m) => m.kind === "execute" && m.command === "npm test");
+    expect(cmd2Card).toBeDefined();
+    expect(messages.indexOf(cmd2Card!)).toBeGreaterThan(messages.indexOf(textBubbles[1]!));
+
+    // 6. Agent streams final delivery summary
+    handler({ type: "delta", delta: "Final delivery summary: All tests passed successfully." });
+
+    messages = rt.messages.value;
+    const allTextBubbles = messages.filter((m) => m.role === "assistant" && m.kind === "text");
+    expect(allTextBubbles).toHaveLength(3);
+    expect(allTextBubbles[2]?.content).toBe("Final delivery summary: All tests passed successfully.");
+
+    // Verify complete chronological narrative interleaving
+    // User -> Step 1 -> Command 1 -> Step 2 -> Command 2 -> Summary
+    const sequence = messages.map((m) => {
+      if (m.role === "user") return "User";
+      if (m.kind === "execute") return `Cmd:${m.command}`;
+      return `Text:${String(m.content).slice(0, 6)}`;
+    });
+    expect(sequence).toEqual([
+      "User",
+      "Text:Step 1",
+      "Cmd:ls -la",
+      "Text:Step 2",
+      "Cmd:npm test",
+      "Text:Final ",
+    ]);
+  });
+
+  it("does not render retired planCard in MainChat even if legacy plan messages exist", async () => {
+    const messages = [
+      { id: "u-1", role: "user" as const, kind: "text" as const, content: "Build project" },
+      {
+        id: "plan-1",
+        role: "system" as const,
+        kind: "plan" as const,
+        content: "Plan text",
+        plan: {
+          planId: "p1",
+          status: "in_progress" as const,
+          items: [{ text: "Item 1", status: "completed" as const }],
+        },
+      },
+    ];
+
+    const wrapper = mount(MainChat, {
+      props: {
+        messages: messages as any,
+        queuedPrompts: [],
+        pendingImages: [],
+        connected: true,
+        busy: false,
+      },
+      attachTo: document.body,
+    });
+
+    await wrapper.vm.$nextTick();
+
+    // The dedicated planCard element and its checkbox markers must not exist (ADR 0002)
+    expect(wrapper.find(".planCard").exists()).toBe(false);
+    expect(wrapper.find(".planCardCheckbox").exists()).toBe(false);
+    expect(wrapper.find(".planCardHeader").exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+});

--- a/client/src/app/chatExecute.ts
+++ b/client/src/app/chatExecute.ts
@@ -1,4 +1,5 @@
 import type { ChatItem, ProjectRuntime } from "./controller";
+import { isLiveMessageId as isLiveMessageIdDefault } from "./chatLive";
 import { findExecuteInsertIndex, normalizeTurnSemanticOrder } from "../lib/chat_sync";
 
 function trimRightLine(line: string): string {
@@ -43,6 +44,7 @@ export function createExecuteActions(params: {
     dropEmptyAssistantPlaceholder,
     maxExecutePreviewLines,
     maxTurnCommands,
+    isLiveMessageId = isLiveMessageIdDefault,
   } = params;
 
   const commandKeyForWsEvent = (command: string, id: string | null): string | null => {
@@ -153,9 +155,18 @@ export function createExecuteActions(params: {
       return;
     }
 
-    const insertAt = findExecuteInsertIndex(cleanedExisting);
+    // Demarcate phase boundary: pre-command assistant explanations are sealed
+    // when a command execution block enters the stream.
+    const sealedExisting = cleanedExisting.map((m) => {
+      if (m.role === "assistant" && m.streaming && !isLiveMessageId?.(m.id)) {
+        return { ...m, streaming: false };
+      }
+      return m;
+    });
 
-    setMessages([...cleanedExisting.slice(0, insertAt), nextItem, ...cleanedExisting.slice(insertAt)], state);
+    const insertAt = findExecuteInsertIndex(sealedExisting);
+
+    setMessages([...sealedExisting.slice(0, insertAt), nextItem, ...sealedExisting.slice(insertAt)], state);
 
     if (state.executeOrder.length > maxTurnCommands) {
       const overflow = state.executeOrder.length - maxTurnCommands;

--- a/client/src/app/chatStreaming.ts
+++ b/client/src/app/chatStreaming.ts
@@ -46,10 +46,16 @@ export function createStreamingActions(params: {
   const { liveStepId, liveActivityId, runtimeOrActive, setMessages, dropEmptyAssistantPlaceholder, isLiveMessageId, randomId } =
     params;
 
-  const findLastStreamingAssistantIndex = (items: ChatItem[]): number => {
+  const findActiveStreamingAssistantIndex = (items: ChatItem[]): number => {
     for (let i = items.length - 1; i >= 0; i--) {
       const msg = items[i]!;
-      if (msg.role === "assistant" && msg.streaming && !isLiveMessageId(msg.id)) {
+      if (isLiveMessageId(msg.id)) continue;
+      // Tool execution blocks and patches demarcate phase boundaries. Assistant text
+      // before a tool call belongs to a prior conversational phase and must not be concatenated into.
+      if (msg.kind === "execute" || msg.kind === "command" || msg.kind === "patch") {
+        return -1;
+      }
+      if (msg.role === "assistant" && msg.kind === "text" && msg.streaming) {
         return i;
       }
     }
@@ -100,15 +106,26 @@ export function createStreamingActions(params: {
     if (!chunk) return;
     dropEmptyAssistantPlaceholder(state);
     const existing = state.messages.value.slice();
-    const streamIndex = findLastStreamingAssistantIndex(existing);
+    const streamIndex = findActiveStreamingAssistantIndex(existing);
     if (streamIndex >= 0) {
       const current = String(existing[streamIndex]!.content ?? "");
       const nextChunk = stripStreamingOverlap(current, chunk);
       if (!nextChunk) return;
-      existing[streamIndex]!.content = current + nextChunk;
+      existing[streamIndex] = {
+        ...existing[streamIndex]!,
+        content: current + nextChunk,
+      };
       setMessages(existing.slice(), state);
       return;
     }
+
+    // Seal any earlier in-flight assistant bubbles from previous phases
+    const sealedExisting = existing.map((m) => {
+      if (m.role === "assistant" && m.streaming && !isLiveMessageId(m.id)) {
+        return { ...m, streaming: false };
+      }
+      return m;
+    });
 
     const nextItem: ChatItem = {
       id: randomId("stream"),
@@ -118,8 +135,8 @@ export function createStreamingActions(params: {
       streaming: true,
       ts: Date.now(),
     };
-    const insertAt = findAssistantInsertIndex(existing);
-    setMessages([...existing.slice(0, insertAt), nextItem, ...existing.slice(insertAt)], state);
+    const insertAt = findAssistantInsertIndex(sealedExisting);
+    setMessages([...sealedExisting.slice(0, insertAt), nextItem, ...sealedExisting.slice(insertAt)], state);
   };
 
   /**
@@ -136,13 +153,23 @@ export function createStreamingActions(params: {
     if (!nextText) return;
     dropEmptyAssistantPlaceholder(state);
     const existing = state.messages.value.slice();
-    const streamIndex = findLastStreamingAssistantIndex(existing);
+    const streamIndex = findActiveStreamingAssistantIndex(existing);
     if (streamIndex >= 0) {
       if (existing[streamIndex]!.content === nextText) return;
-      existing[streamIndex]!.content = nextText;
+      existing[streamIndex] = {
+        ...existing[streamIndex]!,
+        content: nextText,
+      };
       setMessages(existing.slice(), state);
       return;
     }
+
+    const sealedExisting = existing.map((m) => {
+      if (m.role === "assistant" && m.streaming && !isLiveMessageId(m.id)) {
+        return { ...m, streaming: false };
+      }
+      return m;
+    });
 
     const nextItem: ChatItem = {
       id: randomId("stream"),
@@ -152,8 +179,8 @@ export function createStreamingActions(params: {
       streaming: true,
       ts: Date.now(),
     };
-    const insertAt = findAssistantInsertIndex(existing);
-    setMessages([...existing.slice(0, insertAt), nextItem, ...existing.slice(insertAt)], state);
+    const insertAt = findAssistantInsertIndex(sealedExisting);
+    setMessages([...sealedExisting.slice(0, insertAt), nextItem, ...sealedExisting.slice(insertAt)], state);
   };
 
   const upsertThoughtDelta = (delta: string, rt?: ProjectRuntime): void => {

--- a/client/src/components/MainChatMessageList.vue
+++ b/client/src/components/MainChatMessageList.vue
@@ -4,7 +4,7 @@ import { computed, ref, watch } from "vue";
 import MarkdownContent from "./MarkdownContent.vue";
 import ChatFilePreviewModal from "./ChatFilePreviewModal.vue";
 import type { ChatMessage, RenderMessage } from "./mainChat/types";
-import type { ChatItem, ChatPlan, ChatPlanItemStatus } from "../app/controllerTypes";
+import type { ChatItem } from "../app/controllerTypes";
 import { PATCH_DIFF_FALLBACK_KEY, splitUnifiedDiffByPath } from "../lib/patchDiff";
 import { normalizeTurnSemanticOrder } from "../lib/chat_sync";
 import type { MarkdownFilePreviewLink } from "../lib/markdown";
@@ -176,25 +176,6 @@ function buildPatchRows(m: RenderMessage): PatchRenderRow[] {
 
 function isPatchExpanded(messageId: string, rowKey: string): boolean {
   return expandedPatchKeys.value.has(patchExpandKey(messageId, rowKey));
-}
-
-function planItemMarker(status: ChatPlanItemStatus): string {
-  if (status === "completed") return "☑";
-  if (status === "in_progress") return "◐";
-  return "☐";
-}
-
-function planCardSummary(plan: ChatPlan): string {
-  const total = plan.items.length;
-  if (total === 0) return "暂无计划项";
-  const done = plan.items.filter((entry) => entry.status === "completed").length;
-  const inProgress = plan.items.filter((entry) => entry.status === "in_progress").length;
-  if (plan.status === "completed") return `共 ${total} 项 · 全部完成`;
-  if (plan.status === "failed") return `共 ${total} 项 · 计划失败`;
-  if (inProgress > 0) {
-    return `共 ${total} 项 · 已完成 ${done} · 进行中 ${inProgress}`;
-  }
-  return `共 ${total} 项 · 已完成 ${done}`;
 }
 
 function togglePatchExpanded(messageId: string, rowKey: string): void {
@@ -478,23 +459,6 @@ function closeFilePreview(): void {
         </div>
         <div v-if="m.patch?.truncated" class="patchCardNote">Diff 已截断，避免刷屏。</div>
       </div>
-      <div v-else-if="m.kind === 'plan' && m.plan" :class="['bubble', 'bubble--compact', 'planCard']" :data-plan-status="m.plan.status ?? 'in_progress'">
-        <div class="planCardHeader">
-          <span class="prompt-tag">计划</span>
-          <span class="planCardSummary">{{ planCardSummary(m.plan) }}</span>
-        </div>
-        <ul class="planCardList">
-          <li
-            v-for="(item, itemIdx) in m.plan.items"
-            :key="`${m.id}-${itemIdx}`"
-            class="planCardItem"
-            :data-status="item.status"
-          >
-            <span class="planCardCheckbox" aria-hidden="true">{{ planItemMarker(item.status) }}</span>
-            <span class="planCardText" :class="{ 'planCardText--done': item.status === 'completed' }">{{ item.text }}</span>
-          </li>
-        </ul>
-      </div>
       <div v-else-if="m.kind === 'thought'" :class="['bubble', 'bubble--compact', 'thoughtCard']">
         <button
           class="thoughtCardHeader"
@@ -718,79 +682,6 @@ function closeFilePreview(): void {
 
 .execute-more--button:hover {
   color: #0f172a;
-}
-
-.planCard {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 10px 12px;
-  border: 1px solid #cbd5f5;
-  border-radius: 8px;
-  background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
-}
-
-.planCard[data-plan-status="completed"] {
-  border-color: #86efac;
-  background: linear-gradient(180deg, #f0fdf4 0%, #dcfce7 100%);
-}
-
-.planCard[data-plan-status="failed"] {
-  border-color: #fca5a5;
-  background: linear-gradient(180deg, #fef2f2 0%, #fee2e2 100%);
-}
-
-.planCardHeader {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.planCardSummary {
-  color: #475569;
-  font-size: 12px;
-}
-
-.planCardList {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.planCardItem {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  font-size: 13px;
-  line-height: 1.45;
-}
-
-.planCardCheckbox {
-  flex: 0 0 auto;
-  font-size: 14px;
-  color: #475569;
-  line-height: 1.45;
-}
-
-.planCardItem[data-status="completed"] .planCardCheckbox {
-  color: #16a34a;
-}
-
-.planCardItem[data-status="in_progress"] .planCardCheckbox {
-  color: #2563eb;
-}
-
-.planCardText {
-  flex: 1 1 auto;
-  word-break: break-word;
-}
-
-.planCardText--done {
-  color: #64748b;
-  text-decoration: line-through;
 }
 
 .patchCard {

--- a/client/src/lib/chat_sync.ts
+++ b/client/src/lib/chat_sync.ts
@@ -216,10 +216,7 @@ export function getSemanticCardRank(item: ChatItem): number {
   if (item.role === "user") return 0;
   if (item.kind === "plan") return 1;
   if (item.kind === "thought" || isLiveMessageId(item.id)) return 2;
-  if (item.kind === "execute") return 3;
-  if (item.kind === "patch") return 4;
-  if (item.role === "assistant") return 5;
-  return 6;
+  return 3;
 }
 
 type TurnBounds = { start: number; end: number };
@@ -268,26 +265,11 @@ export function findProcessInsertIndex(messages: ChatItem[]): number {
 
 /**
  * Return the insertion point for a command execution card in the current turn.
- * Commands follow process/thought cards and earlier commands, while remaining
- * before patches and the final assistant response.
+ * In an interleaved turn, execution blocks follow the explanation that triggered them,
+ * remaining strictly ahead of live-progress indicators.
  */
 export function findExecuteInsertIndex(messages: ChatItem[]): number {
-  const { start, end } = getCurrentTurnBounds(messages);
-  let insertAt = Math.min(end, start + 1);
-  for (let index = start + 1; index < end; index += 1) {
-    const item = messages[index]!;
-    if (
-      isLiveMessageId(item.id) ||
-      item.kind === "plan" ||
-      item.kind === "thought" ||
-      item.kind === "execute"
-    ) {
-      insertAt = index + 1;
-      continue;
-    }
-    return index;
-  }
-  return insertAt;
+  return getCurrentTurnBounds(messages).end;
 }
 
 /** Return the end of the current turn for a newly-created assistant stream. */

--- a/docs/adr/0002-retire-plan-checkbox-cards.md
+++ b/docs/adr/0002-retire-plan-checkbox-cards.md
@@ -1,0 +1,35 @@
+# ADR 0002: Retire Plan Checkbox Cards in Favor of Interleaved Turn Streaming Progress
+
+## Status
+Accepted
+
+## Context
+In previous ADS releases, a dedicated checkbox Plan Card (`planCard` with `☑`, `◐`, `☐` markers) was maintained in the Web Console. This mechanism was introduced primarily to satisfy the legacy artificial prompt constraint requiring multi-step tasks to output a checkable plan checklist.
+
+In practice, this implementation suffered from several foundational architectural deficiencies:
+1. **Fragile Upstream Parsing**: It relied on brittle regex heuristics and provider-specific mapping of `todo_list` structures in `workerPromptHandler.ts`, which exhibited inconsistent behavior across different AI models and providers.
+2. **Artificial Choreography vs. Real Progress**: Synthetic checkbox choreography provided low contextual value compared to what the model was actually doing. Users received repetitive checklist snapshots rather than meaningful progress.
+3. **Monolithic Bubble Concatenation Breakdown (Issue #141)**: In `chatStreaming.ts`, the client blindly concatenated all assistant deltas emitted across a multi-step turn into a single assistant bubble (`content = current + nextChunk`). When commands intervened, the client failed to delineate phase boundaries, welding explanations emitted before, between, and after command executions into a single bloated, repeating mega-bubble.
+4. **Card Ordering Inversion**: The legacy semantic card rank forced all `assistant` messages to the bottom (rank 5) and all `execute` cards to the top (rank 3), destroying the chronological narrative between pre-command intent and post-command results.
+
+## Decision
+1. **Completely Retire the Dedicated Plan Checkbox Card**:
+   - Remove `planCard` markup, summaries, and styling from `client/src/components/MainChatMessageList.vue`.
+   - Decommission backend `publishPlan`, `PlanSnapshot`, and `todo_list` event mapping in `server/web/server/ws/workerPromptHandler.ts`. The backend will no longer emit synthetic `type: "plan"` WebSocket events or persist `plan:*` status entries.
+2. **Adopt Interleaved Turn Streaming Architecture**:
+   - The agent's real-time step explanations preceding and succeeding command executions are themselves the true, living progress of execution.
+   - Establish clean phase boundaries in `client/src/app/chatStreaming.ts`: when a command execution or patch occurs, the preceding assistant stream is sealed (`streaming: false`). Subsequent explanations start as a distinct conversational segment positioned chronologically below the completed actions.
+   - Unify execution-layer semantic card ordering in `client/src/lib/chat_sync.ts` so that Thought/Live status remains pinned at the cognitive layer, while assistant commentary and command executions interleave strictly according to their natural chronological occurrence:
+     `Pre-command explanation -> Active command block -> Post-command explanation / next step -> Next command block -> Final delivery summary`.
+
+## Consequences
+### Positive
+- Completely eliminates the monolithic repeating text bubble bug and the snowball duplication effect.
+- Restores natural human-agent collaborative rhythm where commands render directly underneath the explanation that triggered them, and follow-up commentary appears below completed commands.
+- Eliminates fragile `todo_list` wire mapping and reduces frontend/backend state complexity.
+- Replaces synthetic checkbox updates with rich, contextual, real-time narrative progress.
+
+### Trade-offs & Migration
+- Historical `plan:*` entries in existing databases remain harmlessly unrendered or treated as plain legacy text, without causing frontend rendering errors.
+- External prompt constraints or agents no longer expect a synthetic checkbox UI.
+

--- a/server/web/server/ws/workerPromptHandler.ts
+++ b/server/web/server/ws/workerPromptHandler.ts
@@ -24,9 +24,6 @@ type Logger = {
   debug: (msg: string) => void;
 };
 
-type PlanItem = { text: string; status: "pending" | "in_progress" | "completed" };
-type PlanSnapshot = { planId: string; status: "in_progress" | "completed" | "failed"; items: PlanItem[] };
-
 function isTransientRetryEvent(event: AgentEvent): boolean {
   const raw = event.raw as ThreadEvent | null | undefined;
   if (raw?.type !== "turn.failed" && raw?.type !== "error") return false;
@@ -118,26 +115,7 @@ export function attachWorkerPromptHandler(args: {
   const terminalCommandKeys = new Set<string>();
   let hasCommandOutput = false;
   let exploredHeaderSent = false;
-  let logicalPlanId: string | null = null;
-  let latestPlan: PlanSnapshot | null = null;
   const isActive = (): boolean => (args.isActive ? args.isActive() : true);
-
-  const publishPlan = (snapshot: PlanSnapshot): void => {
-    if (!isActive()) return;
-    latestPlan = snapshot;
-    const ts = Date.now();
-    args.sendToChat({ type: "plan", ...snapshot, ts });
-    try {
-      args.historyStore.upsertEntryByKind(args.historyKey, {
-        role: "status",
-        text: JSON.stringify(snapshot),
-        ts,
-        kind: `plan:${snapshot.planId}`,
-      });
-    } catch (err) {
-      args.logger.debug(`[Plan] failed to persist plan snapshot: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  };
 
   /**
    * Report every command the agent runs to the global-rule gate. The gate ships
@@ -181,8 +159,6 @@ export function attachWorkerPromptHandler(args: {
     args.logger.debug(`[Event] phase=${event.phase} title=${event.title} detail=${event.detail?.slice(0, 50)}`);
     const raw = event.raw as ThreadEvent;
     if (raw.type === "turn.started") {
-      logicalPlanId = null;
-      latestPlan = null;
       lastRespondingTextByItemId.clear();
       lastReasoningText = "";
       latestStepTraceText = "";
@@ -214,13 +190,6 @@ export function attachWorkerPromptHandler(args: {
         maxAttempts: event.retry.maxAttempts,
       });
       return;
-    }
-    if (raw.type === "turn.completed" && latestPlan && latestPlan.status !== "failed") {
-      publishPlan({
-        ...latestPlan,
-        status: "completed",
-        items: latestPlan.items.map((item) => ({ ...item, status: "completed" })),
-      });
     }
     if (event.phase === "responding" && typeof event.delta === "string" && event.delta) {
       const next = event.delta;
@@ -272,51 +241,6 @@ export function attachWorkerPromptHandler(args: {
         // avoiding smearing cognitive reasoning into generic step traces.
         args.sendToChat({ type: "delta", delta, source: "thought" });
       }
-      return;
-    }
-    if (rawItemType === "todo_list" && (raw.type === "item.started" || raw.type === "item.updated" || raw.type === "item.completed")) {
-      const item = rawItem as { id?: unknown; status?: unknown; items?: unknown };
-      const providerPlanId = String(item.id ?? "").trim();
-      const planStatusRaw = String(item.status ?? "").trim().toLowerCase();
-      const rawItems = Array.isArray(item.items) ? item.items : [];
-      const items = rawItems
-        .map((entry) => {
-          if (!entry || typeof entry !== "object") return null;
-          const rec = entry as Record<string, unknown>;
-          const text = String(rec.text ?? rec.content ?? rec.subject ?? rec.task ?? "").trim();
-          if (!text) return null;
-          const statusRaw = String(rec.status ?? "").trim().toLowerCase();
-          let status: "pending" | "in_progress" | "completed" = "pending";
-          if (rec.completed === true || statusRaw === "completed" || statusRaw === "done") {
-            status = "completed";
-          } else if (
-            statusRaw === "in_progress" ||
-            statusRaw === "active" ||
-            statusRaw === "doing" ||
-            statusRaw === "running"
-          ) {
-            status = "in_progress";
-          }
-          return { text, status };
-        })
-        .filter((entry): entry is { text: string; status: "pending" | "in_progress" | "completed" } => entry !== null);
-      const latestTexts = latestPlan?.items.map((entry) => entry.text) ?? [];
-      const nextTexts = items.map((entry) => entry.text);
-      const startsDistinctPlan =
-        Boolean(logicalPlanId) &&
-        Boolean(providerPlanId) &&
-        providerPlanId !== logicalPlanId &&
-        latestPlan?.status === "completed" &&
-        JSON.stringify(latestTexts) !== JSON.stringify(nextTexts);
-      const planId = startsDistinctPlan ? providerPlanId : logicalPlanId ?? (providerPlanId || `plan-${event.timestamp}`);
-      logicalPlanId = planId;
-      const hasIncompleteItems = items.some((entry) => entry.status !== "completed");
-      const planStatus = planStatusRaw === "failed"
-        ? "failed"
-        : raw.type === "item.completed" && !hasIncompleteItems
-          ? "completed"
-          : "in_progress";
-      publishPlan({ planId, status: planStatus, items });
       return;
     }
     if (isStepTracePhase(event.phase)) {

--- a/tests/web/workerPromptHandler.test.ts
+++ b/tests/web/workerPromptHandler.test.ts
@@ -349,7 +349,7 @@ describe("web/server/ws/workerPromptHandler", () => {
     });
   });
 
-  it("forwards todo_list events as plan messages and persists snapshots by kind", () => {
+  it("decommissions todo_list plan events and does not emit synthetic plan messages (ADR 0002)", () => {
     const { emit, sent, upserts } = createHarness();
 
     const baseEvent = (eventType: "item.started" | "item.updated" | "item.completed", items: Array<{ text: string; status: string }>) => ({
@@ -386,97 +386,10 @@ describe("web/server/ws/workerPromptHandler", () => {
       ]),
     );
 
-    const planMessages = sent.filter((payload) => (payload as { type?: unknown }).type === "plan") as Array<{
-      planId: string;
-      status: string;
-      items: Array<{ text: string; status: string }>;
-    }>;
-    assert.equal(planMessages.length, 3);
-    assert.equal(planMessages[0]?.status, "in_progress");
-    assert.equal(planMessages[2]?.status, "completed");
-    assert.equal(planMessages[2]?.items[0]?.status, "completed");
-
-    // All three updates share the same plan kind so they upsert in place.
-    assert.equal(upserts.length, 3);
-    for (const entry of upserts) {
-      assert.equal(entry.kind, "plan:plan-1");
-      assert.equal(entry.role, "status");
-    }
-    // Final upsert must include the completed items.
-    const finalPersisted = upserts[upserts.length - 1]?.text ?? "";
-    const parsed = JSON.parse(finalPersisted) as { items: Array<{ status: string }>; status: string };
-    assert.equal(parsed.status, "completed");
-    assert.deepEqual(parsed.items.map((entry) => entry.status), ["completed", "completed"]);
-  });
-
-  it("keeps one logical plan when provider item IDs change within a turn", () => {
-    const { emit, sent, upserts } = createHarness();
-
-    emit({
-      phase: "analysis",
-      title: "plan",
-      timestamp: 1,
-      raw: {
-        type: "item.updated",
-        item: { type: "todo_list", id: "tool-call-1", items: [{ text: "Step A", status: "in_progress" }] },
-      },
-    });
-    emit({
-      phase: "analysis",
-      title: "plan",
-      timestamp: 2,
-      raw: {
-        type: "item.updated",
-        item: { type: "todo_list", id: "tool-call-2", items: [{ text: "Step A", status: "completed" }] },
-      },
-    });
-
-    const planMessages = sent.filter((payload) => (payload as { type?: unknown }).type === "plan") as Array<{ planId: string }>;
-    assert.deepEqual(planMessages.map((message) => message.planId), ["tool-call-1", "tool-call-1"]);
-    assert.deepEqual(upserts.map((entry) => entry.kind), ["plan:tool-call-1", "plan:tool-call-1"]);
-  });
-
-  it("publishes an authoritative completed snapshot when the turn succeeds", () => {
-    const { emit, sent, upserts } = createHarness();
-
-    emit({
-      phase: "analysis",
-      title: "plan",
-      timestamp: 1,
-      raw: {
-        type: "item.updated",
-        item: {
-          type: "todo_list",
-          id: "plan-final",
-          items: [
-            { text: "Step A", status: "completed" },
-            { text: "Step B", status: "in_progress" },
-          ],
-        },
-      },
-    });
-    emit({ phase: "done", title: "done", timestamp: 2, raw: { type: "turn.completed" } });
-
-    const finalMessage = sent.at(-1) as { type: string; status: string; items: Array<{ status: string }> };
-    assert.equal(finalMessage.type, "plan");
-    assert.equal(finalMessage.status, "completed");
-    assert.deepEqual(finalMessage.items.map((item) => item.status), ["completed", "completed"]);
-    const persisted = JSON.parse(upserts.at(-1)?.text ?? "{}") as { status?: string };
-    assert.equal(persisted.status, "completed");
-  });
-
-  it("creates a new card for a distinct plan after the prior plan completes", () => {
-    const { emit, sent } = createHarness();
-    emit({
-      phase: "analysis", title: "plan", timestamp: 1,
-      raw: { type: "item.completed", item: { type: "todo_list", id: "plan-a", items: [{ text: "Step A", status: "completed" }] } },
-    });
-    emit({
-      phase: "analysis", title: "plan", timestamp: 2,
-      raw: { type: "item.started", item: { type: "todo_list", id: "plan-b", items: [{ text: "Step B", status: "pending" }] } },
-    });
-
-    const plans = sent.filter((payload) => (payload as { type?: unknown }).type === "plan") as Array<{ planId: string }>;
-    assert.deepEqual(plans.map((plan) => plan.planId), ["plan-a", "plan-b"]);
+    // ADR 0002: todo_list events are decommissioned from emitting plan messages or persisting plan:* snapshots
+    const planMessages = sent.filter((payload) => (payload as { type?: unknown }).type === "plan");
+    assert.equal(planMessages.length, 0);
+    const planUpserts = upserts.filter((entry) => entry.kind.startsWith("plan:"));
+    assert.equal(planUpserts.length, 0);
   });
 });


### PR DESCRIPTION
## Description

Closes #141

### Architectural Summary
1. **Interleaved Turn Streaming Architecture**:
   - Delineates clean phase boundaries in `chatStreaming.ts`: when a command execution block or patch occurs, the preceding in-flight assistant commentary is sealed (`streaming: false`).
   - Subsequent explanations begin as a distinct conversational segment positioned chronologically below completed actions, eliminating monolithic text bubble concatenation and the snowball duplication effect.
   - Refines semantic card ordering in `chat_sync.ts` into a two-tier model: Cognitive/Status layer (User at rank 0, Thought/Live Status at rank 1/2) is pinned above actions, while the Action & Dialogue stream (Assistant text, Execute, Patch at rank 3) preserves chronological interleaving (`Pre-command explanation -> Active command -> Post-command explanation -> Next command -> Final summary`).

2. **Retire Plan Checkbox Card (ADR 0002 Co-Delivery)**:
   - Co-delivers `docs/adr/0002-retire-plan-checkbox-cards.md` documenting the complete decommissioning of synthetic plan checkbox cards in favor of living interleaved progress.
   - Decommissions backend `publishPlan`, `PlanSnapshot`, and `todo_list` event mapping from `server/web/server/ws/workerPromptHandler.ts`.
   - Removes `planCard` template rendering and CSS styles from `client/src/components/MainChatMessageList.vue`.

### Verification
- `npm run build` and `npm run build:web`: exit 0
- `npm run lint`: exit 0
- Unit & regression tests pass cleanly:
  - `client/src/__tests__/issue-141-interleaved-turn-streaming.test.ts`
  - `client/src/__tests__/issue-129-thought-action-unification.test.ts`
  - `client/src/__tests__/chat-semantic-turn-order.test.ts`
  - `client/src/__tests__/chat-streaming-dedup.test.ts`
  - `client/src/lib/chat_sync.test.ts`
  - `tests/web/workerPromptHandler.test.ts`
