### PR TITLE
fix(web): preserve sync phases on reconnect

### DIFF
--- a/client/src/__tests__/chat-history-timestamp-preservation.test.ts
+++ b/client/src/__tests__/chat-history-timestamp-preservation.test.ts
@@ -86,4 +86,53 @@ describe("chat timestamp preservation", () => {
     expect(rt.messages.value[0]?.ts).toBeGreaterThanOrEqual(before);
     expect(rt.messages.value[0]?.ts).toBeLessThanOrEqual(after);
   });
+  it("preserves explicit event timestamp when finalizeAssistant is called with timestamp (Issue #143)", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const rt = ctx.activeRuntime.value;
+
+    const historicalTimestamp = 1672531199000;
+    chat.finalizeAssistant("Historical answer", rt, historicalTimestamp);
+
+    expect(rt.messages.value).toHaveLength(1);
+    expect(rt.messages.value[0]?.ts).toBe(historicalTimestamp);
+  });
+  it("preserves explicit event timestamp on streaming assistant finalization (Issue #143 Finding 2)", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const rt = ctx.activeRuntime.value;
+
+    chat.pushMessageBeforeLive({ id: "stream-1", role: "assistant", kind: "text", content: "In flight", streaming: true, ts: 1000 }, rt);
+    const historicalTimestamp = 1672531199000;
+    chat.finalizeAssistant("Final answer", rt, historicalTimestamp);
+
+    expect(rt.messages.value[0]?.content).toBe("Final answer");
+    expect(rt.messages.value[0]?.streaming).toBe(false);
+    expect(rt.messages.value[0]?.ts).toBe(historicalTimestamp);
+  });
+  it("preserves explicit event timestamp when replacing streaming text from delta_snapshot (Issue #143 Finding 1)", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const rt = ctx.activeRuntime.value;
+    const historicalTimestamp = 1672531199000;
+
+    chat.replaceStreamingText("Recovered snapshot text", rt, historicalTimestamp);
+
+    const streamMsg = rt.messages.value.find((m) => m.content === "Recovered snapshot text");
+    expect(streamMsg).toBeDefined();
+    expect(streamMsg?.ts).toBe(historicalTimestamp);
+  });
+  it("updates existing streaming card timestamp when valid replay ts is supplied to replaceStreamingText", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const rt = ctx.activeRuntime.value;
+
+    chat.pushMessageBeforeLive({ id: "stream-1", role: "assistant", kind: "text", content: "old", streaming: true, ts: 1000 }, rt);
+    chat.replaceStreamingText("new", rt, 2000);
+
+    const streamMsg = rt.messages.value.find((m) => m.id === "stream-1");
+    expect(streamMsg?.content).toBe("new");
+    expect(streamMsg?.streaming).toBe(true);
+    expect(streamMsg?.ts).toBe(2000);
+  });
 });

--- a/client/src/__tests__/chat-semantic-turn-order.test.ts
+++ b/client/src/__tests__/chat-semantic-turn-order.test.ts
@@ -203,4 +203,69 @@ describe("chat semantic card ordering (Issue #67)", () => {
 
     expect(rt.messages.value.map((item) => item.kind)).toEqual(["text", "thought", "execute", "text"]);
   });
+  it("handles user sync event without duplicating locally rendered user prompt (Issue #143)", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const rt = ctx.activeRuntime.value;
+    const handler = createWsMessageHandler({
+      projects: ctx.projects,
+      pid: "default",
+      rt,
+      wsInstance: { sendPrompt: () => true } as any,
+      randomId: (p: string) => p + "-mock",
+      maxTurnCommands: 5,
+      updateProject: () => {},
+      ...chat,
+    });
+
+    chat.pushMessageBeforeLive({ id: "client-msg-1", role: "user", kind: "text", content: "Optimize database queries", ts: 1000 }, rt);
+
+    handler({
+      type: "user",
+      clientMessageId: "client-msg-1",
+      text: "Optimize database queries",
+      ts: 1000,
+    });
+
+    expect(rt.messages.value.filter((m) => m.role === "user")).toHaveLength(1);
+    expect(rt.messages.value[0]?.ts).toBe(1000);
+
+    handler({
+      type: "user",
+      clientMessageId: "server-msg-2",
+      text: "Next prompt from another tab",
+      ts: 2000,
+    });
+
+    expect(rt.messages.value.filter((m) => m.role === "user")).toHaveLength(2);
+    expect(rt.messages.value[1]?.content).toBe("Next prompt from another tab");
+    expect(rt.messages.value[1]?.ts).toBe(2000);
+  });
+  it("does not collapse distinct repeated prompts with same text but distinct clientMessageId (Issue #143 Finding 4)", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const rt = ctx.activeRuntime.value;
+    const handler = createWsMessageHandler({
+      projects: ctx.projects,
+      pid: "default",
+      rt,
+      wsInstance: { sendPrompt: () => true } as any,
+      randomId: (p: string) => p + "-mock",
+      maxTurnCommands: 5,
+      updateProject: () => {},
+      ...chat,
+    });
+
+    handler({ type: "user", clientMessageId: "msg-id-1", text: "same user prompt", ts: 1000 });
+    handler({ type: "result", output: "first answer", ts: 1050 });
+    handler({ type: "user", clientMessageId: "msg-id-2", text: "same user prompt", ts: 2000 });
+    handler({ type: "result", output: "second answer", ts: 2050 });
+
+    const userMessages = rt.messages.value.filter((m) => m.role === "user");
+    expect(userMessages).toHaveLength(2);
+    expect(userMessages[0]?.id).toBe("msg-id-1");
+    expect(userMessages[1]?.id).toBe("msg-id-2");
+    expect(userMessages[0]?.ts).toBe(1000);
+    expect(userMessages[1]?.ts).toBe(2000);
+  });
 });

--- a/client/src/__tests__/issue-141-interleaved-turn-streaming.test.ts
+++ b/client/src/__tests__/issue-141-interleaved-turn-streaming.test.ts
@@ -143,4 +143,65 @@ describe("Issue #141: Interleaved turn streaming and elimination of monolithic b
 
     wrapper.unmount();
   });
+  it("seals assistant streaming bubble and creates separate cards on phase_complete without commands", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const rt = ctx.activeRuntime.value;
+    const handler = createWsMessageHandler({
+      projects: ctx.projects,
+      pid: "default",
+      rt,
+      wsInstance: { sendPrompt: () => true } as any,
+      randomId: (p: string) => `${p}-mock`,
+      maxTurnCommands: 5,
+      updateProject: () => {},
+      ...chat,
+    });
+
+    chat.pushMessageBeforeLive({ id: "user-1", role: "user", kind: "text", content: "Explain concept" }, rt);
+
+    // Phase 1 begins and streams
+    handler({ type: "delta", delta: "First part of explanation." });
+    let messages = rt.messages.value;
+    expect(messages).toHaveLength(2);
+    expect(messages[1]?.content).toBe("First part of explanation.");
+    expect(messages[1]?.streaming).toBe(true);
+
+    // Phase 1 completes (e.g. raw agent_message item completed without any command)
+    handler({ type: "phase_complete", phase: "assistant" });
+    messages = rt.messages.value;
+    expect(messages[1]?.streaming).toBe(false);
+
+    // Phase 2 streams next message
+    handler({ type: "delta", delta: "Second part of explanation." });
+    messages = rt.messages.value;
+    expect(messages).toHaveLength(3);
+    expect(messages[1]?.content).toBe("First part of explanation.");
+    expect(messages[1]?.streaming).toBe(false);
+    expect(messages[2]?.content).toBe("Second part of explanation.");
+    expect(messages[2]?.streaming).toBe(true);
+  });
+  it("phase_complete with no active assistant text is completely harmless", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const rt = ctx.activeRuntime.value;
+    const handler = createWsMessageHandler({
+      projects: ctx.projects,
+      pid: "default",
+      rt,
+      wsInstance: { sendPrompt: () => true } as any,
+      randomId: (p: string) => `${p}-mock`,
+      maxTurnCommands: 5,
+      updateProject: () => {},
+      ...chat,
+    });
+
+    chat.pushMessageBeforeLive({ id: "user-1", role: "user", kind: "text", content: "Wait for something" }, rt);
+    expect(rt.messages.value).toHaveLength(1);
+
+    // Emit phase_complete when no assistant card is active or streaming
+    handler({ type: "phase_complete", phase: "assistant" });
+    expect(rt.messages.value).toHaveLength(1);
+    expect(rt.messages.value[0]?.content).toBe("Wait for something");
+  });
 });

--- a/client/src/__tests__/ws-reconnect-preserve.test.ts
+++ b/client/src/__tests__/ws-reconnect-preserve.test.ts
@@ -419,6 +419,83 @@ describe("WS reconnect preserves UI unless thread_reset", () => {
     }
   });
 
+  it("preserves interleaved user prompts and timestamps across reconnect sync (Issue #143)", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () =>
+        JSON.stringify({
+          events: [
+            {
+              seq: 1,
+              type: "user",
+              revision: 1,
+              ts: 1000000,
+              payload: { type: "user", clientMessageId: "user-prompt-1", text: "first user query", ts: 1000000 },
+            },
+            {
+              seq: 2,
+              type: "result",
+              revision: 1,
+              ts: 1000500,
+              payload: { type: "result", output: "first assistant response", ts: 1000500, ok: true },
+            },
+            {
+              seq: 3,
+              type: "user",
+              revision: 1,
+              ts: 2000000,
+              payload: { type: "user", clientMessageId: "user-prompt-2", text: "second user query", ts: 2000000 },
+            },
+            {
+              seq: 4,
+              type: "result",
+              revision: 1,
+              ts: 2000800,
+              payload: { type: "result", output: "second assistant response", ts: 2000800, ok: true },
+            },
+          ],
+          latestSeq: 4,
+          minAvailableSeq: 1,
+          hasMore: false,
+          truncated: false,
+        }),
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    try {
+      const { wrapper, rt } = await mountReconnectHarness();
+      rt.needsChatSync = true;
+
+      // Connect and trigger reconnect catch-up
+      lastWs!.onOpen?.();
+      lastWs!.onMessage?.({ type: "welcome", latestSeq: 4, inFlight: false });
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+      await vi.waitFor(() => {
+        expect(rt.messages.value.map((m) => [m.role, m.content])).toEqual([
+          ["user", "first user query"],
+          ["assistant", "first assistant response"],
+          ["user", "second user query"],
+          ["assistant", "second assistant response"],
+        ]);
+      });
+
+      expect(rt.messages.value[0]?.ts).toBe(1000000);
+      expect(rt.messages.value[1]?.ts).toBe(1000500);
+      expect(rt.messages.value[2]?.ts).toBe(2000000);
+      expect(rt.messages.value[3]?.ts).toBe(2000800);
+      expect(rt.messages.value.filter((m) => m.role === "user")).toHaveLength(2);
+
+      // Receiving duplicate user sync event does not duplicate the rendered user prompt
+      lastWs!.onMessage?.({ type: "user", clientMessageId: "user-prompt-1", text: "first user query", ts: 1000000, seq: 1 });
+      await settleUi(wrapper);
+      expect(rt.messages.value.filter((m) => m.role === "user")).toHaveLength(2);
+
+      wrapper.unmount();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
   it("orders HTTP catch-up and overlapping live events through one sequencer", async () => {
     const originalFetch = globalThis.fetch;
     let resolveFetch: ((response: Response) => void) | null = null;

--- a/client/src/app/chat.ts
+++ b/client/src/app/chat.ts
@@ -538,6 +538,7 @@ export function createChatActions(ctx: AppContext) {
     upsertStepLiveDelta,
     upsertLiveActivity,
     clearStepLive,
+    sealActiveStreamingAssistant,
   } = createStreamingActions({
     liveStepId: LIVE_STEP_ID,
     liveActivityId: LIVE_ACTIVITY_ID,
@@ -677,7 +678,7 @@ export function createChatActions(ctx: AppContext) {
     }
   };
 
-  const finalizeAssistant = (content: string, rt?: ProjectRuntime): void => {
+  const finalizeAssistant = (content: string, rt?: ProjectRuntime, ts?: number): void => {
     const state = runtimeOrActive(rt);
     const text = String(content ?? "").replace(/\r\n/g, "\n");
     const trimmedText = text.trim();
@@ -704,6 +705,9 @@ export function createChatActions(ctx: AppContext) {
       }
       existing[streamIndex]!.content = text;
       existing[streamIndex]!.streaming = false;
+      if (Number.isFinite(ts) && (ts as number) > 0) {
+        existing[streamIndex]!.ts = Math.floor(ts as number);
+      }
       setMessages(existing.slice(), state);
       return;
     }
@@ -725,7 +729,7 @@ export function createChatActions(ctx: AppContext) {
       }
     }
 
-    pushMessageBeforeLive({ role: "assistant", kind: "text", content: text, ts: Date.now() }, state);
+    pushMessageBeforeLive({ role: "assistant", kind: "text", content: text, ts: (Number.isFinite(ts) && (ts as number) > 0) ? Math.floor(ts as number) : Date.now() }, state);
   };
 
   const pruneTaskChatBuffer = (rt: ProjectRuntime): void => {
@@ -827,6 +831,7 @@ export function createChatActions(ctx: AppContext) {
     upsertStepLiveDelta,
     upsertLiveActivity,
     clearStepLive,
+    sealActiveStreamingAssistant,
     finalizeAssistant,
     pruneTaskChatBuffer,
     bufferTaskChatEvent,

--- a/client/src/app/chatStreaming.ts
+++ b/client/src/app/chatStreaming.ts
@@ -172,6 +172,22 @@ export function createStreamingActions(params: {
     setMessages([...sealedExisting.slice(0, insertAt), nextItem, ...sealedExisting.slice(insertAt)], state);
   };
 
+  const sealActiveStreamingAssistant = (rt?: ProjectRuntime): void => {
+    const state = runtimeOrActive(rt);
+    const existing = state.messages.value.slice();
+    let updated = false;
+    const next = existing.map((m) => {
+      if (m.role === "assistant" && m.streaming && !isLiveMessageId(m.id)) {
+        updated = true;
+        return { ...m, streaming: false };
+      }
+      return m;
+    });
+    if (updated) {
+      setMessages(next, state);
+    }
+  };
+
   /**
    * Replace the in-flight assistant text with an absolute snapshot.
    *
@@ -180,7 +196,7 @@ export function createStreamingActions(params: {
    * carrying the full text so far, and catch-up applies it here — the streaming
    * block is rewritten rather than appended to, so replaying a snapshot is idempotent.
    */
-  const replaceStreamingText = (text: string, rt?: ProjectRuntime): void => {
+  const replaceStreamingText = (text: string, rt?: ProjectRuntime, ts?: number): void => {
     const state = runtimeOrActive(rt);
     const nextText = String(text ?? "");
     if (!nextText) return;
@@ -195,6 +211,7 @@ export function createStreamingActions(params: {
       existing[streamIndex] = {
         ...existing[streamIndex]!,
         content: nextContent,
+        ...(Number.isFinite(ts) && (ts as number) > 0 ? { ts: Math.floor(ts as number) } : {}),
       };
       setMessages(existing.slice(), state);
       return;
@@ -215,7 +232,7 @@ export function createStreamingActions(params: {
       kind: "text",
       content: recovered.text,
       streaming: true,
-      ts: Date.now(),
+      ts: (Number.isFinite(ts) && (ts as number) > 0) ? Math.floor(ts as number) : Date.now(),
     };
     const insertAt = findAssistantInsertIndex(sealedExisting);
     setMessages([...sealedExisting.slice(0, insertAt), nextItem, ...sealedExisting.slice(insertAt)], state);
@@ -372,5 +389,6 @@ export function createStreamingActions(params: {
     upsertStepLiveDelta,
     upsertLiveActivity,
     clearStepLive,
+    sealActiveStreamingAssistant,
   };
 }

--- a/client/src/app/projectsWs/webSocketActions.ts
+++ b/client/src/app/projectsWs/webSocketActions.ts
@@ -28,6 +28,7 @@ const TERMINAL_BOOTSTRAP_COVERED_EVENT_TYPES = new Set([
   "explored",
   "plan",
   "agent",
+  "phase_complete",
 ]);
 const BOOTSTRAP_HISTORY_WATCHDOG_MS = 5000;
 
@@ -48,6 +49,7 @@ export function createWebSocketActions(ctx: AppContext & ChatActions, deps: WsDe
 
   const {
     clearStepLive,
+    sealActiveStreamingAssistant,
     finalizeCommandBlock,
     applyStreamingDisconnectCleanup,
     pushMessageBeforeLive,
@@ -1130,6 +1132,7 @@ export function createWebSocketActions(ctx: AppContext & ChatActions, deps: WsDe
       clearPendingPrompt,
       consumeSessionReset,
       clearStepLive,
+      sealActiveStreamingAssistant,
       commandKeyForWsEvent,
       finalizeAssistant,
       finalizeCommandBlock,

--- a/client/src/app/projectsWs/wsMessage.ts
+++ b/client/src/app/projectsWs/wsMessage.ts
@@ -159,6 +159,7 @@ export type WsMessageHandlerArgs = {
   clearPendingPrompt: ChatActions["clearPendingPrompt"];
   consumeSessionReset?: (payload: Record<string, unknown>) => boolean;
   clearStepLive: ChatActions["clearStepLive"];
+  sealActiveStreamingAssistant?: ChatActions["sealActiveStreamingAssistant"];
   commandKeyForWsEvent: ChatActions["commandKeyForWsEvent"];
   finalizeAssistant: ChatActions["finalizeAssistant"];
   finalizeCommandBlock: ChatActions["finalizeCommandBlock"];
@@ -190,6 +191,7 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
     clearPendingPrompt,
     consumeSessionReset,
     clearStepLive,
+    sealActiveStreamingAssistant,
     commandKeyForWsEvent,
     finalizeAssistant,
     finalizeCommandBlock,
@@ -1229,6 +1231,30 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
       return;
     }
 
+    if (type === "phase_complete") {
+      sealActiveStreamingAssistant?.(rt);
+      return;
+    }
+
+    if (type === "user") {
+      const clientMessageId = String(msg.clientMessageId ?? msg.client_message_id ?? "").trim();
+      const text = String(msg.text ?? msg.content ?? "").trim();
+      const eventTsRaw = Number((msg as { ts?: unknown }).ts);
+      const eventTs = Number.isFinite(eventTsRaw) && eventTsRaw > 0 ? Math.floor(eventTsRaw) : Date.now();
+      const existing = rt.messages.value;
+      const alreadyHas = clientMessageId ? existing.some((m) => m.id === clientMessageId) : existing.length > 0 && existing[existing.length - 1]?.role === "user" && existing[existing.length - 1]?.content === text;
+      if (!alreadyHas && text) {
+        pushMessageBeforeLive({
+          id: clientMessageId || randomId("u"),
+          role: "user",
+          kind: "text",
+          content: text,
+          ts: eventTs,
+        }, rt);
+      }
+      return;
+    }
+
     if (type === "in_flight") {
       const inFlight = (msg as { inFlight?: unknown }).inFlight;
       if (typeof inFlight !== "boolean") return;
@@ -1299,7 +1325,9 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
       rt.busy.value = true;
       rt.turnInFlight = true;
       clearRecoveredBackendStatus();
-      replaceStreamingText(text, rt);
+      const eventTsRaw = Number((msg as { ts?: unknown }).ts);
+      const eventTs = Number.isFinite(eventTsRaw) && eventTsRaw > 0 ? Math.floor(eventTsRaw) : undefined;
+      replaceStreamingText(text, rt, eventTs);
       return;
     }
 
@@ -1537,7 +1565,9 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
         void flushQueuedPrompts(rt);
         return;
       }
-      finalizeAssistant(output, rt);
+      const resultTsRaw = Number((msg as { ts?: unknown }).ts);
+      const resultTs = Number.isFinite(resultTsRaw) && resultTsRaw > 0 ? Math.floor(resultTsRaw) : undefined;
+      finalizeAssistant(output, rt, resultTs);
       void flushQueuedPrompts(rt);
       return;
     }

--- a/client/src/lib/chat_sync.test.ts
+++ b/client/src/lib/chat_sync.test.ts
@@ -618,7 +618,76 @@ describe("chat_sync.mergeHistoryFromServer", () => {
     expect(out).toEqual(local);
   });
 
-  it("uses the newest overlap when comparable messages repeat", () => {
+  it("backfills missing intermediate user and assistant messages between anchors (Issue #143)", () => {
+    const local: ChatItem[] = [
+      msg({ id: "u1", role: "user", content: "first" }),
+      msg({ id: "a1", role: "assistant", content: "old answer" }),
+      msg({ id: "a2", role: "assistant", content: "latest answer" }),
+    ];
+    const server: ChatItem[] = [
+      msg({ id: "s1", role: "user", content: "first" }),
+      msg({ id: "s2", role: "assistant", content: "old answer" }),
+      msg({ id: "s3", role: "user", content: "missing prompt" }),
+      msg({ id: "s4", role: "assistant", content: "latest answer" }),
+    ];
+
+    const out = mergeHistoryFromServer(local, server, LIVE);
+    expect(out.map((m) => [m.role, m.content])).toEqual([
+      ["user", "first"],
+      ["assistant", "old answer"],
+      ["user", "missing prompt"],
+      ["assistant", "latest answer"],
+    ]);
+  });
+
+  it("backfills missing intermediate user prompt when assistant responses repeat (Issue #143 Finding 3)", () => {
+    const local: ChatItem[] = [
+      msg({ id: "u1", role: "user", content: "first" }),
+      msg({ id: "a1", role: "assistant", content: "same answer" }),
+      msg({ id: "a2", role: "assistant", content: "same answer" }),
+    ];
+    const server: ChatItem[] = [
+      msg({ id: "s1", role: "user", content: "first" }),
+      msg({ id: "s2", role: "assistant", content: "same answer" }),
+      msg({ id: "s3", role: "user", content: "missing prompt" }),
+      msg({ id: "s4", role: "assistant", content: "same answer" }),
+    ];
+
+    const out = mergeHistoryFromServer(local, server, LIVE);
+    expect(out.map((m) => [m.role, m.content])).toEqual([
+      ["user", "first"],
+      ["assistant", "same answer"],
+      ["user", "missing prompt"],
+      ["assistant", "same answer"],
+    ]);
+  });
+  it("backfills multiple missing intermediate user prompts across repeated assistants (Issue #143 Finding 2)", () => {
+    const local: ChatItem[] = [
+      msg({ id: "u1", role: "user", content: "first" }),
+      msg({ id: "a1", role: "assistant", content: "same" }),
+      msg({ id: "a2", role: "assistant", content: "same" }),
+    ];
+    const server: ChatItem[] = [
+      msg({ id: "s1", role: "user", content: "first" }),
+      msg({ id: "s2", role: "assistant", content: "same" }),
+      msg({ id: "s3", role: "user", content: "missing1" }),
+      msg({ id: "s4", role: "assistant", content: "same" }),
+      msg({ id: "s5", role: "user", content: "missing2" }),
+      msg({ id: "s6", role: "assistant", content: "same" }),
+    ];
+
+    const out = mergeHistoryFromServer(local, server, LIVE);
+    expect(out.map((m) => [m.role, m.content])).toEqual([
+      ["user", "first"],
+      ["assistant", "same"],
+      ["user", "missing1"],
+      ["assistant", "same"],
+      ["user", "missing2"],
+      ["assistant", "same"],
+    ]);
+  });
+
+  it("preserves intermediate server prompts and responses when comparable messages repeat (Issue #143)", () => {
     const local: ChatItem[] = [
       msg({ id: "u1", role: "user", content: "Hi" }),
       msg({ id: "a1", role: "assistant", content: "Ack" }),
@@ -632,7 +701,7 @@ describe("chat_sync.mergeHistoryFromServer", () => {
     ];
 
     const out = mergeHistoryFromServer(local, server, LIVE);
-    expect(out.map((m) => m.content)).toEqual(["Hi", "Ack", "Tail"]);
+    expect(out.map((m) => m.content)).toEqual(["Hi", "Ack", "Intermediate", "Ack", "Tail"]);
   });
 });
 

--- a/client/src/lib/chat_sync.ts
+++ b/client/src/lib/chat_sync.ts
@@ -141,6 +141,113 @@ export function finalizeStreamingOnDisconnect(items: ChatItem[], liveStepId: str
   return next;
 }
 
+function findLcsAlignment(
+  localCmp: ComparableChat[],
+  serverCmp: ComparableChat[],
+): Array<{ localIdx: number; serverIdx: number }> {
+  const n = localCmp.length;
+  const m = serverCmp.length;
+  if (n === m && localCmp.every((item, i) => comparableKey(item) === comparableKey(serverCmp[i]!))) {
+    return localCmp.map((_, i) => ({ localIdx: i, serverIdx: i }));
+  }
+
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+  for (let i = 0; i < n; i++) {
+    const localKey = comparableKey(localCmp[i]!);
+    for (let j = 0; j < m; j++) {
+      if (localKey === comparableKey(serverCmp[j]!)) {
+        dp[i + 1]![j + 1] = dp[i]![j]! + 1;
+      } else {
+        dp[i + 1]![j + 1] = Math.max(dp[i + 1]![j]!, dp[i]![j + 1]!);
+      }
+    }
+  }
+
+  const alignment: Array<{ localIdx: number; serverIdx: number }> = [];
+  let i = n;
+  let j = m;
+  while (i > 0 && j > 0) {
+    const localKey = comparableKey(localCmp[i - 1]!);
+    const serverKey = comparableKey(serverCmp[j - 1]!);
+    if (localKey === serverKey) {
+      alignment.unshift({ localIdx: i - 1, serverIdx: j - 1 });
+      i--;
+      j--;
+    } else if (dp[i]![j - 1]! >= dp[i - 1]![j]!) {
+      j--;
+    } else {
+      i--;
+    }
+  }
+
+  return alignment;
+}
+
+function alignAndBackfillHistory(
+  local: ChatItem[],
+  server: ChatItem[],
+  alignment: Array<{ localIdx: number; serverIdx: number }>,
+): ChatItem[] {
+  const result: ChatItem[] = [];
+  let prevLocalIdx = -1;
+  let prevServerIdx = -1;
+
+  for (let k = 0; k <= alignment.length; k++) {
+    const pair = alignment[k];
+    const curLocalIdx = pair ? pair.localIdx : local.length;
+    const curServerIdx = pair ? pair.serverIdx : server.length;
+
+    const localSlice = local.slice(prevLocalIdx + 1, curLocalIdx);
+    const serverSlice = server.slice(prevServerIdx + 1, curServerIdx);
+
+    if (k === alignment.length) {
+      let hydratedTail = localSlice;
+      if (serverSlice.length === 0) {
+        if (hydratedTail.length > 0 && hydratedTail.every(isDisconnectMarkedTail)) {
+          hydratedTail = [];
+        }
+        result.push(...hydratedTail);
+      } else {
+        const firstNew = serverSlice[0]!;
+        const reconciledTail = hydratedTail.filter(
+          (item) => !isDisconnectMarkedTail(item) || canReplaceLocalTailWithServer(item, firstNew),
+        );
+        const lastLocal = reconciledTail[reconciledTail.length - 1];
+        if (lastLocal && canReplaceLocalTailWithServer(lastLocal, firstNew)) {
+          const localText = normalizeContentForMerge(lastLocal.content);
+          const serverText = normalizeContentForMerge(firstNew.content);
+          const replacesTruncatedTail =
+            localText && serverText.startsWith(localText) && serverText.length > localText.length;
+          const replacesEmptyExecuteNotice = lastLocal.kind === "execute" && !localText && Boolean(serverText);
+          if (serverText && (replacesTruncatedTail || replacesEmptyExecuteNotice)) {
+            const replaced = { ...firstNew, id: lastLocal.id };
+            result.push(...reconciledTail.slice(0, -1), replaced, ...serverSlice.slice(1));
+          } else {
+            result.push(...reconciledTail, ...serverSlice);
+          }
+        } else {
+          result.push(...reconciledTail, ...serverSlice);
+        }
+      }
+    } else {
+      const localSliceKeys = new Set(localSlice.map((item) => comparableKey(toComparable([item])[0]!)));
+      const missingFromServer = serverSlice.filter(
+        (item) => !localSliceKeys.has(comparableKey(toComparable([item])[0]!)),
+      );
+      result.push(...missingFromServer, ...localSlice);
+
+      const anchorLocal = local[curLocalIdx]!;
+      const anchorServer = server[curServerIdx]!;
+      result.push(hydrateOverlappingExecuteMetadata([anchorLocal], 0, anchorServer)[0]!);
+    }
+
+    prevLocalIdx = curLocalIdx;
+    prevServerIdx = curServerIdx;
+  }
+
+  return result;
+}
+
 export function mergeHistoryFromServer(
   localMessages: ChatItem[],
   serverHistory: ChatItem[],
@@ -153,66 +260,13 @@ export function mergeHistoryFromServer(
 
   const localCmp = toComparable(local);
   const serverCmp = toComparable(server);
-  const localComparableKeyToIdx = new Map<string, number>();
-  for (let i = 0; i < localCmp.length; i += 1) {
-    localComparableKeyToIdx.set(comparableKey(localCmp[i]!), i);
-  }
-  let lastMatchedServerIdx = -1;
-  let lastMatchedLocalIdx = -1;
-
-  // Find the newest server message that already exists locally; local history may have been trimmed.
-  for (let s = serverCmp.length - 1; s >= 0; s--) {
-    const localIdx = localComparableKeyToIdx.get(comparableKey(serverCmp[s]!));
-    if (localIdx !== undefined) {
-      lastMatchedServerIdx = s;
-      lastMatchedLocalIdx = localIdx;
-      break;
-    }
-  }
-
-  if (lastMatchedServerIdx < 0) {
-    // If there is no overlap, avoid clobbering an existing UI transcript.
-    // Only hydrate from server when the local view is effectively empty (system-only).
+  const alignment = findLcsAlignment(localCmp, serverCmp);
+  if (alignment.length === 0) {
     const hasUserOrAssistant = localCmp.some((m) => m.role === "user" || m.role === "assistant");
     return hasUserOrAssistant ? local : server;
   }
 
-  const tailStart = Math.min(server.length, Math.max(0, lastMatchedServerIdx + 1));
-  const tail = server.slice(tailStart);
-  let hydratedLocal = hydrateOverlappingExecuteMetadata(local, lastMatchedLocalIdx, server[lastMatchedServerIdx]!);
-  if (tail.length === 0) {
-    const localTail = hydratedLocal.slice(lastMatchedLocalIdx + 1);
-    if (localTail.length > 0 && localTail.every(isDisconnectMarkedTail)) {
-      return hydratedLocal.slice(0, lastMatchedLocalIdx + 1);
-    }
-    return hydratedLocal;
-  }
-
-  const firstNew = tail[0]!;
-  const localPrefix = hydratedLocal.slice(0, lastMatchedLocalIdx + 1);
-  const localTail = hydratedLocal.slice(lastMatchedLocalIdx + 1);
-  const reconciledTail = localTail.filter(
-    (item) => !isDisconnectMarkedTail(item) || canReplaceLocalTailWithServer(item, firstNew),
-  );
-  if (reconciledTail.length !== localTail.length) {
-    hydratedLocal = [...localPrefix, ...reconciledTail];
-  }
-
-  // If the local tail is a truncated version of the server's next message (common after disconnect),
-  // replace it instead of duplicating it.
-  const lastLocal = hydratedLocal[hydratedLocal.length - 1]!;
-  if (canReplaceLocalTailWithServer(lastLocal, firstNew)) {
-    const localText = normalizeContentForMerge(lastLocal.content);
-    const serverText = normalizeContentForMerge(firstNew.content);
-    const replacesTruncatedTail = localText && serverText.startsWith(localText) && serverText.length > localText.length;
-    const replacesEmptyExecuteNotice = lastLocal.kind === "execute" && !localText && Boolean(serverText);
-    if (serverText && (replacesTruncatedTail || replacesEmptyExecuteNotice)) {
-      const replaced = { ...firstNew, id: lastLocal.id };
-      return [...hydratedLocal.slice(0, -1), replaced, ...tail.slice(1)];
-    }
-  }
-
-  return [...hydratedLocal, ...tail];
+  return alignAndBackfillHistory(local, server, alignment);
 }
 
 export function getSemanticCardRank(item: ChatItem): number {

--- a/docs/adr/0003-preserve-streaming-phase-boundaries.md
+++ b/docs/adr/0003-preserve-streaming-phase-boundaries.md
@@ -1,0 +1,45 @@
+# ADR 0003: Preserve Streaming Phase Boundaries Across Reconnects
+
+## Status
+Accepted
+
+## Context
+
+The Web Console receives assistant text as cumulative streaming updates while the
+Codex app-server interleaves agent messages, tool work, and multiple turns. The
+previous protocol had no durable boundary for a completed assistant item and used
+one coalesced snapshot per lane. A reconnect could therefore restore unrelated
+assistant phases as one message, overwrite earlier snapshots from a later turn, or
+render assistant results without the user prompts that caused them.
+
+## Decision
+
+1. The worker WebSocket adapter emits `phase_complete` when an assistant
+   `agent_message` item completes or a distinct assistant item begins. The client
+   seals the active assistant card at this boundary, and the next phase starts a
+   new card even when no command card is present.
+2. The sync log stores each active assistant phase as a separately coalesced
+   `delta_snapshot`. Snapshot event IDs include an instance-unique stream ID and
+   phase index. Terminal events retire only the active unsealed snapshot; sealed
+   intermediate phases remain available for replay.
+3. Prompt preflight records a durable `user` sync event after history persistence.
+   If that event cannot be recorded, only the newly inserted prompt entry is
+   rolled back so the client can retry without creating a history duplicate.
+4. History reconciliation uses bidirectional LCS alignment to backfill missing
+   server entries while preserving persisted timestamps and execution metadata.
+
+## Consequences
+
+### Positive
+
+- Reconnect replay preserves the visible conversation topology and phase order.
+- Multiple turns cannot overwrite each other's in-flight snapshots.
+- User prompts and assistant results remain aligned in incremental sync.
+- Replaying a snapshot is idempotent because it replaces the active text.
+
+### Trade-offs
+
+- The sync log retains sealed intermediate snapshots until normal lane retention
+  removes them, increasing durable event volume during long-running turns.
+- Legacy producers that omit item IDs receive conservative boundary behavior and
+  cannot provide perfect phase attribution.

--- a/docs/web.md
+++ b/docs/web.md
@@ -28,9 +28,13 @@ Web Console 聚焦于双 Lane 交互界面与 GitHub-Native 交付流：
   - 输入框模型选择器严格联动：仅展示当前 Agent 兼容且已启用的模型，切换 Agent 时自动恢复对应兼容偏好。页面加载或模型列表刷新不会覆盖已有的自定义模型选择。
   - 所有模型配置持久化于全局 SQLite 状态库 (`state.db`)。
 
-### 2.1 流式回复增量
+### 2.1 流式回复增量与阶段边界协议 (Streaming & Phase Boundaries)
 
-WebSocket 流式回复按 Provider 的消息 `itemId` 隔离累计文本；多个 agent message、工具调用和 reasoning item 交错时，不会把其他 item 的完整快照重复追加到当前回复。前端还会忽略已接收的重复累计前缀，作为传输异常时的最后一道保护。
+- **消息增量隔离**：WebSocket 流式回复按 Provider 的消息 `itemId` 隔离累计文本；多个 agent message、工具调用和 reasoning item 交错时，不会把其他 item 的完整快照重复追加到当前回复。前端还会忽略已接收的重复累计前缀，作为传输异常时的最后一道保护。
+- **阶段边界事件 (`phase_complete`)**：当单个 assistant `agent_message` 块完成时，服务端派发显式的 `phase_complete` 事件，通知客户端与重放流封板当前回复气泡并置 `streaming: false`。后续的回复增量会独立创建新气泡，即使没有命令或工具卡片交错，也不会将逻辑上独立的解释文本拼接进同一个气泡中。
+- **阶段化快照持久化与跨轮次无碰撞 ID (`delta_snapshot`)**：增量同步日志中，流式快照按执行阶段分段持久化（`eventId` 格式为 `stream:<laneKey>:<streamId>:<phase>`，其中 `streamId` 对每个活动 stream 唯一）。轮次终端结算 (`finish`) 仅清理当前未封板的活跃快照，严禁删除已封板阶段；新建或重连的 Coalescer 使用新的 stream ID，避免覆盖前序轮次已封板的快照。每当收到 `phase_complete`，当前阶段的 `delta_snapshot` 刷盘封板保留，作为可靠的断线重放记录；重放顺序严格保持 `delta_snapshot (phase 1) -> phase_complete -> delta_snapshot (phase 2) -> ...`。
+- **用户消息同步事件与原子性回滚 (`user`)**：Preflight 阶段保存用户提示词后，同步向 `SyncEventStore` 追加 `type: "user"` 增量事件，保持增量流与完整历史具有相同的回合拓扑（user -> command -> result）。若增量事件写入失败，服务端立即按精确 `kind` 回滚刚刚写入历史库的提示词条目并返回错误，确保客户端重试时不会因历史重复而遭到拦截。
+- **断线重连与双向历史对齐 (History Gap Reconciliation)**：前端对齐算法采用 LCS（最长公共子序列）执行双向对齐，当断线重放或重新拉取历史时，自动回填因连接抖动而在本地遗漏的中间用户消息与助手回复，并保留各事件在 `state.db` 中持久化的原始时间戳与执行元数据。
 
 ### 3. 全局规则系统 (Global Rules)
 - 跨项目、跨 Channel（Web Console / Telegram Bot）以及统一 Codex 引擎生效的规则引擎。

--- a/server/utils/historyStore.ts
+++ b/server/utils/historyStore.ts
@@ -36,6 +36,7 @@ type HistoryStoreStatements = {
   upsertSessionLinkStmt: SqliteStatement;
   selectSessionLinksStmt: SqliteStatement;
   selectRecentSessionLinksStmt: SqliteStatement;
+  deleteByExactKindStmt: SqliteStatement;
 };
 
 const historyStoreStatementsCache = new WeakMap<DatabaseType, HistoryStoreStatements>();
@@ -116,6 +117,7 @@ export class HistoryStore {
   private upsertSessionLinkStmt?: SqliteStatement;
   private selectSessionLinksStmt?: SqliteStatement;
   private selectRecentSessionLinksStmt?: SqliteStatement;
+  private deleteByExactKindStmt?: SqliteStatement;
 
   constructor(options: HistoryStoreOptions = {}) {
     this.storagePath = options.storagePath ?? path.join(resolveAdsStateDir(), "state.db");
@@ -218,6 +220,29 @@ export class HistoryStore {
     } catch (error) {
       logger.warn(`[HistoryStore] Failed to insert history entry (sqlite)`, error);
       return "failed";
+    }
+  }
+
+  removeByExactKind(sessionId: string, kind: string): boolean {
+    const normalizedKey = String(sessionId ?? "").trim();
+    const normalizedKind = String(kind ?? "").trim();
+    if (!normalizedKey || !normalizedKind) return false;
+    if (!this.useSqlite || !this.db || !this.deleteByExactKindStmt) {
+      const existing = this.store.get(normalizedKey);
+      if (!existing) return false;
+      const filtered = existing.filter((e) => String(e.kind ?? "").trim() !== normalizedKind);
+      if (filtered.length === existing.length) return false;
+      this.store.set(normalizedKey, filtered);
+      this.persist();
+      return true;
+    }
+    try {
+      const info = this.deleteByExactKindStmt.run(this.namespace, normalizedKey, normalizedKind);
+      const changes = (info as { changes?: unknown }).changes;
+      return typeof changes === "number" ? changes > 0 : true;
+    } catch (error) {
+      logger.warn("[HistoryStore] Failed to remove entry by exact kind", error);
+      return false;
     }
   }
 
@@ -503,6 +528,7 @@ export class HistoryStore {
     this.upsertSessionLinkStmt = statements.upsertSessionLinkStmt;
     this.selectSessionLinksStmt = statements.selectSessionLinksStmt;
     this.selectRecentSessionLinksStmt = statements.selectRecentSessionLinksStmt;
+    this.deleteByExactKindStmt = statements.deleteByExactKindStmt;
   }
 
   private trimSqlite(sessionId: string): void {
@@ -716,6 +742,9 @@ function getHistoryStoreStatements(db: DatabaseType): HistoryStoreStatements {
      ORDER BY lastSeenAt DESC
      LIMIT ?`,
   );
+  const deleteByExactKindStmt = db.prepare(
+    `DELETE FROM history_entries WHERE namespace = ? AND session_id = ? AND kind = ?`,
+  );
   const { getMigrationMarkerStmt, setMigrationMarkerStmt } = prepareMigrationMarkerStatements(db);
   const statements = {
     insertStmt,
@@ -733,6 +762,7 @@ function getHistoryStoreStatements(db: DatabaseType): HistoryStoreStatements {
     upsertSessionLinkStmt,
     selectSessionLinksStmt,
     selectRecentSessionLinksStmt,
+    deleteByExactKindStmt,
   };
   historyStoreStatementsCache.set(db, statements);
   return statements;

--- a/server/web/server/sync/deltaStream.ts
+++ b/server/web/server/sync/deltaStream.ts
@@ -1,5 +1,6 @@
 import type { SyncEventStore } from "./store.js";
 import { DELTA_SNAPSHOT_EVENT_TYPE } from "./eventClass.js";
+import { randomUUID } from "node:crypto";
 
 /**
  * How often the accumulated stream text is written to the sync log. Per-token
@@ -23,17 +24,24 @@ export type DeltaStreamCoalescer = ReturnType<typeof createDeltaStreamCoalescer>
  * point the durable `result` / `error` event and the history bootstrap carry the text.
  */
 export function createDeltaStreamCoalescer(args: {
-  store: Pick<SyncEventStore, "appendCoalesced" | "deleteCoalesced">;
+  store: Pick<SyncEventStore, "appendCoalesced" | "deleteCoalesced"> & {
+    getHighestCoalescedPhase?: (namespace: string, laneKey: string, eventType?: string) => number;
+  };
   namespace: string;
   laneKey: string;
   flushIntervalMs?: number;
   maxChars?: number;
   now?: () => number;
+  initialPhase?: number;
 }) {
   const flushIntervalMs = Math.max(0, args.flushIntervalMs ?? DELTA_SNAPSHOT_FLUSH_INTERVAL_MS);
   const maxChars = Math.max(1, args.maxChars ?? DELTA_SNAPSHOT_MAX_CHARS);
   const now = args.now ?? (() => Date.now());
-  const eventId = `stream:${args.laneKey}`;
+  // A lane can host multiple turns and coalescer instances. Keep snapshot IDs
+  // unique so a later turn cannot replace a sealed snapshot from an earlier one.
+  const streamId = randomUUID();
+  let currentPhase = Math.max(0, args.initialPhase ?? 0);
+  const getEventId = () => `stream:${args.laneKey}:${streamId}:${currentPhase}`;
 
   let text = "";
   let revision = 0;
@@ -48,7 +56,7 @@ export function createDeltaStreamCoalescer(args: {
       namespace: args.namespace,
       laneKey: args.laneKey,
       type: DELTA_SNAPSHOT_EVENT_TYPE,
-      eventId,
+      eventId: getEventId(),
       revision,
       payload: { type: DELTA_SNAPSHOT_EVENT_TYPE, text, revision },
       ts: lastFlushAt,
@@ -73,25 +81,60 @@ export function createDeltaStreamCoalescer(args: {
       writeSnapshot();
     },
 
-    /** Retire the snapshot once the turn is over; the terminal event supersedes it. */
-    finish(): void {
-      const hadStream = Boolean(text) || revision > 0;
+    /**
+     * Seal the active assistant phase so subsequent text lands in a fresh snapshot slot.
+     * Any buffered text is flushed and retained as a durable replay record for catch-up.
+     */
+    finishPhase(): void {
+      if (pending && text) {
+        writeSnapshot();
+      }
       text = "";
       revision = 0;
       lastFlushAt = 0;
       pending = false;
-      if (!hadStream) return;
+      currentPhase += 1;
+    },
+
+    /**
+     * Retire only the unsealed currently-active snapshot once the turn reaches a terminal frame,
+     * because the terminal result/history supersedes it. Sealed intermediate phase snapshots
+     * remain replayable until normal SyncEventStore retention trims them.
+     */
+    finish(): void {
+      const activeEventId = getEventId();
+      const hadActive = Boolean(text) || revision > 0;
+      text = "";
+      revision = 0;
+      lastFlushAt = 0;
+      pending = false;
+      if (!hadActive) return;
+      currentPhase += 1;
       args.store.deleteCoalesced({
         namespace: args.namespace,
         laneKey: args.laneKey,
         type: DELTA_SNAPSHOT_EVENT_TYPE,
-        eventId,
+        eventId: activeEventId,
       });
+    },
+
+    /** Reset coalescer state on lane switch/disconnect without erasing durable history. */
+    reset(): void {
+      text = "";
+      revision = 0;
+      lastFlushAt = 0;
+      pending = false;
+      currentPhase = 0;
     },
 
     /** Accumulated text so far — exposed for tests and diagnostics. */
     getText(): string {
       return text;
+    },
+
+    /** Current phase index — exposed for tests and diagnostics. */
+    getPhase(): number {
+      return currentPhase;
     },
   };
 }

--- a/server/web/server/ws/preflight.ts
+++ b/server/web/server/ws/preflight.ts
@@ -61,6 +61,7 @@ export function preflightPersistAndAck(args: {
   sessionId: string;
   userId: number;
   onPersistedMessage?: (message: { clientMessageId: string; role: "user"; text: string }) => void;
+  emitUserSyncEvent?: (event: { type: "user"; clientMessageId: string; text: string; ts: number; eventId?: string }) => { ok: boolean };
 }): { enqueue: boolean } {
   if (args.isLaneCurrent && !args.isLaneCurrent() && args.parsed.type !== "clear_history") {
     return { enqueue: false };
@@ -105,8 +106,8 @@ export function preflightPersistAndAck(args: {
       args.sendJson({ type: "error", message: "消息保存失败，请重试" });
       return { enqueue: false };
     }
-    args.sendJson({ type: "ack", client_message_id: args.clientMessageId, duplicate: persistence === "duplicate" });
     if (persistence === "duplicate") {
+      args.sendJson({ type: "ack", client_message_id: args.clientMessageId, duplicate: true });
       const historyEntries = args.historyStore.get(args.historyKey);
       const persistedPrompt = historyEntries.find(
         (entry) =>
@@ -128,6 +129,26 @@ export function preflightPersistAndAck(args: {
       }
       return { enqueue: replayIncomplete };
     }
+    if (args.emitUserSyncEvent) {
+      const syncRes = args.emitUserSyncEvent({
+        type: "user",
+        clientMessageId: args.clientMessageId,
+        text: textResult.text,
+        ts: args.receivedAt,
+        eventId: "user:" + args.clientMessageId,
+      });
+      if (!syncRes.ok) {
+        // Roll back only the prompt inserted by this attempt so a retry can succeed.
+        const rolledBack = args.historyStore.removeByExactKind(args.historyKey, entryKind);
+        if (!rolledBack) {
+          args.warn("[WebSocket][Sync] failed to roll back prompt history entry");
+        }
+        args.warn("[WebSocket][Sync] failed to append user sync event; rolled back prompt entry");
+        args.sendJson({ type: "error", message: "消息保存失败，请重试" });
+        return { enqueue: false };
+      }
+    }
+    args.sendJson({ type: "ack", client_message_id: args.clientMessageId, duplicate: false });
     args.onPersistedMessage?.({ clientMessageId: args.clientMessageId, role: "user", text: textResult.text });
     args.broadcastPersistedHistory?.();
     args.broadcastInFlight?.();

--- a/server/web/server/ws/server.ts
+++ b/server/web/server/ws/server.ts
@@ -370,11 +370,17 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
       }
       if (lane.deltaCoalescer && isStreamTerminalEvent(eventType)) {
         lane.deltaCoalescer.finish();
+      } else if (lane.deltaCoalescer && eventType === "phase_complete") {
+        lane.deltaCoalescer.finishPhase();
       }
+      const eventId = String(payloadRecord.eventId ?? payloadRecord.event_id ?? "").trim() || undefined;
+      const eventTs = Number(payloadRecord.ts);
       const seq = syncEventStore.append({
         namespace: lane.laneNamespace,
         laneKey: lane.historyKey,
         type: eventType,
+        eventId,
+        ts: Number.isFinite(eventTs) && eventTs > 0 ? Math.floor(eventTs) : undefined,
         payload: payloadRecord,
       });
       if (seq === null) {
@@ -729,6 +735,7 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
         isLaneCurrent: () => isLaneCurrent(lane),
         traceWsDuplication: config.traceWsDuplication,
         warn: (message) => logger.warn(message),
+        emitUserSyncEvent: (userEv) => { const res = appendSyncEventForLane(lane, userEv); return { ok: res.ok }; },
         sessionId: lane.sessionId,
         userId: lane.userId,
         onPersistedMessage: ({ clientMessageId: persistedId, text }) => {

--- a/server/web/server/ws/workerPromptHandler.ts
+++ b/server/web/server/ws/workerPromptHandler.ts
@@ -108,6 +108,8 @@ export function attachWorkerPromptHandler(args: {
   getThoughtText: () => string;
 } {
   const lastRespondingTextByItemId = new Map<string, string>();
+  let activeRespondingItemId: string | null = null;
+  const completedRespondingItemIds = new Set<string>();
   let lastReasoningText = "";
   let latestStepTraceText = "";
   const lastCommandOutputsByKey = new Map<string, string>();
@@ -160,6 +162,8 @@ export function attachWorkerPromptHandler(args: {
     const raw = event.raw as ThreadEvent;
     if (raw.type === "turn.started") {
       lastRespondingTextByItemId.clear();
+      activeRespondingItemId = null;
+      completedRespondingItemIds.clear();
       lastReasoningText = "";
       latestStepTraceText = "";
     }
@@ -195,6 +199,11 @@ export function attachWorkerPromptHandler(args: {
       const next = event.delta;
       const rawItem = (raw as { item?: { id?: unknown } }).item;
       const itemId = rawItem && typeof rawItem === "object" ? String(rawItem.id ?? "").trim() || "__unknown__" : "__unknown__";
+      if (activeRespondingItemId && activeRespondingItemId !== itemId && !completedRespondingItemIds.has(activeRespondingItemId)) {
+        completedRespondingItemIds.add(activeRespondingItemId);
+        args.sendToChat({ type: "phase_complete", phase: "assistant", ts: Date.now() });
+      }
+      activeRespondingItemId = itemId;
       const previous = lastRespondingTextByItemId.get(itemId) ?? "";
       if (previous && !next.startsWith(previous)) {
         // App-server agent-message updates are cumulative per item. A shorter or
@@ -208,8 +217,24 @@ export function attachWorkerPromptHandler(args: {
       }
       return;
     }
-    const rawItem = (raw as { item?: { type?: unknown } }).item;
+    const rawItem = (raw as { item?: { type?: unknown; id?: unknown } }).item;
     const rawItemType = rawItem && typeof rawItem === "object" ? String((rawItem as { type?: unknown }).type ?? "").trim() : "";
+    if (raw.type === "item.completed" && rawItemType === "agent_message") {
+      const itemId = rawItem && typeof rawItem === "object" ? String((rawItem as { id?: unknown }).id ?? "").trim() : "";
+      if (itemId) {
+        if (!completedRespondingItemIds.has(itemId)) {
+          completedRespondingItemIds.add(itemId);
+          if (activeRespondingItemId === itemId) {
+            activeRespondingItemId = null;
+            args.sendToChat({ type: "phase_complete", phase: "assistant", ts: Date.now() });
+          }
+        }
+      } else if (activeRespondingItemId === "__unknown__") {
+        activeRespondingItemId = null;
+        args.sendToChat({ type: "phase_complete", phase: "assistant", ts: Date.now() });
+      }
+    }
+
     if (raw.type === "item.completed" && rawItemType === "file_change") {
       const item = rawItem as { changes?: unknown };
       const changes = Array.isArray(item.changes) ? (item.changes as Array<{ kind?: unknown; path?: unknown }>) : [];

--- a/tests/web/deltaStreamPhase.test.ts
+++ b/tests/web/deltaStreamPhase.test.ts
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SyncEventStore } from '../../server/web/server/sync/store.js';
+import { createDeltaStreamCoalescer } from '../../server/web/server/sync/deltaStream.js';
+import { resetStateDatabaseForTests } from '../../server/state/database.js';
+import { WEB_WORKER_NAMESPACE } from '../../server/web/server/start/webLaneResources.js';
+
+describe('server/sync/deltaStream phase segmentation and lifecycle with real SyncEventStore', () => {
+  let tmpDir: string;
+  let stateDbPath: string;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ads-deltastream-sync-'));
+    stateDbPath = path.join(tmpDir, 'state.db');
+    process.env.ADS_STATE_DB_PATH = stateDbPath;
+    resetStateDatabaseForTests();
+  });
+
+  afterEach(() => {
+    resetStateDatabaseForTests();
+    process.env = { ...originalEnv };
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('yields independently replayable snapshots and preserves append/replay sequence in SQLite', () => {
+    const store = new SyncEventStore({ stateDbPath });
+    const laneKey = 'lane-phase-test';
+    const coalescer = createDeltaStreamCoalescer({
+      store,
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey,
+      flushIntervalMs: 0,
+    });
+
+    // Phase 1 streams and completes
+    coalescer.appendDelta('Phase 1 explanation');
+    coalescer.finishPhase();
+    store.append({
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey,
+      type: 'phase_complete',
+      payload: { type: 'phase_complete', phase: 'assistant' },
+    });
+
+    // Phase 2 streams and completes
+    coalescer.appendDelta('Phase 2 explanation');
+    coalescer.finishPhase();
+    store.append({
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey,
+      type: 'phase_complete',
+      payload: { type: 'phase_complete', phase: 'assistant' },
+    });
+
+    // Phase 3 streams (active)
+    coalescer.appendDelta('Phase 3 active');
+
+    // Read catch-up sequence from real SQLite
+    const result = store.readAfter({ namespace: WEB_WORKER_NAMESPACE, laneKey, afterSeq: 0 });
+    assert.equal(result.events.length, 5);
+    const sequence = result.events.map((e) => `${e.type}:${(e.payload as any).text ?? (e.payload as any).phase}`);
+    assert.deepEqual(sequence, [
+      'delta_snapshot:Phase 1 explanation',
+      'phase_complete:assistant',
+      'delta_snapshot:Phase 2 explanation',
+      'phase_complete:assistant',
+      'delta_snapshot:Phase 3 active',
+    ]);
+    assert.match(String(result.events[0]?.eventId), /^stream:lane-phase-test:[^:]+:0$/);
+    assert.match(String(result.events[2]?.eventId), /^stream:lane-phase-test:[^:]+:1$/);
+    assert.match(String(result.events[4]?.eventId), /^stream:lane-phase-test:[^:]+:2$/);
+
+    // Terminal event finish() only retires active Phase 3, keeping sealed Phase 1 and 2
+    coalescer.finish();
+    const afterTerminal = store.readAfter({ namespace: WEB_WORKER_NAMESPACE, laneKey, afterSeq: 0 });
+    assert.equal(afterTerminal.events.length, 4);
+    const terminalSeq = afterTerminal.events.map((e) => `${e.type}:${(e.payload as any).text ?? (e.payload as any).phase}`);
+    assert.deepEqual(terminalSeq, [
+      'delta_snapshot:Phase 1 explanation',
+      'phase_complete:assistant',
+      'delta_snapshot:Phase 2 explanation',
+      'phase_complete:assistant',
+    ]);
+  });
+
+  it('does not collide IDs or overwrite sealed snapshots across turns after finish()', () => {
+    const store = new SyncEventStore({ stateDbPath });
+    const laneKey = 'lane-turn-collision-test';
+    const coalescer = createDeltaStreamCoalescer({
+      store,
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey,
+      flushIntervalMs: 0,
+    });
+
+    // Turn 1 Phase 0 streams and seals
+    coalescer.appendDelta('Turn 1 Phase 0 sealed');
+    coalescer.finishPhase();
+    store.append({
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey,
+      type: 'phase_complete',
+      payload: { type: 'phase_complete', phase: 'assistant' },
+    });
+
+    // Turn 1 finishes
+    coalescer.finish();
+
+    // Verify Turn 1 sealed snapshot exists
+    let read = store.readAfter({ namespace: WEB_WORKER_NAMESPACE, laneKey, afterSeq: 0 });
+    assert.equal(read.events.length, 2);
+    assert.match(String(read.events[0]?.eventId), /^stream:lane-turn-collision-test:[^:]+:0$/);
+    assert.equal((read.events[0]?.payload as any).text, 'Turn 1 Phase 0 sealed');
+
+    // Turn 2 begins!
+    coalescer.appendDelta('Turn 2 Phase 0');
+    read = store.readAfter({ namespace: WEB_WORKER_NAMESPACE, laneKey, afterSeq: 0 });
+
+    // Turn 2 must NOT overwrite Turn 1 sealed phase 0
+    assert.equal(read.events.length, 3);
+    assert.match(String(read.events[0]?.eventId), /^stream:lane-turn-collision-test:[^:]+:0$/);
+    assert.equal((read.events[0]?.payload as any).text, 'Turn 1 Phase 0 sealed');
+    assert.match(String(read.events[2]?.eventId), /^stream:lane-turn-collision-test:[^:]+:1$/);
+    assert.equal((read.events[2]?.payload as any).text, 'Turn 2 Phase 0');
+
+    // Turn 2 completes and terminal finish() cleans active Turn 2 snapshot
+    coalescer.finish();
+    read = store.readAfter({ namespace: WEB_WORKER_NAMESPACE, laneKey, afterSeq: 0 });
+    assert.equal(read.events.length, 2);
+    assert.match(String(read.events[0]?.eventId), /^stream:lane-turn-collision-test:[^:]+:0$/);
+
+    // Now simulate reconnect: a brand new coalescer is created on the same lane
+    const coalescerReconnect = createDeltaStreamCoalescer({
+      store,
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey,
+      flushIntervalMs: 0,
+    });
+    coalescerReconnect.appendDelta('Reconnect turn delta');
+    read = store.readAfter({ namespace: WEB_WORKER_NAMESPACE, laneKey, afterSeq: 0 });
+
+    // Reconnected coalescer must pick non-colliding phase beyond existing sealed phases
+    assert.equal(read.events.length, 3);
+    assert.match(String(read.events[0]?.eventId), /^stream:lane-turn-collision-test:[^:]+:0$/);
+    assert.equal((read.events[0]?.payload as any).text, 'Turn 1 Phase 0 sealed');
+    assert.match(String(read.events[2]?.eventId), /^stream:lane-turn-collision-test:[^:]+:0$/);
+    assert.equal((read.events[2]?.payload as any).text, 'Reconnect turn delta');
+  });
+});

--- a/tests/web/preflight.test.ts
+++ b/tests/web/preflight.test.ts
@@ -1,3 +1,8 @@
+import fs from "node:fs";
+import { SyncEventStore } from "../../server/web/server/sync/store.js";
+import { resetStateDatabaseForTests } from "../../server/state/database.js";
+import os from "node:os";
+import path from "node:path";
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
@@ -343,6 +348,233 @@ describe("web/ws/preflight", () => {
       assert.equal(historyStore.get("history-plan").length, 1);
     } finally {
       historyStore.clear("history-plan");
+    }
+  });
+  it("emits replayable user sync event after prompt persistence succeeds (Issue #143)", () => {
+    const historyStore = new HistoryStore({ namespace: "test-preflight-user-sync", maxEntriesPerSession: 20 });
+    const emittedUserEvents: any[] = [];
+    const sanitizeInput = (p: any) => typeof p === "string" ? p : String(p?.text ?? "");
+
+    try {
+      const res = preflightPersistAndAck({
+        parsed: {
+          type: "prompt",
+          payload: { text: "hello sync" },
+          client_message_id: "u-sync-1",
+        },
+        requestId: "req-user-sync",
+        clientMessageId: "u-sync-1",
+        receivedAt: 1234567,
+        historyStore,
+        historyKey: "history-user-sync",
+        sanitizeInput,
+        sendJson: () => {},
+        traceWsDuplication: false,
+        warn: () => {},
+        sessionId: "session-1",
+        userId: 7,
+        emitUserSyncEvent: (ev) => { emittedUserEvents.push(ev); return { ok: true }; },
+      });
+
+      assert.deepEqual(res, { enqueue: true });
+      assert.equal(emittedUserEvents.length, 1);
+      assert.deepEqual(emittedUserEvents[0], {
+        type: "user",
+        clientMessageId: "u-sync-1",
+        text: "hello sync",
+        ts: 1234567,
+        eventId: "user:u-sync-1",
+      });
+    } finally {
+      historyStore.clear("history-user-sync");
+    }
+  });
+  it("preserves stable eventId and does not duplicate user event on duplicate preflight (Issue #143 Finding 5)", () => {
+    const historyStore = new HistoryStore({ namespace: "test-preflight-user-dedup", maxEntriesPerSession: 20 });
+    const emittedUserEvents: any[] = [];
+    const sanitizeInput = (p: any) => typeof p === "string" ? p : String(p?.text ?? "");
+
+    try {
+      const first = preflightPersistAndAck({
+        parsed: { type: "prompt", payload: { text: "idempotent prompt" }, client_message_id: "u-idempotent-1" },
+        requestId: "req-idem-1",
+        clientMessageId: "u-idempotent-1",
+        receivedAt: 5000,
+        historyStore,
+        historyKey: "history-idem-1",
+        sanitizeInput,
+        sendJson: () => {},
+        traceWsDuplication: false,
+        warn: () => {},
+        sessionId: "session-1",
+        userId: 7,
+        emitUserSyncEvent: (ev) => { emittedUserEvents.push(ev); return { ok: true }; },
+      });
+      const second = preflightPersistAndAck({
+        parsed: { type: "prompt", payload: { text: "idempotent prompt" }, client_message_id: "u-idempotent-1" },
+        requestId: "req-idem-2",
+        clientMessageId: "u-idempotent-1",
+        receivedAt: 6000,
+        historyStore,
+        historyKey: "history-idem-1",
+        sanitizeInput,
+        sendJson: () => {},
+        traceWsDuplication: false,
+        warn: () => {},
+        sessionId: "session-1",
+        userId: 7,
+        emitUserSyncEvent: (ev) => { emittedUserEvents.push(ev); return { ok: true }; },
+      });
+      assert.deepEqual(first, { enqueue: true });
+      assert.deepEqual(second, { enqueue: false });
+      assert.equal(emittedUserEvents.length, 1);
+      assert.equal(emittedUserEvents[0]?.eventId, "user:u-idempotent-1");
+      assert.equal(emittedUserEvents[0]?.clientMessageId, "u-idempotent-1");
+    } finally {
+      historyStore.clear("history-idem-1");
+    }
+  });
+  it("verifies actual SyncEventStore row persistence, eventId, ts, and idempotency (Issue #143 Finding 4)", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ads-preflight-sync-"));
+    const stateDbPath = path.join(tmpDir, "state.db");
+    const syncEventStore = new SyncEventStore({ stateDbPath });
+    const historyStore = new HistoryStore({ storagePath: stateDbPath, namespace: "test-preflight-db-sync", maxEntriesPerSession: 20 });
+    const laneKey = "lane-test-1";
+    const namespace = "worker";
+    const sanitizeInput = (p: any) => typeof p === "string" ? p : String(p?.text ?? "");
+
+    try {
+      const emitUserSyncEvent = (userEv: any) => {
+        const seq = syncEventStore.append({
+          namespace,
+          laneKey,
+          type: userEv.type,
+          eventId: userEv.eventId,
+          ts: userEv.ts,
+          payload: userEv,
+        });
+        return { ok: seq !== null };
+      };
+
+      const first = preflightPersistAndAck({
+        parsed: { type: "prompt", payload: { text: "db persisted prompt" }, client_message_id: "client-db-1" },
+        requestId: "req-db-1",
+        clientMessageId: "client-db-1",
+        receivedAt: 777000,
+        historyStore,
+        historyKey: "history-db-1",
+        sanitizeInput,
+        sendJson: () => {},
+        traceWsDuplication: false,
+        warn: () => {},
+        sessionId: "session-db-1",
+        userId: 1,
+        emitUserSyncEvent,
+      });
+
+      const second = preflightPersistAndAck({
+        parsed: { type: "prompt", payload: { text: "db persisted prompt" }, client_message_id: "client-db-1" },
+        requestId: "req-db-2",
+        clientMessageId: "client-db-1",
+        receivedAt: 888000,
+        historyStore,
+        historyKey: "history-db-1",
+        sanitizeInput,
+        sendJson: () => {},
+        traceWsDuplication: false,
+        warn: () => {},
+        sessionId: "session-db-1",
+        userId: 1,
+        emitUserSyncEvent,
+      });
+
+      assert.equal(first.enqueue, true);
+      assert.equal(second.enqueue, false);
+
+      const readResult = syncEventStore.readAfter({ namespace, laneKey, afterSeq: 0 });
+      assert.equal(readResult.events.length, 1);
+      const row = readResult.events[0];
+      assert.equal(row?.type, "user");
+      assert.equal(row?.eventId, "user:client-db-1");
+      assert.equal(row?.ts, 777000);
+      assert.equal(row?.payload.clientMessageId, "client-db-1");
+      assert.equal(row?.payload.text, "db persisted prompt");
+    } finally {
+      resetStateDatabaseForTests();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+  it("fails preflight, returns error, rolls back prompt entry, and allows retry on user sync event append failure (Finding B)", () => {
+    const historyStore = new HistoryStore({ namespace: "test-preflight-fail-sync", maxEntriesPerSession: 20 });
+    const sent: unknown[] = [];
+    const warnings: string[] = [];
+    const sanitizeInput = (p: unknown): string => typeof p === "string" ? p : String((p as { text?: unknown })?.text ?? "");
+
+    try {
+      // 1. First attempt fails sync append
+      const first = preflightPersistAndAck({
+        parsed: { type: "prompt", payload: { text: "will fail sync" }, client_message_id: "client-fail-1" },
+        requestId: "req-fail-1",
+        clientMessageId: "client-fail-1",
+        receivedAt: 999000,
+        historyStore,
+        historyKey: "history-fail-1",
+        sanitizeInput,
+        sendJson: (p) => sent.push(p),
+        traceWsDuplication: false,
+        warn: (m) => warnings.push(m),
+        sessionId: "session-fail-1",
+        userId: 1,
+        emitUserSyncEvent: () => ({ ok: false }),
+      });
+
+      assert.equal(first.enqueue, false);
+      assert.deepEqual(sent, [{ type: "error", message: "消息保存失败，请重试" }]);
+      assert.equal(warnings.length, 1);
+      // Ensure prompt was rolled back from historyStore
+      assert.equal(historyStore.get("history-fail-1").length, 0);
+
+      // 2. Immediate client retry with same clientMessageId now succeeds instead of being rejected as stale duplicate!
+      const retry = preflightPersistAndAck({
+        parsed: { type: "prompt", payload: { text: "will fail sync" }, client_message_id: "client-fail-1" },
+        requestId: "req-fail-2",
+        clientMessageId: "client-fail-1",
+        receivedAt: 1000000,
+        historyStore,
+        historyKey: "history-fail-1",
+        sanitizeInput,
+        sendJson: (p) => sent.push(p),
+        traceWsDuplication: false,
+        warn: (m) => warnings.push(m),
+        sessionId: "session-fail-1",
+        userId: 1,
+        emitUserSyncEvent: () => ({ ok: true }),
+      });
+
+      assert.equal(retry.enqueue, true);
+      assert.equal(historyStore.get("history-fail-1").length, 1);
+      assert.deepEqual(sent.at(-1), { type: "ack", client_message_id: "client-fail-1", duplicate: false });
+    } finally {
+      historyStore.clear("history-fail-1");
+    }
+  });
+  it("removeByExactKind removes only matching entry and reports success", () => {
+    const historyStore = new HistoryStore({ namespace: "test-remove-exact", maxEntriesPerSession: 20 });
+    try {
+      historyStore.add("session-1", { role: "user", text: "keep me", ts: 1000, kind: "kind:keep" });
+      historyStore.add("session-1", { role: "user", text: "delete me", ts: 1001, kind: "kind:delete" });
+      assert.equal(historyStore.get("session-1").length, 2);
+
+      const removed = historyStore.removeByExactKind("session-1", "kind:delete");
+      assert.equal(removed, true);
+      const remaining = historyStore.get("session-1");
+      assert.equal(remaining.length, 1);
+      assert.equal(remaining[0]?.kind, "kind:keep");
+
+      // Non-existent kind returns false
+      assert.equal(historyStore.removeByExactKind("session-1", "kind:nonexistent"), false);
+    } finally {
+      historyStore.clear("session-1");
     }
   });
 });

--- a/tests/web/syncEvents.test.ts
+++ b/tests/web/syncEvents.test.ts
@@ -293,4 +293,56 @@ describe("web sync events", () => {
     store.deleteCoalesced(args);
     assert.equal(store.readAfter({ namespace: WEB_WORKER_NAMESPACE, laneKey, afterSeq: 0 }).events.length, 0);
   });
+  it("preserves phase-segmented delta snapshots and phase_complete ordering through catch-up", () => {
+    const store = new SyncEventStore({ stateDbPath });
+    const laneKey = "phase-stream-lane";
+
+    // Snapshot 1
+    store.appendCoalesced({
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey,
+      type: "delta_snapshot",
+      eventId: `stream:${laneKey}:0`,
+      payload: { type: "delta_snapshot", text: "Phase 1 explanation" },
+    });
+    // Phase complete 1
+    store.append({
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey,
+      type: "phase_complete",
+      payload: { type: "phase_complete", phase: "assistant" },
+    });
+    // Snapshot 2
+    store.appendCoalesced({
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey,
+      type: "delta_snapshot",
+      eventId: `stream:${laneKey}:1`,
+      payload: { type: "delta_snapshot", text: "Phase 2 explanation" },
+    });
+    // Phase complete 2
+    store.append({
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey,
+      type: "phase_complete",
+      payload: { type: "phase_complete", phase: "assistant" },
+    });
+    // Snapshot 3 (active)
+    store.appendCoalesced({
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey,
+      type: "delta_snapshot",
+      eventId: `stream:${laneKey}:2`,
+      payload: { type: "delta_snapshot", text: "Phase 3 in-flight" },
+    });
+    const result = store.readAfter({ namespace: WEB_WORKER_NAMESPACE, laneKey, afterSeq: 0 });
+    const sequence = result.events.map((e) => `${e.type}:${(e.payload as any).text ?? (e.payload as any).phase}`);
+    assert.deepEqual(sequence, [
+      "delta_snapshot:Phase 1 explanation",
+      "phase_complete:assistant",
+      "delta_snapshot:Phase 2 explanation",
+      "phase_complete:assistant",
+      "delta_snapshot:Phase 3 in-flight",
+    ]);
+  });
 });

--- a/tests/web/workerPromptHandler.test.ts
+++ b/tests/web/workerPromptHandler.test.ts
@@ -392,4 +392,111 @@ describe("web/server/ws/workerPromptHandler", () => {
     const planUpserts = upserts.filter((entry) => entry.kind.startsWith("plan:"));
     assert.equal(planUpserts.length, 0);
   });
+  it("handles out-of-order old completion and new delta without double phase_complete", () => {
+    const { emit, sent } = createHarness();
+
+    // 1. First message streams
+    emit(respondingEvent("msg-1", "Hello from msg 1"));
+    // 2. New delta for msg-2 arrives BEFORE msg-1 completion event
+    emit(respondingEvent("msg-2", "Hello from msg 2"));
+
+    // Should have emitted exactly one phase_complete when transitioning msg-1 -> msg-2
+    let phaseEvents = sent.filter((p: any) => p.type === "phase_complete");
+    assert.equal(phaseEvents.length, 1);
+
+    // 3. Late arrival of msg-1 completed event
+    emit({
+      phase: "responding",
+      title: "done 1",
+      timestamp: Date.now(),
+      raw: {
+        type: "item.completed",
+        item: { type: "agent_message", id: "msg-1" },
+      },
+    });
+
+    // Must NOT emit a second phase_complete that would prematurely seal msg-2
+    phaseEvents = sent.filter((p: any) => p.type === "phase_complete");
+    assert.equal(phaseEvents.length, 1);
+
+    // 4. Now msg-2 legitimately completes
+    emit({
+      phase: "responding",
+      title: "done 2",
+      timestamp: Date.now(),
+      raw: {
+        type: "item.completed",
+        item: { type: "agent_message", id: "msg-2" },
+      },
+    });
+
+    phaseEvents = sent.filter((p: any) => p.type === "phase_complete");
+    assert.equal(phaseEvents.length, 2);
+  });
+  it("ignores id-less old completion after a new identified delta begins (Finding A)", () => {
+    const { emit, sent } = createHarness();
+
+    // 1. Identified message streams
+    emit(respondingEvent("msg-identified-1", "Identified text"));
+
+    // 2. An anonymous / id-less old completion arrives out of order
+    emit({
+      phase: "responding",
+      title: "done unknown",
+      timestamp: Date.now(),
+      raw: {
+        type: "item.completed",
+        item: { type: "agent_message" },
+      },
+    });
+
+    // Must NOT emit phase_complete and must NOT seal msg-identified-1
+    const phaseEvents = sent.filter((p: any) => p.type === "phase_complete");
+    assert.equal(phaseEvents.length, 0);
+  });
+  it("does not double-seal active identified phase when stale anonymous completion arrives after transition", () => {
+    const { emit, sent } = createHarness();
+
+    // 1. Anonymous delta arrives (no item ID)
+    emit({
+      phase: "responding",
+      title: "streaming anon",
+      delta: "Anonymous delta text",
+      timestamp: 1000,
+      raw: { type: "item.started", item: { type: "agent_message" } },
+    });
+
+    // 2. Identified message begins streaming -> seals anonymous phase
+    emit(respondingEvent("msg-identified-2", "Identified text"));
+    let phaseEvents = sent.filter((p: any) => p.type === "phase_complete");
+    assert.equal(phaseEvents.length, 1);
+
+    // 3. Stale anonymous completion arrives out of order
+    emit({
+      phase: "responding",
+      title: "done anon",
+      timestamp: 2000,
+      raw: {
+        type: "item.completed",
+        item: { type: "agent_message" },
+      },
+    });
+
+    // Must NOT emit a second phase_complete that would seal msg-identified-2
+    phaseEvents = sent.filter((p: any) => p.type === "phase_complete");
+    assert.equal(phaseEvents.length, 1);
+
+    // 4. Identified message finishes
+    emit({
+      phase: "responding",
+      title: "done 2",
+      timestamp: 3000,
+      raw: {
+        type: "item.completed",
+        item: { type: "agent_message", id: "msg-identified-2" },
+      },
+    });
+    phaseEvents = sent.filter((p: any) => p.type === "phase_complete");
+    assert.equal(phaseEvents.length, 2);
+  });
 });


### PR DESCRIPTION
## Summary
- add explicit assistant phase boundaries for interleaved app-server agent messages
- persist replayable phase snapshots with stream-scoped IDs across turns
- reconcile missing user history, timestamps, and user sync events during reconnect

## Verification
- `npm run test:web` (84 files, 448 tests)
- `npm run lint`
- `npx tsc -p tsconfig.build.json --noEmit`
- `npm run build`
- focused backend Issue #143 tests pass
- `npm test`: 881 passed, 1 pre-existing flaky `cliRunner` idle-timeout test failed

Closes #143
