### PR TITLE
fix(web): preserve active command blocks across reconnect races

### DIFF
--- a/client/src/__tests__/execute-preview-queue-order.test.ts
+++ b/client/src/__tests__/execute-preview-queue-order.test.ts
@@ -12,7 +12,7 @@ async function settleUi(wrapper: { vm: { $nextTick: () => Promise<void> } }): Pr
 }
 
 describe("execute preview queue ordering", () => {
-  it("keeps insertion order stable even when older commands receive later output, and renders only the newest", async () => {
+  it("keeps insertion order stable even when older commands receive later output, and renders every block", async () => {
     const rt = {
       messages: ref([] as Array<any>),
       executePreviewByKey: new Map<string, any>(),
@@ -62,9 +62,13 @@ describe("execute preview queue ordering", () => {
 
     await settleUi(wrapper);
 
-    expect(wrapper.findAll(".execute-block")).toHaveLength(1);
-    const topCmd = wrapper.find(".execute-cmd");
-    expect(topCmd.text()).toContain("cmd-4");
+    expect(wrapper.findAll(".execute-block")).toHaveLength(4);
+    expect(wrapper.findAll(".execute-cmd").map((node) => node.text())).toEqual([
+      "cmd-1",
+      "cmd-2",
+      "cmd-3",
+      "cmd-4",
+    ]);
 
     expect(wrapper.findAll(".execute-underlay")).toHaveLength(0);
 

--- a/client/src/__tests__/execute-stacking-and-command-collapse.test.ts
+++ b/client/src/__tests__/execute-stacking-and-command-collapse.test.ts
@@ -224,7 +224,7 @@ describe("chat execute stacking and command collapse", () => {
     wrapper.unmount();
   });
 
-  it("shows only the latest finalized execute history block", async () => {
+  it("shows all finalized execute history blocks in arrival order", async () => {
     const wrapper = mount(MainChat, {
       props: {
         messages: [
@@ -250,16 +250,14 @@ describe("chat execute stacking and command collapse", () => {
     await settleUi(wrapper);
 
     const blocks = wrapper.findAll(".execute-block");
-    expect(blocks).toHaveLength(1);
-    expect(blocks[0]!.find(".execute-cmd").text()).toContain("cmd-3");
-    expect(blocks[0]!.find(".execute-output").text()).toContain("out-3");
-    expect(blocks[0]!.text()).not.toContain("cmd-1");
-    expect(blocks[0]!.text()).not.toContain("cmd-2");
+    expect(blocks).toHaveLength(3);
+    expect(blocks.map((block) => block.find(".execute-cmd").text())).toEqual(["cmd-1", "cmd-2", "cmd-3"]);
+    expect(blocks.map((block) => block.find(".execute-output").text())).toEqual(["out-1", "out-2", "out-3"]);
 
     wrapper.unmount();
   });
 
-  it("shows only the latest transient execute preview when multiple previews are consecutive", async () => {
+  it("shows every transient execute preview when multiple previews are consecutive", async () => {
     const wrapper = mount(MainChat, {
       props: {
         messages: [
@@ -285,27 +283,26 @@ describe("chat execute stacking and command collapse", () => {
     await settleUi(wrapper);
 
     const blocks = wrapper.findAll(".execute-block");
-    expect(blocks).toHaveLength(1);
+    expect(blocks).toHaveLength(3);
 
     const left = wrapper.find(".execute-left");
     expect(left.exists()).toBe(true);
     expect(left.find(".prompt-tag").exists()).toBe(true);
     expect(left.find(".execute-cmd").exists()).toBe(true);
-    expect(left.find(".execute-cmd").text()).toContain("cmd-3");
+    expect(left.find(".execute-cmd").text()).toContain("cmd-1");
 
     expect(wrapper.findAll(".execute-underlay")).toHaveLength(0);
     expect(wrapper.find(".execute-stack-count").exists()).toBe(false);
 
     const output = wrapper.find(".execute-output");
     expect(output.exists()).toBe(true);
-    expect(output.text()).toContain("out-3");
-    expect(output.text()).not.toContain("out-1");
-    expect(output.text()).not.toContain("out-2");
+    expect(output.text()).toContain("out-1");
+    expect(wrapper.findAll(".execute-output").map((node) => node.text())).toEqual(["out-1", "out-2", "out-3"]);
 
     wrapper.unmount();
   });
 
-  it("shows only the latest transient execute preview even when many previews are consecutive", async () => {
+  it("shows every transient execute preview even when many previews are consecutive", async () => {
     const wrapper = mount(MainChat, {
       props: {
         messages: [
@@ -331,18 +328,18 @@ describe("chat execute stacking and command collapse", () => {
 
     await settleUi(wrapper);
 
-    expect(wrapper.findAll(".execute-block")).toHaveLength(1);
+    expect(wrapper.findAll(".execute-block")).toHaveLength(4);
 
-    const topCmd = wrapper.find(".execute-cmd");
-    expect(topCmd.exists()).toBe(true);
-    expect(topCmd.text()).toContain("cmd-4");
+    const commands = wrapper.findAll(".execute-cmd");
+    expect(commands).toHaveLength(4);
+    expect(commands.map((node) => node.text())).toEqual(["cmd-1", "cmd-2", "cmd-3", "cmd-4"]);
 
     expect(wrapper.findAll(".execute-underlay")).toHaveLength(0);
 
     wrapper.unmount();
   });
 
-  it("does not render underlays even for large stacks", async () => {
+  it("renders all blocks without underlays even for large stacks", async () => {
     const execs = Array.from({ length: 20 }, (_, i) => {
       const n = i + 1;
       return {
@@ -373,18 +370,18 @@ describe("chat execute stacking and command collapse", () => {
 
     await settleUi(wrapper);
 
-    expect(wrapper.findAll(".execute-block")).toHaveLength(1);
+    expect(wrapper.findAll(".execute-block")).toHaveLength(20);
     expect(wrapper.findAll(".execute-underlay")).toHaveLength(0);
     expect(wrapper.find(".execute-stack-count").exists()).toBe(false);
 
-    const topCmd = wrapper.find(".execute-cmd");
-    expect(topCmd.exists()).toBe(true);
-    expect(topCmd.text()).toContain("cmd-20");
+    const commands = wrapper.findAll(".execute-cmd");
+    expect(commands).toHaveLength(20);
+    expect(commands.at(-1)?.text()).toContain("cmd-20");
 
     const output = wrapper.find(".execute-output");
     expect(output.exists()).toBe(true);
-    expect(output.text()).toContain("out-20");
-    expect(output.text()).not.toContain("out-1");
+    expect(output.text()).toContain("out-1");
+    expect(wrapper.findAll(".execute-output").at(-1)?.text()).toContain("out-20");
 
     wrapper.unmount();
   });

--- a/client/src/__tests__/issue-143-reconnect-visible-blocks.test.ts
+++ b/client/src/__tests__/issue-143-reconnect-visible-blocks.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { defineComponent, ref } from "vue";
+
+import { createAppController } from "../app/controller";
+import MainChat from "../components/MainChat.vue";
+
+let lastWs: {
+  onOpen?: () => void;
+  onClose?: (ev: { code: number; reason?: string }) => void;
+  onError?: () => void;
+  onMessage?: (msg: unknown) => void;
+  sendPrompt?: (payload: unknown, clientMessageId?: string) => void;
+  clearHistory: () => void;
+} | null = null;
+
+vi.mock("../api/ws", () => {
+  class AdsWebSocket {
+    onOpen?: () => void;
+    onClose?: (ev: { code: number; reason?: string }) => void;
+    onError?: () => void;
+    onTaskEvent?: (payload: unknown) => void;
+    onMessage?: (msg: unknown) => void;
+
+    clearHistory = vi.fn();
+
+    constructor(options: { sessionId: string; chatSessionId?: string }) {
+      const chatSessionId = String(options.chatSessionId ?? "main").trim() || "main";
+      if (chatSessionId === "planner") return;
+      lastWs = this as unknown as typeof lastWs;
+    }
+
+    connect(): void {}
+    close(): void {}
+    send(): void {}
+    sendPrompt(): void {}
+    interrupt(): void {}
+  }
+
+  return { AdsWebSocket };
+});
+
+async function settleUi(wrapper: { vm: { $nextTick: () => Promise<void> } }): Promise<void> {
+  await wrapper.vm.$nextTick();
+  await Promise.resolve();
+  await wrapper.vm.$nextTick();
+}
+
+async function mountReconnectHarness() {
+  let controller: ReturnType<typeof createAppController> | null = null;
+  const Harness = defineComponent({
+    name: "ReconnectHarness",
+    setup() {
+      controller = createAppController();
+      return {};
+    },
+    template: "<div />",
+  });
+
+  const wrapper = mount(Harness);
+  await settleUi(wrapper as { vm: { $nextTick: () => Promise<void> } });
+  if (!controller) {
+    throw new Error("controller not created");
+  }
+
+  controller.loggedIn.value = true;
+  controller.currentUser.value = { id: "u-1", username: "admin" } as any;
+  await controller.connectWs("default");
+  await settleUi(wrapper as { vm: { $nextTick: () => Promise<void> } });
+  expect(lastWs).toBeTruthy();
+  return { wrapper, controller, rt: controller.getRuntime("default") };
+}
+
+describe("Issue #143 follow-up: Reconnect correctness and visible block contract", () => {
+  beforeEach(() => {
+    lastWs = null;
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    lastWs = null;
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it("1. preserves user prompt and active command across reconnect", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () =>
+        JSON.stringify({
+          events: [
+            {
+              seq: 2,
+              type: "command",
+              revision: 1,
+              ts: 5000,
+              payload: {
+                type: "command",
+                seq: 2,
+                ts: 5000,
+                command: {
+                  id: "cmd-in-flight",
+                  command: "npm test",
+                  outputDelta: "PASS tests/web.test.ts\n",
+                  status: "running",
+                },
+              },
+            },
+          ],
+          latestSeq: 2,
+          minAvailableSeq: 1,
+          hasMore: false,
+          truncated: false,
+        }),
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const { wrapper, rt } = await mountReconnectHarness();
+
+      // Initial state: user sent a prompt
+      rt.messages.value = [
+        { id: "u-1", role: "user", kind: "text", content: "Run the test suite", ts: 1000 },
+      ];
+      rt.busy.value = true;
+      rt.turnInFlight = true;
+
+      // Disconnect while turn is still running
+      lastWs!.onClose?.({ code: 1006, reason: "" });
+      await settleUi(wrapper);
+
+      // Reconnect begins
+      lastWs!.onOpen?.();
+      lastWs!.onMessage?.({
+        type: "welcome",
+        inFlight: true,
+        latestSeq: 2,
+        bootstrapHistory: true,
+      });
+
+      // Bootstrap history arrives carrying only the durable user prompt
+      lastWs!.onMessage?.({
+        type: "history",
+        items: [
+          { role: "user", text: "Run the test suite", ts: 1000, kind: "client_message_id:u-1" },
+        ],
+      });
+      await settleUi(wrapper);
+
+      // Verify user message did not disappear and active command is rendered
+      await vi.waitFor(() => {
+        expect(rt.messages.value.some((m) => m.role === "user" && m.content === "Run the test suite")).toBe(true);
+        expect(rt.messages.value.some((m) => m.kind === "execute" && m.command === "npm test")).toBe(true);
+      });
+
+      const execMsg = rt.messages.value.find((m) => m.kind === "execute");
+      expect(execMsg?.ts).toBe(5000);
+      expect(execMsg?.content).toContain("PASS tests/web.test.ts");
+
+      wrapper.unmount();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("2. creates a fresh execute block when a command is emitted after reconnect", async () => {
+    const { wrapper, rt } = await mountReconnectHarness();
+
+    // User prompt in flight
+    rt.messages.value = [
+      { id: "u-1", role: "user", kind: "text", content: "Build project", ts: 1000 },
+    ];
+    rt.busy.value = true;
+    rt.turnInFlight = true;
+
+    // Disconnect
+    lastWs!.onClose?.({ code: 1006, reason: "" });
+    await settleUi(wrapper);
+
+    // Reconnect
+    lastWs!.onOpen?.();
+    lastWs!.onMessage?.({
+      type: "welcome",
+      inFlight: true,
+      latestSeq: 0,
+      bootstrapHistory: false,
+    });
+    await settleUi(wrapper);
+
+    // Backend later starts a new command after reconnect
+    lastWs!.onMessage?.({
+      type: "command",
+      ts: 7500,
+      command: {
+        id: "cmd-new-1",
+        command: "npm run build",
+        outputDelta: "$ npm run build\nBuilding assets...\n",
+        status: "running",
+      },
+    });
+    await settleUi(wrapper);
+
+    const executeBlocks = rt.messages.value.filter((m) => m.kind === "execute");
+    expect(executeBlocks).toHaveLength(1);
+    expect(executeBlocks[0]!.command).toBe("npm run build");
+    expect(executeBlocks[0]!.content).toContain("Building assets...");
+    expect(executeBlocks[0]!.ts).toBe(7500);
+
+    // User message is still present and precedes the execute block
+    expect(rt.messages.value[0]?.role).toBe("user");
+    expect(rt.messages.value[0]?.content).toBe("Build project");
+
+    wrapper.unmount();
+  });
+
+  it("3. duplicate/reordered catch-up does not duplicate blocks", async () => {
+    const { wrapper, rt } = await mountReconnectHarness();
+
+    // Catch-up replay emits user prompt and command event
+    lastWs!.onOpen?.();
+    lastWs!.onMessage?.({
+      type: "user",
+      clientMessageId: "msg-user-1",
+      text: "Deploy service",
+      ts: 1000,
+      seq: 1,
+    });
+    lastWs!.onMessage?.({
+      type: "command",
+      seq: 2,
+      ts: 1200,
+      command: {
+        id: "c-deploy",
+        command: "deploy.sh",
+        outputDelta: "$ deploy.sh\nDeploying...\n",
+      },
+    });
+    await settleUi(wrapper);
+
+    expect(rt.messages.value.filter((m) => m.role === "user")).toHaveLength(1);
+    expect(rt.messages.value.filter((m) => m.kind === "execute")).toHaveLength(1);
+
+    // Replayed duplicate user event with same clientMessageId or text
+    lastWs!.onMessage?.({
+      type: "user",
+      clientMessageId: "msg-user-1",
+      text: "Deploy service",
+      ts: 1000,
+      seq: 1,
+    });
+    // Duplicate command event with same key/id
+    lastWs!.onMessage?.({
+      type: "command",
+      seq: 2,
+      ts: 1200,
+      command: {
+        id: "c-deploy",
+        command: "deploy.sh",
+        outputDelta: "$ deploy.sh\nDeploying...\n",
+      },
+    });
+    await settleUi(wrapper);
+
+    // Blocks MUST NOT be duplicated
+    expect(rt.messages.value.filter((m) => m.role === "user")).toHaveLength(1);
+    expect(rt.messages.value.filter((m) => m.kind === "execute")).toHaveLength(1);
+    expect(rt.messages.value.find((m) => m.kind === "execute")?.content).toBe("Deploying...");
+
+    wrapper.unmount();
+  });
+
+  it("4. thought/plan/patch do not render as standalone visible cards and patch folds into explanation", async () => {
+    const messages = ref([
+      { id: "u-1", role: "user" as const, kind: "text" as const, content: "Update app" },
+      {
+        id: "th-1",
+        role: "assistant" as const,
+        kind: "thought" as const,
+        content: "Internal reasoning about files",
+      },
+      {
+        id: "plan-1",
+        role: "system" as const,
+        kind: "plan" as const,
+        content: "[ ] Step 1",
+        plan: { planId: "p1", status: "in_progress" as const, items: [{ text: "Step 1", status: "in_progress" as const }] },
+      },
+      {
+        id: "exec-1",
+        role: "system" as const,
+        kind: "execute" as const,
+        command: "git status",
+        content: "M index.ts",
+      },
+      {
+        id: "patch-1",
+        role: "system" as const,
+        kind: "patch" as const,
+        content: "diff --git a/index.ts b/index.ts\n+const x = 1;\n",
+        patch: {
+          files: [{ path: "index.ts", added: 1, removed: 0 }],
+          diff: "diff --git a/index.ts b/index.ts\n+const x = 1;\n",
+        },
+      },
+      {
+        id: "a-1",
+        role: "assistant" as const,
+        kind: "text" as const,
+        content: "I have updated index.ts with the required change.",
+      },
+    ]);
+
+    const wrapper = mount(MainChat, {
+      props: {
+        messages: messages.value as any,
+        queuedPrompts: [],
+        pendingImages: [],
+        connected: true,
+        busy: false,
+      },
+      global: {
+        stubs: {
+          MarkdownContent: true,
+        },
+      },
+      attachTo: document.body,
+    });
+
+    await settleUi(wrapper);
+
+    // 1. thought and plan MUST NOT render as standalone cards
+    expect(wrapper.find(".thoughtCard").exists()).toBe(false);
+    expect(wrapper.find(".planCard").exists()).toBe(false);
+    expect(wrapper.findAll('.msg[data-kind="thought"]')).toHaveLength(0);
+    expect(wrapper.findAll('.msg[data-kind="plan"]')).toHaveLength(0);
+
+    // 2. patch MUST NOT render as a standalone visible card
+    expect(wrapper.findAll('.msg[data-kind="patch"]')).toHaveLength(0);
+
+    // 3. patch info is folded into the surrounding assistant explanation
+    expect(wrapper.find(".foldedPatch").exists()).toBe(true);
+    expect(wrapper.find(".patchCardTitle").text()).toContain("index.ts");
+    expect(wrapper.find(".patchCardMeta").text()).toContain("(+1 -0)");
+
+    // 4. The only visible conversational blocks are: user, execute block, and assistant
+    const renderedMsgs = wrapper.findAll(".msg");
+    // User message, execute block, and assistant explanation
+    expect(renderedMsgs).toHaveLength(3);
+    expect(renderedMsgs[0]!.attributes("data-role")).toBe("user");
+    expect(renderedMsgs[1]!.attributes("data-kind")).toBe("execute");
+    expect(renderedMsgs[2]!.attributes("data-role")).toBe("assistant");
+
+    wrapper.unmount();
+  });
+});

--- a/client/src/__tests__/mainchat-patch-card.test.ts
+++ b/client/src/__tests__/mainchat-patch-card.test.ts
@@ -10,7 +10,7 @@ async function settleUi(wrapper: { vm: { $nextTick: () => Promise<void> } }): Pr
 }
 
 describe("MainChat patch card", () => {
-  it("renders one patch row per file and expands inline", async () => {
+  it("folds one patch row per file into the assistant explanation and expands inline", async () => {
     const wrapper = mount(MainChat, {
       props: {
         messages: [
@@ -24,6 +24,12 @@ describe("MainChat patch card", () => {
               diff: "diff --git a/tests/agents/codexAppServerAdapter.test.ts b/tests/agents/codexAppServerAdapter.test.ts\n+hello\n",
               truncated: false,
             },
+          },
+          {
+            id: "assistant-1",
+            role: "assistant",
+            kind: "text",
+            content: "Updated the requested file.",
           },
         ],
         queuedPrompts: [],
@@ -41,7 +47,7 @@ describe("MainChat patch card", () => {
 
     await settleUi(wrapper);
 
-    expect(wrapper.find(".patchCard").exists()).toBe(true);
+    expect(wrapper.find(".foldedPatch").exists()).toBe(true);
     expect(wrapper.findAll(".patchCardRow")).toHaveLength(1);
     expect(wrapper.find(".patchCardTitle").text()).toContain("tests/agents/codexAppServerAdapter.test.ts");
     expect(wrapper.find(".patchCardMeta").text()).toContain("(+118 -2)");
@@ -49,7 +55,7 @@ describe("MainChat patch card", () => {
     expect(wrapper.find(".patchCardMeta .patchCardStatDel").exists()).toBe(true);
     expect(wrapper.find(".patchCardDiff").exists()).toBe(false);
 
-    const toggle = wrapper.find('[data-testid="patch-toggle-patch-1-0"]');
+    const toggle = wrapper.find('[data-testid="patch-toggle-assistant-1-0"]');
     expect(toggle.exists()).toBe(true);
     expect(toggle.text()).toContain("展开");
 
@@ -60,12 +66,12 @@ describe("MainChat patch card", () => {
     expect(wrapper.find(".patchCardDiff").text()).toContain("diff --git a/tests/agents/codexAppServerAdapter.test.ts");
     expect(wrapper.find(".patchCardDiff .patchCardDiffLine--meta").exists()).toBe(true);
     expect(wrapper.find(".patchCardDiff .patchCardDiffLine--add").exists()).toBe(true);
-    expect(wrapper.find('[data-testid="patch-toggle-patch-1-0"]').text()).toContain("收起");
+    expect(wrapper.find('[data-testid="patch-toggle-assistant-1-0"]').text()).toContain("收起");
 
     wrapper.unmount();
   });
 
-  it("renders multiple files as separate rows and expands only the target file diff", async () => {
+  it("folds multiple files as separate rows and expands only the target file diff", async () => {
     const wrapper = mount(MainChat, {
       props: {
         messages: [
@@ -98,6 +104,12 @@ describe("MainChat patch card", () => {
               truncated: false,
             },
           },
+          {
+            id: "assistant-2",
+            role: "assistant",
+            kind: "text",
+            content: "Updated both files.",
+          },
         ],
         queuedPrompts: [],
         pendingImages: [],
@@ -118,7 +130,7 @@ describe("MainChat patch card", () => {
     expect(wrapper.findAll(".patchCardRow")).toHaveLength(2);
     expect(wrapper.findAll(".patchCardDiff")).toHaveLength(0);
 
-    await wrapper.find('[data-testid="patch-toggle-patch-2-1"]').trigger("click");
+    await wrapper.find('[data-testid="patch-toggle-assistant-2-1"]').trigger("click");
     await settleUi(wrapper);
 
     const diffs = wrapper.findAll(".patchCardDiff");

--- a/client/src/__tests__/thought-card-persistence.test.ts
+++ b/client/src/__tests__/thought-card-persistence.test.ts
@@ -56,7 +56,7 @@ describe("thought card persistence", () => {
     expect(thoughtIndex).toBeLessThan(assistantIndex);
   });
 
-  it("renders collapsible thought card with summary in MainChat", async () => {
+  it("keeps thought blocks internal and does not render standalone thought cards in MainChat", async () => {
     const wrapper = mount(MainChat, {
       props: {
         messages: [
@@ -79,21 +79,14 @@ describe("thought card persistence", () => {
 
     await wrapper.vm.$nextTick();
 
-    const thoughtCard = wrapper.find(".thoughtCard");
-    expect(thoughtCard.exists()).toBe(true);
-    expect(thoughtCard.text()).toContain("思考");
-    expect(thoughtCard.text()).toContain("Need to check git diff before making changes");
-    expect(thoughtCard.find(".thoughtCardBody").exists()).toBe(false);
-
-    const toggleBtn = thoughtCard.find(".thoughtCardHeader");
-    expect(toggleBtn.exists()).toBe(true);
-    expect(toggleBtn.text()).toContain("展开");
-
-    await toggleBtn.trigger("click");
-    await wrapper.vm.$nextTick();
-
-    expect(thoughtCard.find(".thoughtCardBody").exists()).toBe(true);
-    expect(toggleBtn.text()).toContain("收起");
+    // Thought blocks are internal and must NOT render as standalone cards
+    expect(wrapper.find(".thoughtCard").exists()).toBe(false);
+    expect(wrapper.findAll('.msg[data-kind="thought"]')).toHaveLength(0);
+    // Visible blocks are user prompt and assistant explanation
+    const renderedMsgs = wrapper.findAll(".msg");
+    expect(renderedMsgs).toHaveLength(2);
+    expect(renderedMsgs[0]!.attributes("data-role")).toBe("user");
+    expect(renderedMsgs[1]!.attributes("data-role")).toBe("assistant");
 
     wrapper.unmount();
   });

--- a/client/src/__tests__/ws-reconnect-preserve.test.ts
+++ b/client/src/__tests__/ws-reconnect-preserve.test.ts
@@ -911,7 +911,7 @@ describe("WS reconnect preserves UI unless thread_reset", () => {
     wrapper.unmount();
   });
 
-  it("drops transient execute previews while reconnecting", async () => {
+  it("preserves active execute previews while reconnecting", async () => {
     const { wrapper, rt } = await mountReconnectHarness();
 
     rt.busy.value = true;
@@ -932,7 +932,7 @@ describe("WS reconnect preserves UI unless thread_reset", () => {
     lastWs!.onClose?.({ code: 1006, reason: "" });
     await settleUi(wrapper);
 
-    expect(rt.messages.value.some((m: any) => m.kind === "execute")).toBe(false);
+    expect(rt.messages.value.some((m: any) => m.kind === "execute")).toBe(true);
     expect(rt.laneStatus.value).toEqual({ kind: "progress", message: RECONNECT_BUSY_MESSAGE });
     wrapper.unmount();
   });

--- a/client/src/app/chatExecute.ts
+++ b/client/src/app/chatExecute.ts
@@ -1,4 +1,4 @@
-import type { ChatItem, ProjectRuntime } from "./controller";
+import type { ChatItem, ExecutePreviewState, ProjectRuntime } from "./controller";
 import { isLiveMessageId as isLiveMessageIdDefault } from "./chatLive";
 import { findExecuteInsertIndex, normalizeTurnSemanticOrder } from "../lib/chat_sync";
 
@@ -25,6 +25,16 @@ function stripCommandHeader(outputDelta: string, command: string): string {
   }
   return normalizedDelta;
 }
+
+export type ExecuteBlockUpdate = {
+  ts?: number;
+  eventId?: string;
+  revision?: number;
+  startOffset?: number;
+  endOffset?: number;
+  snapshot?: boolean;
+  terminal?: boolean;
+};
 
 export function createExecuteActions(params: {
   runtimeOrActive: (rt?: ProjectRuntime) => ProjectRuntime;
@@ -62,67 +72,148 @@ export function createExecuteActions(params: {
 
     // `command_execution.id` is not always unique per visible command (e.g. batched execution that reuses an id
     // while changing the command string). Dedup on (id, command) so we still count distinct commands, while
-    // avoiding overcounting multiple output deltas for the same command.
+    // avoiding overcounting multiple output deltas for the same command. For
+    // id-less frames the server assigns a synthetic identity; the command text
+    // fallback remains useful for legacy producers.
     const normalizedId = String(id ?? "").trim();
-    if (normalizedId) {
-      const key = commandKeyForWsEvent(cmd, normalizedId);
-      if (!key) return;
-      if (state.seenCommandIds.has(key)) return;
-      state.seenCommandIds.add(key);
+    if (!normalizedId) {
+      // There is no stable identity to distinguish two executions of the same
+      // command. Treat each legacy frame as a new command; modern server
+      // frames always carry the synthetic identity and are deduplicated below.
+      pushRecentCommand(cmd, state);
+      return;
     }
+    const key = commandKeyForWsEvent(cmd, normalizedId);
+    if (!key) return;
+    if (state.seenCommandIds.has(key)) return;
+    state.seenCommandIds.add(key);
     pushRecentCommand(cmd, state);
   };
 
-  const upsertExecuteBlock = (key: string, command: string, outputDelta: string, rt?: ProjectRuntime): void => {
+  const upsertExecuteBlock = (
+    key: string,
+    command: string,
+    outputDelta: string,
+    rt?: ProjectRuntime,
+    update?: number | ExecuteBlockUpdate,
+  ): void => {
     const state = runtimeOrActive(rt);
-    dropEmptyAssistantPlaceholder?.(state);
     const normalizedKey = String(key ?? "").trim();
     if (!normalizedKey) return;
     const normalizedCommand = String(command ?? "").trim();
     if (!normalizedCommand) return;
+    dropEmptyAssistantPlaceholder?.(state);
+
+    const options: ExecuteBlockUpdate = typeof update === "number" ? { ts: update } : (update ?? {});
+    const eventTs = Number.isFinite(options.ts) && (options.ts as number) > 0
+      ? Math.floor(options.ts as number)
+      : undefined;
 
     const existing = state.messages.value.slice();
-    const current =
-      state.executePreviewByKey.get(normalizedKey) ??
-      (() => {
-        const created = {
-          key: normalizedKey,
-          command: normalizedCommand,
-          previewLines: [] as string[],
-          fullLines: [] as string[],
-          totalLines: 0,
-          remainder: "",
-        };
-        state.executePreviewByKey.set(normalizedKey, created);
-        state.executeOrder = [...state.executeOrder, normalizedKey];
-        return created;
-      })();
+    const existingItem = existing.find((m) => m.id === `exec:${normalizedKey}`);
+    const prevTs = existingItem?.ts;
+    const current: ExecutePreviewState =
+      state.executePreviewByKey.get(normalizedKey) ?? {
+        key: normalizedKey,
+        command: normalizedCommand,
+        previewLines: [],
+        fullLines: [],
+        totalLines: 0,
+        remainder: "",
+        outputText: "",
+        outputStartOffset: 0,
+        outputEndOffset: 0,
+        snapshotRevision: 0,
+        terminal: false,
+        seenEventIds: new Set<string>(),
+      };
+    if (current.outputText === undefined) {
+      const legacyLines = [...(current.fullLines ?? []), ...(current.remainder ? [current.remainder] : [])];
+      current.outputText = legacyLines.join("\n");
+      current.outputStartOffset = 0;
+      current.outputEndOffset = current.outputText.length;
+    }
+    if (!state.executePreviewByKey.has(normalizedKey)) {
+      state.executePreviewByKey.set(normalizedKey, current);
+      state.executeOrder = [...state.executeOrder, normalizedKey];
+    }
 
-    const cleanedDelta = stripCommandHeader(outputDelta, normalizedCommand).replace(/^\n+/, "");
-    if (cleanedDelta) {
-      const combined = (current.remainder + cleanedDelta).replace(/\r\n/g, "\n");
-      const parts = combined.split("\n");
-      current.remainder = parts.pop() ?? "";
-      for (const rawLine of parts) {
-        const line = trimRightLine(rawLine);
-        if (!line) continue;
-        current.totalLines += 1;
-        current.fullLines.push(line);
-        if (current.previewLines.length < maxExecutePreviewLines) {
-          current.previewLines.push(line);
-        }
+    const eventId = String(options.eventId ?? "").trim();
+    if (eventId) {
+      current.seenEventIds ??= new Set<string>();
+      if (current.seenEventIds.has(eventId)) return;
+      current.seenEventIds.add(eventId);
+      if (current.seenEventIds.size > 256) {
+        const first = current.seenEventIds.values().next().value;
+        if (first) current.seenEventIds.delete(first);
       }
     }
 
-    const preview = current.previewLines.slice();
-    if (preview.length < maxExecutePreviewLines) {
-      const partial = trimRightLine(current.remainder);
-      if (partial) preview.push(partial);
+    const incoming = String(outputDelta ?? "");
+    const incomingStart = Number.isFinite(options.startOffset) && (options.startOffset as number) >= 0
+      ? Math.floor(options.startOffset as number)
+      : null;
+    const incomingEnd = Number.isFinite(options.endOffset) && (options.endOffset as number) >= 0
+      ? Math.floor(options.endOffset as number)
+      : null;
+    const currentStart = Number.isFinite(current.outputStartOffset) ? Math.max(0, current.outputStartOffset as number) : 0;
+    const currentEnd = Number.isFinite(current.outputEndOffset)
+      ? Math.max(currentStart, current.outputEndOffset as number)
+      : currentStart + String(current.outputText ?? "").length;
+
+    current.terminal = current.terminal === true || options.terminal === true;
+
+    if (options.snapshot) {
+      // A snapshot is an absolute replacement, never an append. Older or
+      // duplicate snapshots are harmless; a newer truncated snapshot wins.
+      const snapshotEnd = incomingEnd ?? Math.max(incomingStart ?? 0, (incomingStart ?? 0) + incoming.length);
+      const snapshotRevision = Number.isFinite(options.revision) && (options.revision as number) > 0
+        ? Math.floor(options.revision as number)
+        : 0;
+      const currentRevision = current.snapshotRevision ?? 0;
+      const newerRevision = snapshotRevision > currentRevision;
+      const sameRevisionWithMoreData = snapshotRevision === currentRevision && snapshotEnd > currentEnd;
+      const firstSnapshot = !current.outputText && currentEnd === currentStart;
+      const offsetlessLegacySnapshot = incomingStart === null && incomingEnd === null && snapshotRevision === 0;
+      if (firstSnapshot || newerRevision || sameRevisionWithMoreData || offsetlessLegacySnapshot) {
+        // An offsetless empty snapshot must not erase already received output.
+        if (incoming || !current.outputText || newerRevision) {
+          current.outputText = incoming;
+          current.outputStartOffset = incomingStart ?? Math.max(0, snapshotEnd - incoming.length);
+          current.outputEndOffset = snapshotEnd;
+        }
+        current.snapshotRevision = Math.max(currentRevision, snapshotRevision);
+      }
+    } else if (incoming) {
+      let appendable = incoming;
+      const nextEnd = incomingEnd ?? ((incomingStart ?? currentEnd) + incoming.length);
+      if (incomingStart !== null) {
+        if (nextEnd <= currentEnd) {
+          appendable = "";
+        } else if (incomingStart < currentEnd) {
+          appendable = incoming.slice(Math.min(incoming.length, currentEnd - incomingStart));
+        }
+      }
+      if (appendable) {
+        if (!current.outputText) {
+          current.outputStartOffset = incomingStart ?? currentStart;
+        }
+        current.outputText = `${current.outputText ?? ""}${appendable}`;
+        current.outputEndOffset = nextEnd;
+        current.outputStartOffset = Math.max(0, nextEnd - current.outputText.length);
+      } else if (incomingEnd !== null && incomingEnd > currentEnd) {
+        current.outputEndOffset = incomingEnd;
+      }
     }
 
-    const fullLines = current.fullLines.slice();
-    const partial = trimRightLine(current.remainder);
-    if (partial) fullLines.push(partial);
+    const displayText = stripCommandHeader(String(current.outputText ?? ""), normalizedCommand)
+      .replace(/^\n+/, "")
+      .replace(/\r\n/g, "\n");
+    const fullLines = displayText
+      .split("\n")
+      .map((line) => trimRightLine(line))
+      .filter((line) => Boolean(line));
+    const preview = fullLines.slice(0, maxExecutePreviewLines);
     const hiddenLineCount = Math.max(0, fullLines.length - preview.length);
     const fullContent = fullLines.join("\n");
     const itemId = `exec:${normalizedKey}`;
@@ -136,7 +227,8 @@ export function createExecuteActions(params: {
       hiddenLineCount,
       commandsTotal: state.turnCommandCount,
       commandsLimit: maxTurnCommands,
-      streaming: true,
+      streaming: current.terminal ? false : options.snapshot ? true : existingItem?.streaming !== false,
+      ts: prevTs ?? eventTs,
     };
 
     // Eliminate redundant live-step announcer card if it only announced the command

--- a/client/src/app/chatStreaming.ts
+++ b/client/src/app/chatStreaming.ts
@@ -25,7 +25,7 @@ function trimLiveStepSnapshot(text: string, maxLines: number, maxChars = 2500): 
 }
 
 function isActionStepTrace(text: string): boolean {
-  const firstLine = text.trim().split("\n")[0]!.toLowerCase();
+  const firstLine = String(text ?? "").trim().split("\n")[0]!.toLowerCase();
   return (
     firstLine.startsWith("[tool]") ||
     firstLine.startsWith("[editing]") ||
@@ -133,7 +133,12 @@ export function createStreamingActions(params: {
     return firstLine === "active" || firstLine === "thinking…" || firstLine === "thinking..." || firstLine === "working…";
   };
 
-  const upsertStreamingDelta = (delta: string, rt?: ProjectRuntime): void => {
+  const upsertStreamingDelta = (
+    delta: string,
+    rt?: ProjectRuntime,
+    ts?: number,
+    options?: { preserveRepeatedText?: boolean },
+  ): void => {
     const state = runtimeOrActive(rt);
     const chunk = String(delta ?? "");
     if (!chunk) return;
@@ -142,7 +147,7 @@ export function createStreamingActions(params: {
     const streamIndex = findActiveStreamingAssistantIndex(existing);
     if (streamIndex >= 0) {
       const current = String(existing[streamIndex]!.content ?? "");
-      const nextChunk = stripStreamingOverlap(current, chunk);
+      const nextChunk = options?.preserveRepeatedText ? chunk : stripStreamingOverlap(current, chunk);
       if (!nextChunk) return;
       existing[streamIndex] = {
         ...existing[streamIndex]!,
@@ -166,7 +171,7 @@ export function createStreamingActions(params: {
       kind: "text",
       content: chunk,
       streaming: true,
-      ts: Date.now(),
+      ts: (Number.isFinite(ts) && (ts as number) > 0) ? Math.floor(ts as number) : Date.now(),
     };
     const insertAt = findAssistantInsertIndex(sealedExisting);
     setMessages([...sealedExisting.slice(0, insertAt), nextItem, ...sealedExisting.slice(insertAt)], state);
@@ -211,7 +216,9 @@ export function createStreamingActions(params: {
       existing[streamIndex] = {
         ...existing[streamIndex]!,
         content: nextContent,
-        ...(Number.isFinite(ts) && (ts as number) > 0 ? { ts: Math.floor(ts as number) } : {}),
+        ...(Number.isFinite(ts) && (ts as number) > 0
+          ? { ts: Math.floor(ts as number) }
+          : {}),
       };
       setMessages(existing.slice(), state);
       return;
@@ -238,13 +245,15 @@ export function createStreamingActions(params: {
     setMessages([...sealedExisting.slice(0, insertAt), nextItem, ...sealedExisting.slice(insertAt)], state);
   };
 
+  // Keep reasoning in the internal message state for backwards compatibility
+  // and for history reconciliation. MainChatMessageList deliberately filters
+  // these items, so they never become standalone visible blocks.
   const upsertThoughtDelta = (delta: string, rt?: ProjectRuntime): void => {
     const state = runtimeOrActive(rt);
     const chunk = String(delta ?? "");
     if (!chunk) return;
     dropEmptyAssistantPlaceholder(state);
     const existing = state.messages.value.slice();
-
     const thoughtIndex = existing.findIndex(
       (m) => m.role === "assistant" && m.kind === "thought" && m.streaming,
     );
@@ -344,37 +353,29 @@ export function createStreamingActions(params: {
     const existing = state.messages.value.slice();
     const stepMsg = existing.find((m) => m.id === liveStepId);
     const stepContent = trimLiveStepSnapshot(String(stepMsg?.content ?? "").trim(), 14).trim();
-
     let next = existing.filter((m) => !isLiveMessageId(m.id));
 
-    // Finalize any in-flight thought card
-    next = next.map((m) => {
-      if (m.kind === "thought" && m.streaming) {
-        return { ...m, streaming: false };
-      }
-      return m;
-    });
+    // Finalize the internal reasoning card, if one was streamed. The renderer
+    // hides it; retaining it here keeps older providers/history compatible.
+    next = next.map((m) => (m.kind === "thought" && m.streaming ? { ...m, streaming: false } : m));
 
-    // Action step traces ([tool], [editing], [command], etc.) MUST NEVER be stored as thought.
-    // Only genuine reasoning text (e.g. from legacy producers that prefixed [analysis]) is preserved.
+    // Action traces are not reasoning and must not be promoted to an internal
+    // thought record when the live status card is cleared.
     if (stepContent && !isActionStepTrace(stepContent) && !shouldIgnoreStepDelta(stepContent)) {
       const cleanReasoning = stepContent.startsWith("[analysis]")
         ? stepContent.slice("[analysis]".length).trim()
         : stepContent;
-      if (cleanReasoning) {
-        const alreadyHas = next.some((m) => m.kind === "thought" && m.content.includes(cleanReasoning));
-        if (!alreadyHas) {
-          const thoughtItem: ChatItem = {
-            id: randomId("thought"),
-            role: "assistant",
-            kind: "thought",
-            content: cleanReasoning,
-            streaming: false,
-            ts: stepMsg?.ts ?? Date.now(),
-          };
-          const insertAt = findProcessInsertIndex(next);
-          next.splice(insertAt, 0, thoughtItem);
-        }
+      if (cleanReasoning && !next.some((m) => m.kind === "thought" && m.content.includes(cleanReasoning))) {
+        const thoughtItem: ChatItem = {
+          id: randomId("thought"),
+          role: "assistant",
+          kind: "thought",
+          content: cleanReasoning,
+          streaming: false,
+          ts: stepMsg?.ts ?? Date.now(),
+        };
+        const insertAt = findProcessInsertIndex(next);
+        next.splice(insertAt, 0, thoughtItem);
       }
     }
     if (next.length === existing.length && next.every((m, idx) => m === existing[idx])) return;

--- a/client/src/app/controllerTypes.ts
+++ b/client/src/app/controllerTypes.ts
@@ -131,6 +131,22 @@ export type ChatItem = {
   execution?: ChatExecutionContext;
 };
 
+export type ExecutePreviewState = {
+  key: string;
+  command: string;
+  previewLines: string[];
+  fullLines: string[];
+  totalLines: number;
+  remainder: string;
+  /** Canonical wire output used for absolute-offset reconciliation. */
+  outputText?: string;
+  outputStartOffset?: number;
+  outputEndOffset?: number;
+  snapshotRevision?: number;
+  terminal?: boolean;
+  seenEventIds?: Set<string>;
+};
+
 export type BufferedTaskChatEvent =
   | { kind: "message"; role: "user" | "assistant" | "system"; content: string }
   | { kind: "delta"; role: "assistant"; delta: string; source?: "chat" | "step"; modelUsed?: string | null }
@@ -180,10 +196,13 @@ export type ProjectRuntime = {
   turnCommandCount: number;
   executePreviewByKey: Map<
     string,
-    { key: string; command: string; previewLines: string[]; fullLines: string[]; totalLines: number; remainder: string }
+    ExecutePreviewState
   >;
   executeOrder: string[];
   seenCommandIds: Set<string>;
+  /** Last absolute end offset observed for each assistant stream. */
+  streamEndOffsets?: Map<string, number>;
+  streamSnapshotRevisions?: Map<string, number>;
   pendingImages: Ref<IncomingImage[]>;
   queuedPrompts: Ref<QueuedPrompt[]>;
   composerDraft: Ref<string>;

--- a/client/src/app/projectRuntime.ts
+++ b/client/src/app/projectRuntime.ts
@@ -43,6 +43,8 @@ export function createProjectRuntime(options: { maxLiveActivitySteps: number }):
     executePreviewByKey: new Map(),
     executeOrder: [],
     seenCommandIds: new Set(),
+    streamEndOffsets: new Map(),
+    streamSnapshotRevisions: new Map(),
     pendingImages: ref([]),
     queuedPrompts: ref([]),
     composerDraft: ref(""),

--- a/client/src/app/projectsWs/syncSequencer.test.ts
+++ b/client/src/app/projectsWs/syncSequencer.test.ts
@@ -18,8 +18,39 @@ describe("sync event sequencer", () => {
 
     sequencer.observe({ seq: 1 }, () => applied.push(1));
 
-    expect(applied).toEqual([1]);
-    expect(sequencer.getLastAppliedSeq()).toBe(1);
-    expect(writeCursor).toHaveBeenLastCalledWith(1);
+   expect(applied).toEqual([1]);
+   expect(sequencer.getLastAppliedSeq()).toBe(1);
+   expect(writeCursor).toHaveBeenLastCalledWith(1);
+ });
+
+  it("buffers unsequenced live events during catch-up and applies them after catch-up completes", () => {
+    const writeCursor = vi.fn();
+    const applied: string[] = [];
+    const sequencer = createSyncEventSequencer({ initialCursor: 0, writeCursor });
+
+    sequencer.beginCatchUp();
+    // Live unsequenced event arrives while catch-up is in flight
+    sequencer.observe({ type: "live" }, () => applied.push("unsequenced-live"));
+    expect(applied).toEqual([]);
+
+    // Sequenced catch-up item arrives
+    sequencer.applyCatchUp({ seq: 1 }, () => applied.push("catch-up-1"));
+    expect(applied).toEqual(["catch-up-1"]);
+
+    // Catch-up completes
+    sequencer.completeCatchUp();
+    expect(applied).toEqual(["catch-up-1", "unsequenced-live"]);
+  });
+
+  it("drops buffered unsequenced events when catch-up is aborted", () => {
+    const writeCursor = vi.fn();
+    const applied: string[] = [];
+    const sequencer = createSyncEventSequencer({ initialCursor: 0, writeCursor });
+
+    sequencer.beginCatchUp();
+    sequencer.observe({ type: "live" }, () => applied.push("unsequenced-live"));
+    sequencer.abortCatchUp();
+
+    expect(applied).toEqual([]);
   });
 });

--- a/client/src/app/projectsWs/syncSequencer.ts
+++ b/client/src/app/projectsWs/syncSequencer.ts
@@ -4,40 +4,131 @@ function readSequence(payload: unknown): number | null {
   return Number.isFinite(seq) && seq > 0 ? Math.floor(seq) : null;
 }
 
+function readAfterSequence(payload: unknown): number | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+  const value = Number((payload as Record<string, unknown>).afterSeq);
+  return Number.isFinite(value) && value >= 0 ? Math.floor(value) : null;
+}
+
 function normalizeCursor(value: number): number {
   return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
 }
 
+type PendingLive = {
+  afterSeq: number | null;
+  arrivalOrder: number;
+  apply: () => void;
+};
+
 export type SyncEventSequencer = ReturnType<typeof createSyncEventSequencer>;
 
+/**
+ * Serializes cursor-based HTTP catch-up with frames arriving on the live
+ * socket at the same time.
+ *
+ * A transient frame carrying `afterSeq = N` was produced after all persisted
+ * events through N. It is therefore released only after the cursor reaches N.
+ * Frames without a barrier are held until the catch-up transaction completes.
+ * The caller can explicitly mark protocol/control frames as `immediate`; this
+ * is used for `welcome`, which must establish the catch-up boundary before any
+ * other frame is observed.
+ */
 export function createSyncEventSequencer(args: {
   initialCursor: number;
   writeCursor: (seq: number) => void;
 }) {
   let lastAppliedSeq = normalizeCursor(args.initialCursor);
   let buffering = false;
+  let nextArrivalOrder = 0;
   const buffered = new Map<number, () => void>();
+  const pendingLive: PendingLive[] = [];
+
+  const sortPendingLive = (): void => {
+    pendingLive.sort((left, right) => {
+      const leftBarrier = left.afterSeq === null ? Number.POSITIVE_INFINITY : left.afterSeq;
+      const rightBarrier = right.afterSeq === null ? Number.POSITIVE_INFINITY : right.afterSeq;
+      return leftBarrier - rightBarrier || left.arrivalOrder - right.arrivalOrder;
+    });
+  };
+
+  const flushReadyLive = (includeUnbarriered = false): void => {
+    // Keep future-barrier frames queued. This matters when a live delta is
+    // received just after the HTTP page was read: applying it immediately
+    // could put it before the command whose sequence is in its barrier.
+    sortPendingLive();
+    for (let index = 0; index < pendingLive.length;) {
+      const entry = pendingLive[index]!;
+      if (entry.afterSeq === null && !includeUnbarriered) {
+        index += 1;
+        continue;
+      }
+      if (entry.afterSeq !== null && entry.afterSeq > lastAppliedSeq) {
+        index += 1;
+        continue;
+      }
+      pendingLive.splice(index, 1);
+      entry.apply();
+    }
+  };
+
+  const flushLiveBefore = (seq: number): void => {
+    sortPendingLive();
+    for (let index = 0; index < pendingLive.length;) {
+      const entry = pendingLive[index]!;
+      if (entry.afterSeq === null || entry.afterSeq >= seq) {
+        index += 1;
+        continue;
+      }
+      pendingLive.splice(index, 1);
+      entry.apply();
+    }
+  };
 
   const commit = (seq: number, apply: () => void): boolean => {
-    if (seq <= lastAppliedSeq) return false;
+    const normalizedSeq = normalizeCursor(seq);
+    if (normalizedSeq <= lastAppliedSeq) {
+      // Duplicate delivery is intentionally ignored. It is still useful to
+      // release a frame whose barrier equals the already committed cursor.
+      flushReadyLive();
+      return false;
+    }
+    flushLiveBefore(normalizedSeq);
     apply();
-    lastAppliedSeq = seq;
+    lastAppliedSeq = normalizedSeq;
     args.writeCursor(lastAppliedSeq);
+    flushReadyLive();
     return true;
   };
 
-  const observe = (payload: unknown, apply: () => void): void => {
-    const seq = readSequence(payload);
-    if (seq === null) {
+  const observe = (
+    payload: unknown,
+    apply: () => void,
+    options?: { immediate?: boolean },
+  ): void => {
+    if (options?.immediate) {
       apply();
       return;
     }
-    if (seq <= lastAppliedSeq) return;
-    if (buffering) {
-      if (!buffered.has(seq)) buffered.set(seq, apply);
+
+    const seq = readSequence(payload);
+    if (seq !== null) {
+      if (buffering) {
+        if (seq > lastAppliedSeq && !buffered.has(seq)) buffered.set(seq, apply);
+        return;
+      }
+      commit(seq, apply);
       return;
     }
-    commit(seq, apply);
+
+    if (buffering) {
+      pendingLive.push({
+        afterSeq: readAfterSequence(payload),
+        arrivalOrder: nextArrivalOrder++,
+        apply,
+      });
+      return;
+    }
+    apply();
   };
 
   const applyCatchUp = (payload: unknown, apply: () => void): void => {
@@ -57,26 +148,48 @@ export function createSyncEventSequencer(args: {
     for (const bufferedSeq of buffered.keys()) {
       if (bufferedSeq <= lastAppliedSeq) buffered.delete(bufferedSeq);
     }
+    // A full snapshot covers all barriers through its cursor. Future-barrier
+    // frames remain queued for the next observed sequence.
+    for (let index = pendingLive.length - 1; index >= 0; index -= 1) {
+      const barrier = pendingLive[index]!.afterSeq;
+      if (barrier !== null && barrier <= lastAppliedSeq) pendingLive.splice(index, 1);
+    }
+    flushReadyLive();
   };
 
   const completeCatchUp = (): void => {
     const entries = [...buffered.entries()].sort(([left], [right]) => left - right);
+    buffered.clear();
     for (const [seq, apply] of entries) {
       commit(seq, apply);
-      buffered.delete(seq);
     }
     buffering = false;
+    // Unbarriered frames are safe only after the complete catch-up
+    // transaction (including all buffered sequenced events) has committed.
+    flushReadyLive(true);
   };
 
-  const abortCatchUp = (): void => {
+  /**
+   * Abort a request attempt. By default all queued frames are discarded (lane
+   * teardown/reset semantics). `preserveLive` keeps the barrier queue and
+   * leaves the sequencer buffering so a retry can replay it after the missing
+   * persisted range has been fetched.
+   */
+  const abortCatchUp = (options?: { preserveLive?: boolean }): void => {
     buffered.clear();
-    buffering = false;
+    if (!options?.preserveLive) {
+      pendingLive.length = 0;
+      buffering = false;
+      return;
+    }
+    buffering = true;
   };
 
   const resetCursor = (): void => {
     lastAppliedSeq = 0;
-    buffering = false;
     buffered.clear();
+    pendingLive.length = 0;
+    buffering = false;
     args.writeCursor(0);
   };
 
@@ -90,5 +203,6 @@ export function createSyncEventSequencer(args: {
     resetCursor,
     getLastAppliedSeq: () => lastAppliedSeq,
     isBuffering: () => buffering,
+    getPendingCount: () => buffered.size + pendingLive.length,
   };
 }

--- a/client/src/app/projectsWs/webSocketActions.ts
+++ b/client/src/app/projectsWs/webSocketActions.ts
@@ -24,6 +24,7 @@ const TERMINAL_BOOTSTRAP_COVERED_EVENT_TYPES = new Set([
   "error",
   "status",
   "command",
+  "command_snapshot",
   "patch",
   "explored",
   "plan",
@@ -495,7 +496,16 @@ export function createWebSocketActions(ctx: AppContext & ChatActions, deps: WsDe
     let disconnectWasBusy = false;
     const shouldSyncTasks = mode === "worker";
     let handleWsPayload: ((msg: unknown) => void) | null = null;
-    let deferredBootstrapHistory: Record<string, unknown> | null = null;
+    type DeferredBootstrapHistory = {
+      payload: Record<string, unknown>;
+      seq: number | null;
+      afterSeq: number | null;
+      arrivalOrder: number;
+    };
+    let deferredBootstrapHistory: DeferredBootstrapHistory[] = [];
+    let bootstrapHistoryArrivalOrder = 0;
+    let bootstrapHistoryApplyScheduled = false;
+    let deferredRuntimeSnapshots: Record<string, unknown>[] = [];
     let bootstrapBoundarySeq = 0;
     let bootstrapReportedInFlight: boolean | null = null;
     let bootstrapHistoryExpected = false;
@@ -550,6 +560,74 @@ export function createWebSocketActions(ctx: AppContext & ChatActions, deps: WsDe
       resolveBootstrapHistoryWait = null;
     };
 
+    const selectBootstrapHistory = (): Record<string, unknown> | null => {
+      if (deferredBootstrapHistory.length === 0) return null;
+      const candidates = deferredBootstrapHistory.slice().sort((left, right) => {
+        const leftBarrier = left.seq ?? left.afterSeq ?? -1;
+        const rightBarrier = right.seq ?? right.afterSeq ?? -1;
+        return leftBarrier - rightBarrier || left.arrivalOrder - right.arrivalOrder;
+      });
+      return candidates[candidates.length - 1]?.payload ?? null;
+    };
+
+    const clearDeferredBootstrapHistory = (): void => {
+      deferredBootstrapHistory = [];
+    };
+
+    const clearDeferredRuntimeSnapshots = (): void => {
+      deferredRuntimeSnapshots = [];
+    };
+
+    const applyDeferredRuntimeSnapshots = (): void => {
+      if (deferredRuntimeSnapshots.length === 0) return;
+      const snapshots = deferredRuntimeSnapshots.slice();
+      deferredRuntimeSnapshots = [];
+      snapshots.sort((left, right) => {
+        const leftBarrier = Number(left.afterSeq ?? left.snapshotSeq ?? 0);
+        const rightBarrier = Number(right.afterSeq ?? right.snapshotSeq ?? 0);
+        return (Number.isFinite(leftBarrier) ? leftBarrier : 0) - (Number.isFinite(rightBarrier) ? rightBarrier : 0);
+      });
+      for (const snapshot of snapshots) {
+        handleWsPayload?.(snapshot);
+      }
+    };
+
+    const applyIdleBootstrapHistory = (): void => {
+      bootstrapHistoryApplyScheduled = false;
+      if (sequencer.isBuffering() || rt.syncInProgress) return;
+      const history = selectBootstrapHistory();
+      if (!history) return;
+      clearDeferredBootstrapHistory();
+      bootstrapHistoryExpected = false;
+      finishBootstrapHistoryWait();
+      bootstrapHistoryWait = null;
+      clearBootstrapHistoryWatchdog();
+      handleWsPayload?.(history);
+      applyDeferredRuntimeSnapshots();
+    };
+
+    const scheduleIdleBootstrapHistory = (): void => {
+      if (bootstrapHistoryApplyScheduled) return;
+      bootstrapHistoryApplyScheduled = true;
+      Promise.resolve().then(applyIdleBootstrapHistory);
+    };
+
+    const deferBootstrapHistory = (payload: Record<string, unknown>): void => {
+      const seqRaw = Number(payload.seq);
+      const afterRaw = Number(payload.afterSeq);
+      deferredBootstrapHistory.push({
+        payload,
+        seq: Number.isFinite(seqRaw) && seqRaw > 0 ? Math.floor(seqRaw) : null,
+        afterSeq: Number.isFinite(afterRaw) && afterRaw >= 0 ? Math.floor(afterRaw) : null,
+        arrivalOrder: bootstrapHistoryArrivalOrder++,
+      });
+      // The first history frame releases the waiter; selecting the latest
+      // candidate at the barrier below prevents a later sibling/bootstrap
+      // frame from overwriting it with an older snapshot.
+      finishBootstrapHistoryWait();
+      if (!sequencer.isBuffering() && !rt.syncInProgress) scheduleIdleBootstrapHistory();
+    };
+
     const clearBootstrapHistoryWatchdog = (): void => {
       if (bootstrapHistoryWatchdogTimer === null) return;
       try {
@@ -598,7 +676,8 @@ export function createWebSocketActions(ctx: AppContext & ChatActions, deps: WsDe
       syncRetryAttempts = 0;
       sequencer.abortCatchUp();
       sequencer = createChatSequencer(syncChatSessionId);
-      deferredBootstrapHistory = null;
+      clearDeferredBootstrapHistory();
+      clearDeferredRuntimeSnapshots();
       bootstrapBoundarySeq = 0;
       bootstrapReportedInFlight = null;
       bootstrapHistoryExpected = false;
@@ -615,7 +694,8 @@ export function createWebSocketActions(ctx: AppContext & ChatActions, deps: WsDe
       syncLaneEpoch += 1;
       sequencer.abortCatchUp();
       sequencer.resetCursor();
-      deferredBootstrapHistory = null;
+      clearDeferredBootstrapHistory();
+      clearDeferredRuntimeSnapshots();
       bootstrapBoundarySeq = 0;
       bootstrapReportedInFlight = null;
       bootstrapHistoryExpected = false;
@@ -803,7 +883,8 @@ export function createWebSocketActions(ctx: AppContext & ChatActions, deps: WsDe
               },
             );
             showSyncRecoveryNotice();
-            deferredBootstrapHistory = null;
+            clearDeferredBootstrapHistory();
+            applyDeferredRuntimeSnapshots();
             bootstrapHistoryExpected = false;
             bootstrapHistoryWait = null;
             rt.needsTaskResync = shouldSyncTasks;
@@ -837,8 +918,8 @@ export function createWebSocketActions(ctx: AppContext & ChatActions, deps: WsDe
         await waitForBootstrapHistory();
         if (!isCurrentSync(operationLaneEpoch)) return;
         rt.needsChatSync = false;
-        const bootstrapHistory = deferredBootstrapHistory;
-        deferredBootstrapHistory = null;
+        const bootstrapHistory = selectBootstrapHistory();
+        clearDeferredBootstrapHistory();
         bootstrapHistoryExpected = false;
         bootstrapHistoryWait = null;
         clearBootstrapHistoryWatchdog();
@@ -924,6 +1005,11 @@ export function createWebSocketActions(ctx: AppContext & ChatActions, deps: WsDe
           });
         }
         activeSequencer.completeCatchUp();
+        // Bootstrap snapshots are current-state rows rather than another
+        // history stream. Apply them only after the baseline and all cursor
+        // events have committed, so a stale snapshot cannot overwrite a newer
+        // live update.
+        applyDeferredRuntimeSnapshots();
         syncRetryAttempts = 0;
         clearSyncRetryTimer();
         if (shouldSyncTasks && rt.needsTaskResync) {
@@ -934,6 +1020,11 @@ export function createWebSocketActions(ctx: AppContext & ChatActions, deps: WsDe
         }
       } catch {
         if (isCurrentSync(operationLaneEpoch)) {
+          // Keep barrier-tagged live frames queued for the retry. Dropping them
+          // here loses transient deltas that have no individual replay row;
+          // the retry will first fetch the missing cursor range and then
+          // release the preserved frames in order.
+          activeSequencer.abortCatchUp({ preserveLive: true });
           rt.needsChatSync = true;
           scheduleSyncRetry();
         }
@@ -1055,7 +1146,10 @@ export function createWebSocketActions(ctx: AppContext & ChatActions, deps: WsDe
       finishBootstrapHistoryWait();
       clearStepLive(rt);
       applyStreamingDisconnectCleanup(rt);
-      finalizeCommandBlock(rt);
+      // Keep command previews across a transport disconnect. They are runtime
+      // state and the coalesced command snapshot will reconcile them after the
+      // next connection; clearing them here loses the old block before that
+      // reconciliation can happen.
       if (disconnectWasBusy && showReconnectMessage) {
         const reconnectContent = pickReconnectNotice({
           hasPendingAck: Boolean(String(rt.pendingAckClientMessageId ?? "").trim()),
@@ -1157,9 +1251,19 @@ export function createWebSocketActions(ctx: AppContext & ChatActions, deps: WsDe
       if (msg && typeof msg === "object" && !Array.isArray(msg)) {
         const rec = msg as Record<string, unknown>;
         const seq = Number(rec.seq);
-        if (rec.type === "history" && sequencer.isBuffering() && !(Number.isFinite(seq) && seq > 0)) {
-          deferredBootstrapHistory = rec;
-          finishBootstrapHistoryWait();
+        if (rec.type === "history" && !(Number.isFinite(seq) && seq > 0)) {
+          deferBootstrapHistory(rec);
+          return;
+        }
+        if (
+          rec.bootstrap === true &&
+          (rec.type === "delta_snapshot" || rec.type === "command_snapshot")
+        ) {
+          deferredRuntimeSnapshots.push(rec);
+          if (!sequencer.isBuffering() && !rt.syncInProgress) {
+            if (deferredBootstrapHistory.length > 0) scheduleIdleBootstrapHistory();
+            else applyDeferredRuntimeSnapshots();
+          }
           return;
         }
         if (
@@ -1221,6 +1325,7 @@ export function createWebSocketActions(ctx: AppContext & ChatActions, deps: WsDe
           if (Number.isFinite(latestSeq) && latestSeq > 0) {
             bootstrapBoundarySeq = Math.floor(latestSeq);
           }
+          if (rec.bootstrapHistory === true) expectBootstrapHistory();
           const taskLatestSeq = Number(rec.taskLatestSeq);
           if (
             shouldSyncTasks &&
@@ -1233,27 +1338,38 @@ export function createWebSocketActions(ctx: AppContext & ChatActions, deps: WsDe
           if (Number.isFinite(latestSeq) && latestSeq > sequencer.getLastAppliedSeq()) {
             rt.needsChatSync = true;
             sequencer.beginCatchUp();
-            if (rec.bootstrapHistory === true) expectBootstrapHistory();
             void syncChatEvents();
           } else {
             rt.needsChatSync = false;
+            // With no cursor gap the history frame is still the baseline for
+            // runtime snapshots sent in the same bootstrap. Apply it through
+            // the deferred path instead of letting a later generic observer
+            // race the snapshot.
+            if (rec.bootstrapHistory !== true) {
+              scheduleIdleBootstrapHistory();
+            }
           }
-        } else if (rec.type === "history" && !rt.awaitingBootstrapHistory && !bootstrapHistoryExpected) {
-          clearBootstrapHistoryWatchdog();
+          // `welcome` establishes the cursor boundary and must not be queued
+          // as an ordinary unsequenced live frame. Queueing it after
+          // beginCatchUp caused duplicate handling and stale barriers.
+          // The message handler owns thread/model/session state updates for
+          // welcome. Invoke it exactly once, outside the sequencer, after the
+          // cursor boundary has been established.
+          handleMessage(msg);
+          // `handleMessage` derives `awaitingBootstrapHistory` from the
+          // welcome context and queued prompts, so arm the watchdog only after
+          // that state has been updated.
+          if (
+            rec.bootstrapHistory === true ||
+            rt.awaitingBootstrapHistory ||
+            rt.inputLocked.value
+          ) {
+            armBootstrapHistoryWatchdog();
+          }
+          return;
         }
       }
       sequencer.observe(msg, () => handleMessage(msg));
-      if (
-        msg &&
-        typeof msg === "object" &&
-        !Array.isArray(msg) &&
-        (msg as Record<string, unknown>).type === "welcome" &&
-        ((msg as Record<string, unknown>).bootstrapHistory === true ||
-          rt.awaitingBootstrapHistory ||
-          rt.inputLocked.value)
-      ) {
-        armBootstrapHistoryWatchdog();
-      }
     };
 
     wsInstance.connect();

--- a/client/src/app/projectsWs/wsMessage.ts
+++ b/client/src/app/projectsWs/wsMessage.ts
@@ -20,6 +20,7 @@ import {
 } from "../../lib/chatPreferences";
 import { splitUnifiedDiffByPath } from "../../lib/patchDiff";
 import { normalizeTurnSemanticOrder } from "../../lib/chat_sync";
+import type { ExecuteBlockUpdate } from "../chatExecute";
 
 import { isReconnectNotice } from "./reconnectNotice";
 
@@ -212,6 +213,139 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
   rt.inputLocked ??= { value: false };
   rt.laneStatus ??= { value: null };
   let recoveredBackendActivitySeen = false;
+  const legacyCommandTracks = new Map<string, {
+    identity: string;
+    terminal: boolean;
+    sawOutput: boolean;
+    endOffset: number;
+    lastOutput: string;
+  }>();
+  const explicitCommandIdentities = new Map<string, string>();
+  const seenCommandFrameIds = new Set<string>();
+  let legacyCommandCounter = 0;
+
+  const finiteOffset = (value: unknown): number | null => {
+    const offset = Number(value);
+    return Number.isFinite(offset) && offset >= 0 ? Math.floor(offset) : null;
+  };
+
+  const finiteTimestamp = (value: unknown): number | undefined => {
+    const timestamp = Number(value);
+    return Number.isFinite(timestamp) && timestamp > 0 ? Math.floor(timestamp) : undefined;
+  };
+
+  const clearStreamTracking = (): void => {
+    rt.streamEndOffsets?.clear();
+    rt.streamSnapshotRevisions?.clear();
+    legacyCommandTracks.clear();
+    explicitCommandIdentities.clear();
+    seenCommandFrameIds.clear();
+  };
+
+  const resolveCommandIdentity = (payload: Record<string, unknown>, command: string, outputDelta: string): string => {
+    const explicit = String(payload.identity ?? "").trim();
+    if (explicit) return explicit;
+    const id = String(payload.id ?? "").trim();
+    if (id) {
+      const key = `${id}\u0000${command}`;
+      const known = explicitCommandIdentities.get(key);
+      if (known) return known;
+      const hasSameId = [...explicitCommandIdentities.keys()].some((entry) => entry.startsWith(`${id}\u0000`));
+      const identity = hasSameId
+        ? `${id}:${Array.from(command).reduce((hash, char) => ((hash * 33) ^ char.charCodeAt(0)) >>> 0, 5381).toString(16)}`
+        : id;
+      explicitCommandIdentities.set(key, identity);
+      return identity;
+    }
+
+    const key = command;
+    const previous = legacyCommandTracks.get(key);
+    const status = String(payload.status ?? "").trim().toLowerCase();
+    const terminal = status === "completed" || status === "failed" || status === "declined" || status === "cancelled";
+    const header = outputDelta.replace(/^\s+/, "").startsWith(`$ ${command}\n`) || outputDelta.replace(/^\s+/, "").startsWith(`$ ${command}\r\n`);
+    const startOffset = Number(payload.outputStartOffset ?? payload.output_start_offset);
+    const endOffset = Number(payload.outputEndOffset ?? payload.output_end_offset);
+    const offsetRollback = Number.isFinite(startOffset) && startOffset >= 0 && previous && startOffset < previous.endOffset;
+    const duplicateTerminal = Boolean(
+      previous?.terminal && terminal &&
+      (!outputDelta || outputDelta === previous.lastOutput || (Number.isFinite(endOffset) && endOffset <= previous.endOffset)),
+    );
+    const startsNew = Boolean(
+      !previous ||
+      (!duplicateTerminal && previous.terminal) ||
+      (!duplicateTerminal && offsetRollback) ||
+      (!duplicateTerminal && header && (previous.sawOutput || previous.terminal)),
+    );
+    const identity = startsNew ? `legacy-command-${++legacyCommandCounter}` : previous.identity;
+    legacyCommandTracks.set(key, {
+      identity,
+      terminal: previous?.terminal === true || terminal,
+      sawOutput: previous?.sawOutput === true || Boolean(outputDelta),
+      endOffset: Number.isFinite(endOffset) && endOffset >= 0
+        ? Math.floor(endOffset)
+        : (previous?.endOffset ?? 0) + outputDelta.length,
+      lastOutput: outputDelta || previous?.lastOutput || "",
+    });
+    return identity;
+  };
+
+  const consumeAssistantDelta = (payload: Record<string, unknown>): void => {
+    const delta = String(payload.delta ?? "");
+    if (!delta) return;
+    const streamId = String(payload.streamId ?? payload.stream_id ?? "").trim();
+    const startOffset = finiteOffset(payload.startOffset ?? payload.start_offset);
+    const endOffset = finiteOffset(payload.endOffset ?? payload.end_offset);
+    let chunk = delta;
+    if (streamId && startOffset !== null && endOffset !== null) {
+      rt.streamEndOffsets ??= new Map<string, number>();
+      const currentEnd = rt.streamEndOffsets.get(streamId) ?? 0;
+      if (endOffset <= currentEnd) return;
+      if (startOffset < currentEnd) {
+        chunk = delta.slice(Math.min(delta.length, currentEnd - startOffset));
+      }
+      rt.streamEndOffsets.set(streamId, endOffset);
+      if (!chunk) return;
+    }
+    const eventTs = finiteTimestamp(payload.ts);
+    upsertStreamingDelta(
+      chunk,
+      rt,
+      eventTs,
+      streamId ? { preserveRepeatedText: true } : undefined,
+    );
+  };
+
+  const consumeAssistantSnapshot = (payload: Record<string, unknown>): void => {
+    const text = String(payload.text ?? "");
+    if (!text) return;
+    const streamId = String(payload.streamId ?? payload.stream_id ?? "").trim();
+    const revisionRaw = Number(payload.revision);
+    const revision = Number.isFinite(revisionRaw) && revisionRaw > 0 ? Math.floor(revisionRaw) : 0;
+    const startOffset = finiteOffset(payload.startOffset ?? payload.start_offset);
+    const endOffset = finiteOffset(payload.endOffset ?? payload.end_offset);
+
+    if (streamId) {
+      rt.streamSnapshotRevisions ??= new Map<string, number>();
+      rt.streamEndOffsets ??= new Map<string, number>();
+      const previousRevision = rt.streamSnapshotRevisions.get(streamId) ?? 0;
+      const previousEnd = rt.streamEndOffsets.get(streamId) ?? 0;
+      if (revision > 0 && revision < previousRevision) return;
+      if (revision > 0 && revision === previousRevision && endOffset !== null && endOffset <= previousEnd) return;
+      if (revision === 0 && endOffset !== null && endOffset <= previousEnd) return;
+      if (revision > 0) rt.streamSnapshotRevisions.set(streamId, Math.max(previousRevision, revision));
+      if (endOffset !== null) rt.streamEndOffsets.set(streamId, Math.max(previousEnd, endOffset));
+    }
+
+    rt.busy.value = true;
+    rt.turnInFlight = true;
+    clearRecoveredBackendStatus();
+    const eventTs = finiteTimestamp(payload.ts);
+    replaceStreamingText(text, rt, eventTs);
+    // `startOffset` is consumed by the ordering/dedup checks above. Keeping
+    // the read here makes malformed snapshots explicit without changing the
+    // backwards-compatible wire shape.
+    void startOffset;
+  };
 
   const isGitDiffCommand = (raw: string): boolean => {
     const cmd = String(raw ?? "").trim().toLowerCase();
@@ -679,6 +813,7 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
     rt.awaitingBootstrapHistory = false;
     rt.pendingAckClientMessageId = null;
     rt.queuedPrompts.value = [];
+    clearStreamTracking();
     resetTurnPatchSummary();
     clearPendingPrompt(rt);
     clearStepLive(rt);
@@ -1108,6 +1243,8 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
           );
           continue;
         }
+        // Plans and reasoning remain internal history records for compatibility;
+        // MainChatMessageList filters them from the visible block stream.
         if (kind.startsWith("plan:") || kind === "plan") {
           restoredHistoryStatus = null;
           const planId = kind.startsWith("plan:") ? kind.slice("plan:".length).trim() || `plan-${idx}` : `plan-${idx}`;
@@ -1118,30 +1255,21 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
             parsed = null;
           }
           if (!parsed || typeof parsed !== "object") continue;
-          const itemsRaw = Array.isArray(parsed.items) ? parsed.items : [];
           const planItems: ChatPlanItem[] = [];
-          for (const planEntry of itemsRaw) {
+          for (const planEntry of Array.isArray(parsed.items) ? parsed.items : []) {
             if (!planEntry || typeof planEntry !== "object" || Array.isArray(planEntry)) continue;
             const rec = planEntry as Record<string, unknown>;
-            const text = String(rec.text ?? rec.content ?? "").trim();
-            if (!text) continue;
+            const itemText = String(rec.text ?? rec.content ?? "").trim();
+            if (!itemText) continue;
             const itemStatusRaw = String(rec.status ?? "").trim().toLowerCase();
-            const planStatus: ChatPlanItemStatus =
-              itemStatusRaw === "completed"
-                ? "completed"
-                : itemStatusRaw === "in_progress"
-                  ? "in_progress"
-                  : "pending";
-            planItems.push({ text, status: planStatus });
+            const itemStatus: ChatPlanItemStatus =
+              itemStatusRaw === "completed" ? "completed" : itemStatusRaw === "in_progress" ? "in_progress" : "pending";
+            planItems.push({ text: itemText, status: itemStatus });
           }
           if (planItems.length === 0) continue;
           const planStatusRaw = String(parsed.status ?? "").trim().toLowerCase();
           const planStatus: ChatPlan["status"] =
-            planStatusRaw === "completed"
-              ? "completed"
-              : planStatusRaw === "failed"
-                ? "failed"
-                : "in_progress";
+            planStatusRaw === "completed" ? "completed" : planStatusRaw === "failed" ? "failed" : "in_progress";
           const persistedPlanId = String(parsed.planId ?? "").trim() || planId;
           next.push({
             id: `plan:${persistedPlanId}`,
@@ -1157,13 +1285,7 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
         }
         if (kind === "thought" || role === "thought") {
           restoredHistoryStatus = null;
-          next.push({
-            id: `h-th-${idx}`,
-            role: "assistant",
-            kind: "thought",
-            content: historyText,
-            ts: ts ?? undefined,
-          });
+          next.push({ id: `h-th-${idx}`, role: "assistant", kind: "thought", content: historyText, ts: ts ?? undefined });
           continue;
         }
         if (kind === "session_divider" || (role === "status" && kind === "session_divider") || (role === "system" && kind === "divider")) {
@@ -1197,11 +1319,7 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
           });
         } else if (role === "ai" || role === "assistant") {
           restoredHistoryStatus = null;
-          if (kind === "thought") {
-            next.push({ id: `h-th-${idx}`, role: "assistant", kind: "thought", content: historyText, ts: ts ?? undefined });
-          } else {
-            next.push({ id: `h-a-${idx}`, role: "assistant", kind: "text", content: historyText, ts: ts ?? undefined });
-          }
+          next.push({ id: `h-a-${idx}`, role: "assistant", kind: "text", content: historyText, ts: ts ?? undefined });
         }
       }
       dropReconnectBusyMessage();
@@ -1242,7 +1360,10 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
       const eventTsRaw = Number((msg as { ts?: unknown }).ts);
       const eventTs = Number.isFinite(eventTsRaw) && eventTsRaw > 0 ? Math.floor(eventTsRaw) : Date.now();
       const existing = rt.messages.value;
-      const alreadyHas = clientMessageId ? existing.some((m) => m.id === clientMessageId) : existing.length > 0 && existing[existing.length - 1]?.role === "user" && existing[existing.length - 1]?.content === text;
+      const lastUser = [...existing].reverse().find((m) => m.role === "user");
+      const alreadyHas = clientMessageId
+        ? existing.some((m) => m.id === clientMessageId)
+        : Boolean(lastUser && lastUser.content === text && lastUser.ts === eventTs);
       if (!alreadyHas && text) {
         pushMessageBeforeLive({
           id: clientMessageId || randomId("u"),
@@ -1282,6 +1403,7 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
       const source = String(msg.source ?? "").trim();
       if (source === "thought" || source === "reasoning") {
         upsertThoughtDelta?.(String(msg.delta ?? ""), rt);
+        return;
       } else if (source === "step") {
         const delta = String(msg.delta ?? "");
         if (delta.trim().startsWith("[analysis]")) {
@@ -1294,7 +1416,7 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
         if (shouldIgnoreStepDelta(delta)) return;
         upsertStepLiveDelta(delta, rt);
       } else {
-        upsertStreamingDelta(String(msg.delta ?? ""), rt);
+        consumeAssistantDelta(msg as Record<string, unknown>);
       }
       return;
     }
@@ -1303,15 +1425,8 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
       rt.busy.value = true;
       rt.turnInFlight = true;
       clearRecoveredBackendStatus();
-      const delta = String(
-        (msg as { delta?: unknown }).delta ??
-          (msg as { content?: unknown }).content ??
-          (msg as { text?: unknown }).text ??
-          "",
-      );
-      if (delta) {
-        upsertThoughtDelta?.(delta, rt);
-      }
+      const delta = String(msg.delta ?? msg.content ?? msg.text ?? "");
+      if (delta) upsertThoughtDelta?.(delta, rt);
       return;
     }
 
@@ -1320,14 +1435,7 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
       // assistant text accumulated so far, so a client that reconnected mid-turn
       // resumes the stream instead of losing everything emitted while it was gone.
       // Replaying it is idempotent — the streaming block is rewritten, not appended to.
-      const text = String(msg.text ?? "");
-      if (!text) return;
-      rt.busy.value = true;
-      rt.turnInFlight = true;
-      clearRecoveredBackendStatus();
-      const eventTsRaw = Number((msg as { ts?: unknown }).ts);
-      const eventTs = Number.isFinite(eventTsRaw) && eventTsRaw > 0 ? Math.floor(eventTsRaw) : undefined;
-      replaceStreamingText(text, rt, eventTs);
+      consumeAssistantSnapshot(msg as Record<string, unknown>);
       return;
     }
 
@@ -1471,6 +1579,35 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
       return;
     }
 
+    if (type === "command_snapshot") {
+      const snapshot = msg.command && typeof msg.command === "object" && !Array.isArray(msg.command)
+        ? (msg.command as Record<string, unknown>)
+        : null;
+      const cmd = String(snapshot?.command ?? "").trim();
+      if (!cmd) return;
+      const identity = String(snapshot?.identity ?? snapshot?.id ?? cmd).trim();
+      const key = commandKeyForWsEvent(cmd, identity || null);
+      if (!key) return;
+      const status = String(snapshot?.status ?? "").trim().toLowerCase();
+      const terminal = status === "completed" || status === "failed" || status === "declined" || status === "cancelled";
+      const eventTs = finiteTimestamp((msg as Record<string, unknown>).ts ?? snapshot?.ts);
+      const revision = Number(snapshot?.revision);
+      rt.busy.value = true;
+      rt.turnInFlight = true;
+      clearRecoveredBackendStatus();
+      ingestCommand(cmd, rt, identity || null);
+      upsertExecuteBlock(key, cmd, String(snapshot?.output ?? ""), rt, {
+        snapshot: true,
+        terminal,
+        eventId: String(msg.eventId ?? msg.seq ?? `snapshot:${identity}:${revision || 0}`).trim(),
+        revision: Number.isFinite(revision) && revision > 0 ? Math.floor(revision) : undefined,
+        startOffset: finiteOffset(snapshot?.startOffset),
+        endOffset: finiteOffset(snapshot?.endOffset),
+        ts: eventTs,
+      } satisfies ExecuteBlockUpdate);
+      return;
+    }
+
     if (type === "result") {
       annotatePendingUserMessageExecution(msg as Record<string, unknown>);
       recoveredBackendActivitySeen = false;
@@ -1481,6 +1618,7 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
       rt.busy.value = false;
       rt.turnInFlight = false;
       rt.turnHasPatch = false;
+      clearStreamTracking();
       resetTurnPatchSummary();
       rt.pendingAckClientMessageId = null;
       clearPendingPrompt(rt);
@@ -1586,6 +1724,7 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
       rt.busy.value = false;
       rt.turnInFlight = false;
       rt.turnHasPatch = false;
+      clearStreamTracking();
       resetTurnPatchSummary();
       rt.pendingAckClientMessageId = null;
       clearPendingPrompt(rt);
@@ -1616,10 +1755,11 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
     if (type === "command") {
       const payload = msg.command && typeof msg.command === "object" ? (msg.command as Record<string, unknown>) : null;
       const cmd = String(payload?.command ?? "").trim();
-      const id = String(payload?.id ?? "").trim();
-      const key = commandKeyForWsEvent(cmd, id || null);
+      const rawOutputDelta = String(payload?.outputDelta ?? "");
+      const identity = resolveCommandIdentity(payload ?? {}, cmd, rawOutputDelta);
+      const key = commandKeyForWsEvent(cmd, identity || null);
       if (!key) return;
-      let outputDelta = String(payload?.outputDelta ?? "");
+      let outputDelta = rawOutputDelta;
       const rawExitCode = payload?.exit_code ?? payload?.exitCode;
       const exitCode = typeof rawExitCode === "number" && Number.isFinite(rawExitCode) ? rawExitCode : null;
       if (exitCode !== null && exitCode !== 0) {
@@ -1633,11 +1773,25 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
       rt.busy.value = true;
       rt.turnInFlight = true;
       clearRecoveredBackendStatus();
-      ingestCommand(cmd, rt, id || null);
+      ingestCommand(cmd, rt, identity || null);
+      const eventTsRaw = Number((msg as { ts?: unknown }).ts ?? payload?.ts);
+      const eventTs = Number.isFinite(eventTsRaw) && eventTsRaw > 0 ? Math.floor(eventTsRaw) : undefined;
+      const status = String(payload?.status ?? "").trim().toLowerCase();
+      const terminal = status === "completed" || status === "failed" || status === "declined" || status === "cancelled";
+      const seq = Number((msg as { seq?: unknown }).seq);
+      const eventId = String((msg as { eventId?: unknown }).eventId ?? (Number.isFinite(seq) && seq > 0 ? `seq:${Math.floor(seq)}` : "")).trim();
+      const startOffset = finiteOffset(payload?.outputStartOffset ?? payload?.output_start_offset);
+      const endOffset = finiteOffset(payload?.outputEndOffset ?? payload?.output_end_offset);
       if (rt.turnHasPatch && isGitDiffCommand(cmd) && looksLikeUnifiedDiff(outputDelta)) {
         dropExecuteBlockForKey(key);
       } else {
-        upsertExecuteBlock(key, cmd, outputDelta, rt);
+        upsertExecuteBlock(key, cmd, outputDelta, rt, {
+          ts: eventTs,
+          eventId: eventId || undefined,
+          terminal,
+          startOffset,
+          endOffset,
+        });
       }
       if (cmd) {
         ingestCommandActivity(rt.liveActivity, cmd);

--- a/client/src/components/MainChatMessageList.vue
+++ b/client/src/components/MainChatMessageList.vue
@@ -32,7 +32,6 @@ const emit = defineEmits<{
 const openCommandTrees = ref<Set<string>>(new Set());
 const expandedExecuteIds = ref<Set<string>>(new Set());
 const expandedPatchKeys = ref<Set<string>>(new Set());
-const expandedThoughtIds = ref<Set<string>>(new Set());
 const filePreviewTarget = ref<MarkdownFilePreviewLink | null>(null);
 
 type PatchRenderRow = {
@@ -186,10 +185,69 @@ function togglePatchExpanded(messageId: string, rowKey: string): void {
   expandedPatchKeys.value = next;
 }
 
+const renderMessages = computed<RenderMessage[]>(() => {
+  const rawOrdered = normalizeTurnSemanticOrder(props.messages as ChatItem[]) as ChatMessage[];
+  const turns: ChatMessage[][] = [];
+  let currentTurn: ChatMessage[] = [];
+  for (const msg of rawOrdered) {
+    if (msg.role === "user" && currentTurn.length > 0) {
+      turns.push(currentTurn);
+      currentTurn = [];
+    }
+    currentTurn.push(msg);
+  }
+  if (currentTurn.length > 0) turns.push(currentTurn);
+
+  const processed: ChatMessage[] = [];
+  for (const turn of turns) {
+    const turnPatches = turn
+      .filter((m) => (m.kind === "patch" && Boolean(m.patch || m.content)) || Boolean(m.patch))
+      .map((m) => m.patch ?? (m.content ? { files: [], diff: m.content } : null))
+      .filter(Boolean);
+
+    let mergedPatch: ChatMessage["patch"] | undefined;
+    if (turnPatches.length > 0) {
+      const allFiles = turnPatches.flatMap((p) => p?.files ?? []);
+      const allDiffs = turnPatches.map((p) => p?.diff ?? "").filter(Boolean).join("\n\n");
+      const truncated = turnPatches.some((p) => p?.truncated);
+      if (allFiles.length > 0 || allDiffs.trim()) {
+        mergedPatch = {
+          files: allFiles,
+          diff: allDiffs,
+          truncated: truncated || undefined,
+        };
+      }
+    }
+
+    const visibleTurn: ChatMessage[] = [];
+    for (const msg of turn) {
+      if (msg.kind === "thought" || msg.kind === "plan" || msg.kind === "patch" || msg.kind === "command") {
+        continue;
+      }
+      visibleTurn.push({ ...msg });
+    }
+
+    if (mergedPatch) {
+      // A patch is supplementary metadata, never a standalone message. Only
+      // fold it into a substantive assistant explanation; creating an empty
+      // bubble would make a patch look like an unsolicited response.
+      const target = [...visibleTurn]
+        .reverse()
+        .find((m) => m.role === "assistant" && m.kind === "text" && String(m.content ?? "").trim());
+      if (target) {
+        target.patch = mergedPatch;
+      }
+    }
+
+    processed.push(...visibleTurn);
+  }
+  return processed;
+});
+
 watch(
   () =>
-    props.messages
-      .filter((m) => m.kind === "patch")
+    renderMessages.value
+      .filter((m) => Boolean(m.patch))
       .flatMap((m) =>
         buildPatchRows(m as RenderMessage)
           .map((row) => patchExpandKey(String(m.id ?? "").trim(), row.key))
@@ -205,23 +263,6 @@ watch(
   },
   { immediate: true },
 );
-
-const renderMessages = computed<RenderMessage[]>(() => {
-  // Keep the DOM contract defensive: history replay and test/integration
-  // callers may provide an arrival-ordered snapshot instead of going through
-  // the chat action setter. Rendering must still be deterministic.
-  const ordered = normalizeTurnSemanticOrder(props.messages as ChatItem[]) as ChatMessage[];
-  let latestExecuteId: string | null = null;
-  for (let i = ordered.length - 1; i >= 0; i--) {
-    const m = ordered[i]!;
-    if (m.kind === "execute") {
-      latestExecuteId = m.id;
-      break;
-    }
-  }
-
-  return ordered.filter((m) => m.kind !== "command" && (m.kind !== "execute" || m.id === latestExecuteId));
-});
 
 function getCommands(content: string): string[] {
   return content
@@ -292,25 +333,6 @@ function toggleExecuteExpanded(id: string): void {
   if (next.has(id)) next.delete(id);
   else next.add(id);
   expandedExecuteIds.value = next;
-}
-
-function isThoughtExpanded(id: string): boolean {
-  return expandedThoughtIds.value.has(id);
-}
-
-function toggleThoughtExpanded(id: string): void {
-  const next = new Set(expandedThoughtIds.value);
-  if (next.has(id)) next.delete(id);
-  else next.add(id);
-  expandedThoughtIds.value = next;
-}
-
-function getThoughtSummary(content: string): string {
-  const normalized = String(content ?? "").trim();
-  if (!normalized) return "过程分析与推理";
-  const firstLine = normalized.split("\n")[0]!.replace(/^\[(?:analysis|thought|step)\]\s*/i, "").replace(/^\*+|\*+$/g, "").trim();
-  if (firstLine.length <= 60) return firstLine;
-  return `${firstLine.slice(0, 57)}…`;
 }
 
 function caretPath(open: boolean): string {
@@ -435,46 +457,6 @@ function closeFilePreview(): void {
         </button>
         <div v-else-if="(m.hiddenLineCount ?? 0) > 0" class="execute-more">… 还有 {{ m.hiddenLineCount }} 行</div>
       </div>
-      <div v-else-if="m.kind === 'patch'" :class="['bubble', 'bubble--compact', 'patchCard']">
-        <div v-for="(row, rowIdx) in buildPatchRows(m)" :key="row.key" class="patchCardRow">
-          <div class="patchCardHeader">
-            <div class="patchCardSummary">
-              <div class="patchCardTitle" :title="patchRowTitle(row)">{{ patchRowTitle(row) }}</div>
-              <div v-if="patchRowMeta(row)" class="patchCardMeta" v-html="patchRowMeta(row)"></div>
-            </div>
-            <button
-              v-if="row.diff"
-              class="patchCardToggle"
-              type="button"
-              :aria-expanded="isPatchExpanded(m.id, row.key)"
-              :data-testid="`patch-toggle-${m.id}-${rowIdx}`"
-              @click.stop="togglePatchExpanded(m.id, row.key)"
-            >
-              {{ isPatchExpanded(m.id, row.key) ? "收起" : "展开" }}
-            </button>
-          </div>
-          <div v-if="row.diff && isPatchExpanded(m.id, row.key)" class="patchCardBody">
-            <pre class="patchCardDiff" v-html="renderPatchDiffHtml(row.diff)"></pre>
-          </div>
-        </div>
-        <div v-if="m.patch?.truncated" class="patchCardNote">Diff 已截断，避免刷屏。</div>
-      </div>
-      <div v-else-if="m.kind === 'thought'" :class="['bubble', 'bubble--compact', 'thoughtCard']">
-        <button
-          class="thoughtCardHeader"
-          type="button"
-          :aria-expanded="isThoughtExpanded(m.id)"
-          @click.stop="toggleThoughtExpanded(m.id)"
-        >
-          <span class="prompt-tag">思考</span>
-          <span class="thoughtCardSummary">{{ getThoughtSummary(m.content) }}</span>
-          <span v-if="m.streaming" class="thoughtSpinner" aria-label="Thinking..."></span>
-          <span class="thoughtCardToggleText">{{ isThoughtExpanded(m.id) ? "收起" : "展开" }}</span>
-        </button>
-        <div v-if="isThoughtExpanded(m.id)" class="thoughtCardBody">
-          <MarkdownContent :content="m.content" :enable-file-preview="Boolean(workspaceRoot)" @open-file-preview="openFilePreview" />
-        </div>
-      </div>
       <div v-else-if="m.kind === 'divider'" class="sessionBoundaryDivider" data-testid="session-boundary-divider">
         <div class="sessionBoundaryLine">
           <span class="sessionBoundaryTag">⚡ New Session Initialized</span>
@@ -520,7 +502,33 @@ function closeFilePreview(): void {
             </button>
           </div>
         </div>
-        <MarkdownContent v-else :content="m.content" :enable-file-preview="Boolean(workspaceRoot)" @open-file-preview="openFilePreview" />
+        <div v-else>
+          <MarkdownContent :content="m.content" :enable-file-preview="Boolean(workspaceRoot)" @open-file-preview="openFilePreview" />
+          <div v-if="m.patch && buildPatchRows(m).length > 0" class="patchCard foldedPatch">
+            <div v-for="(row, rowIdx) in buildPatchRows(m)" :key="row.key" class="patchCardRow">
+              <div class="patchCardHeader">
+                <div class="patchCardSummary">
+                  <div class="patchCardTitle" :title="patchRowTitle(row)">{{ patchRowTitle(row) }}</div>
+                  <div v-if="patchRowMeta(row)" class="patchCardMeta" v-html="patchRowMeta(row)"></div>
+                </div>
+                <button
+                  v-if="row.diff"
+                  class="patchCardToggle"
+                  type="button"
+                  :aria-expanded="isPatchExpanded(m.id, row.key)"
+                  :data-testid="`patch-toggle-${m.id}-${rowIdx}`"
+                  @click.stop="togglePatchExpanded(m.id, row.key)"
+                >
+                  {{ isPatchExpanded(m.id, row.key) ? "收起" : "展开" }}
+                </button>
+              </div>
+              <div v-if="row.diff && isPatchExpanded(m.id, row.key)" class="patchCardBody">
+                <pre class="patchCardDiff" v-html="renderPatchDiffHtml(row.diff)"></pre>
+              </div>
+            </div>
+            <div v-if="m.patch?.truncated" class="patchCardNote">Diff 已截断，避免刷屏。</div>
+          </div>
+        </div>
         <div v-if="shouldShowMsgActions(m)" class="msgActions">
           <button class="msgCopyBtn" type="button" aria-label="复制消息" @click="emit('copyMessage', m)">
             <svg
@@ -810,6 +818,12 @@ function closeFilePreview(): void {
 .patchCardNote {
   font-size: 12px;
   color: #64748b;
+}
+
+.foldedPatch {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
 }
 
 .command-tree-header {

--- a/client/src/lib/chat_sync.ts
+++ b/client/src/lib/chat_sync.ts
@@ -24,7 +24,7 @@ export function stripStreamingDisconnectNotice(text: string): string {
 }
 
 function isTransientExecutePreview(item: ChatItem): boolean {
-  return item.kind === "execute" && (item.streaming === true || String(item.id ?? "").startsWith("exec:"));
+  return item.kind === "execute" && item.streaming === true;
 }
 
 function withoutLiveAndTransientExecute(items: ChatItem[], liveStepId: string): ChatItem[] {
@@ -311,7 +311,7 @@ export function findProcessInsertIndex(messages: ChatItem[]): number {
   let insertAt = Math.min(end, start + 1);
   for (let index = start + 1; index < end; index += 1) {
     const item = messages[index]!;
-    if (isLiveMessageId(item.id) || item.kind === "plan" || item.kind === "thought") {
+    if (isLiveMessageId(item.id)) {
       insertAt = index + 1;
       continue;
     }

--- a/docs/adr/0005-reconnect-runtime-snapshot-barrier.md
+++ b/docs/adr/0005-reconnect-runtime-snapshot-barrier.md
@@ -1,0 +1,30 @@
+# ADR 0005: Reconnect Runtime Snapshots and Ordering Barriers
+
+## Status
+
+Accepted
+
+## Context
+
+The Web client receives live assistant deltas and command events over a WebSocket while reconnect catch-up reads a cursor-based HTTP event log. A reconnect can therefore observe the same turn through three paths: live frames, persisted events, and bootstrap history. Command execution previews are runtime state rather than durable conversation history, while an active command can continue after the original socket disappears.
+
+Without an explicit barrier, an unsequenced live delta can be applied before the HTTP catch-up command that logically precedes it, or a bootstrap history payload can overwrite a newer live block. Without a runtime snapshot, history replay cannot restore an active command.
+
+## Decision
+
+1. Keep one sync runtime per logical lane on the server. It owns the assistant delta and command snapshot coalescers and is reused by sibling connections.
+2. Persist active command snapshots as coalesced `command_snapshot` rows. Each command identity has absolute output offsets, revisions, and a stable event identity. Snapshots remain available through command completion and are removed only after the enclosing result or error.
+3. Persist assistant text as phase-scoped `delta_snapshot` rows. A command or phase-complete event seals the current assistant phase before its own sequence is allocated.
+4. Add `afterSeq` to live delta frames. The client sequencer holds barriered frames until the cursor reaches the barrier and holds unbarriered frames until catch-up completes. Bootstrap runtime snapshots are applied after the baseline history and catch-up events.
+5. Use a visible-block whitelist: user messages, assistant text, execute blocks, and terminal/error/divider messages are renderable. Thought, plan, and patch records remain accepted as internal or supplementary inputs; patches may be folded into an assistant explanation but never create a standalone chat block.
+
+## Consequences
+
+- Reconnects can restore active command output without treating transient execution UI as durable chat history.
+- Duplicate or overlapping delivery is reconciled by sequence, command identity, revision, and output offsets.
+- Sealed assistant phases remain replayable, which preserves command/explanation ordering across reconnect.
+- Runtime rows require normal sync-event retention and must be scoped to the logical lane; lane reset and turn completion clear them.
+
+## Verification
+
+The server command snapshot tests cover duplicate output, absolute offsets, reused command IDs, reconnect hydration, and terminal cleanup. Client tests cover catch-up barriers, active command restoration, distinct post-reconnect execute blocks, duplicate delivery, and the visible-block whitelist.

--- a/server/web/server/sync/commandSnapshot.ts
+++ b/server/web/server/sync/commandSnapshot.ts
@@ -1,0 +1,437 @@
+import { createHash } from "node:crypto";
+
+import type { SyncEventStore } from "./store.js";
+
+export const COMMAND_SNAPSHOT_EVENT_TYPE = "command_snapshot";
+export const COMMAND_SNAPSHOT_MAX_CHARS = 200_000;
+
+type CommandFrame = {
+  type: "command";
+  ts?: unknown;
+  command?: {
+    id?: unknown;
+    identity?: unknown;
+    command?: unknown;
+    status?: unknown;
+    exit_code?: unknown;
+    outputDelta?: unknown;
+    outputStartOffset?: unknown;
+    outputEndOffset?: unknown;
+  };
+};
+
+export type CommandSnapshotPosition = {
+  eventId: string;
+  identity: string;
+  startOffset: number;
+  endOffset: number;
+  snapshotSeq: number | null;
+  revision: number;
+  terminal: boolean;
+};
+
+type SnapshotRow = {
+  seq: number;
+  eventId?: string;
+  revision: number;
+  payload: Record<string, unknown>;
+  ts: number;
+};
+
+type ActiveCommand = {
+  eventId: string;
+  identity: string;
+  id: string;
+  command: string;
+  output: string;
+  startOffset: number;
+  endOffset: number;
+  revision: number;
+  startedAt: number;
+  status?: string;
+  exitCode?: number;
+  terminal: boolean;
+  snapshotSeq: number | null;
+  legacyKey: string;
+};
+
+type LegacyTrack = {
+  identity: string;
+  terminal: boolean;
+  sawOutput: boolean;
+  endOffset: number;
+  lastOutput: string;
+};
+
+type SnapshotStore = Pick<SyncEventStore, "appendCoalesced" | "deleteCoalesced"> & {
+  readCoalesced?: (args: { namespace: string; laneKey: string; type?: string }) => SnapshotRow[];
+  deleteCoalescedByType?: (args: { namespace: string; laneKey: string; type: string }) => void;
+};
+
+function normalizeTimestamp(value: unknown, fallback: () => number): number {
+  const timestamp = Number(value);
+  return Number.isFinite(timestamp) && timestamp > 0 ? Math.floor(timestamp) : fallback();
+}
+
+function isTerminalStatus(value: unknown): boolean {
+  const status = String(value ?? "").trim().toLowerCase();
+  return status === "completed" || status === "failed" || status === "declined" || status === "cancelled";
+}
+
+function commandEventId(identity: string): string {
+  return `active-command:${createHash("sha256").update(identity).digest("hex").slice(0, 24)}`;
+}
+
+function commandIdentitySuffix(command: string): string {
+  return createHash("sha256").update(command).digest("hex").slice(0, 12);
+}
+
+function readOffset(value: unknown): number | null {
+  const offset = Number(value);
+  return Number.isFinite(offset) && offset >= 0 ? Math.floor(offset) : null;
+}
+
+function commandFromPayload(payload: Record<string, unknown>): Record<string, unknown> | null {
+  const command = payload.command;
+  return command && typeof command === "object" && !Array.isArray(command)
+    ? (command as Record<string, unknown>)
+    : null;
+}
+
+function hasCommandHeader(outputDelta: string, commandLine: string): boolean {
+  const normalized = String(outputDelta ?? "").replace(/^\s+/, "");
+  return normalized.startsWith(`$ ${commandLine}\n`) || normalized.startsWith(`$ ${commandLine}\r\n`);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/**
+ * Coalesces command output into one durable runtime row per command identity.
+ *
+ * Rows survive individual command completion and are removed only after the
+ * enclosing result/error. This lets a reconnect restore every command block
+ * from one still-running turn. Identity handling differs deliberately for
+ * modern and legacy producers:
+ *
+ * - an explicit identity is authoritative;
+ * - an id plus command is stable, while the same id with another command gets
+ *   a deterministic suffix;
+ * - id-less commands get a new identity after a terminal instance, a command
+ *   header, or an output-offset rollback.
+ */
+export function createCommandSnapshotCoalescer(args: {
+  store: SnapshotStore;
+  namespace: string;
+  laneKey: string;
+  now?: () => number;
+  hydrate?: boolean;
+}) {
+  const now = args.now ?? (() => Date.now());
+  const active = new Map<string, ActiveCommand>();
+  const legacyTracks = new Map<string, LegacyTrack>();
+  const explicitIdentities = new Map<string, string>();
+  let anonymousCounter = 0;
+  let hydrated = false;
+
+  const hydrate = (): void => {
+    if (hydrated || !args.hydrate || !args.store.readCoalesced) return;
+    hydrated = true;
+    for (const row of args.store.readCoalesced({
+      namespace: args.namespace,
+      laneKey: args.laneKey,
+      type: COMMAND_SNAPSHOT_EVENT_TYPE,
+    })) {
+      const command = commandFromPayload(row.payload);
+      if (row.payload.active === false || command === null) continue;
+      const identity = String(command.identity ?? command.id ?? "").trim();
+      const commandLine = String(command.command ?? "").trim();
+      if (!identity || !commandLine) continue;
+      const output = String(command.output ?? "").slice(-COMMAND_SNAPSHOT_MAX_CHARS);
+      const endOffset = readOffset(command.endOffset) ?? output.length;
+      const startOffset = readOffset(command.startOffset) ?? Math.max(0, endOffset - output.length);
+      const id = String(command.id ?? "").trim();
+      const status = String(command.status ?? "").trim() || undefined;
+      const terminal = isTerminalStatus(status);
+      const eventId = String(row.eventId ?? commandEventId(identity)).trim() || commandEventId(identity);
+      const entry: ActiveCommand = {
+        eventId,
+        identity,
+        id,
+        command: commandLine,
+        output,
+        startOffset,
+        endOffset,
+        revision: Math.max(1, Math.floor(Number(command.revision) || row.revision || 1)),
+        startedAt: normalizeTimestamp(command.ts, () => row.ts || now()),
+        status,
+        exitCode: isFiniteNumber(command.exit_code) ? command.exit_code : undefined,
+        terminal,
+        snapshotSeq: Number.isFinite(row.seq) && row.seq > 0 ? Math.floor(row.seq) : null,
+        legacyKey: `${id}\u0000${commandLine}`,
+      };
+      active.set(identity, entry);
+      legacyTracks.set(entry.legacyKey, {
+        identity,
+        terminal,
+        sawOutput: Boolean(output),
+        endOffset,
+        lastOutput: output,
+      });
+      if (id) explicitIdentities.set(entry.legacyKey, identity);
+    }
+  };
+
+  hydrate();
+
+  const resolveExplicitIdentity = (payload: Record<string, unknown>, commandLine: string): string | null => {
+    const explicit = String(payload.identity ?? "").trim();
+    if (explicit) return explicit;
+
+    const id = String(payload.id ?? "").trim();
+    if (!id) return null;
+    const key = `${id}\u0000${commandLine}`;
+    const known = explicitIdentities.get(key);
+    if (known) return known;
+
+    // Preserve the first id verbatim for compatibility. A reused id with a
+    // different command receives a deterministic identity and cannot overwrite
+    // the first command's output.
+    const sameId = [...explicitIdentities.entries()].find(([entryKey]) => entryKey.startsWith(`${id}\u0000`));
+    const identity = sameId ? `${id}:${commandIdentitySuffix(commandLine)}` : id;
+    explicitIdentities.set(key, identity);
+    return identity;
+  };
+
+  const resolveLegacyIdentity = (
+    commandLine: string,
+    outputDelta: string,
+    startOffset: number | null,
+    endOffset: number | null,
+    terminal: boolean,
+  ): string => {
+    const legacyKey = `\u0000${commandLine}`;
+    const previous = legacyTracks.get(legacyKey);
+    const header = hasCommandHeader(outputDelta, commandLine);
+    const offsetRollback = startOffset !== null && previous !== undefined && startOffset < previous.endOffset;
+    const duplicateTerminal = Boolean(
+      previous?.terminal && terminal &&
+      (outputDelta === "" || outputDelta === previous.lastOutput || (endOffset !== null && endOffset <= previous.endOffset)),
+    );
+    const startsNew = Boolean(
+      !previous ||
+      (!duplicateTerminal && previous.terminal) ||
+      (!duplicateTerminal && offsetRollback) ||
+      (!duplicateTerminal && header && (previous.sawOutput || previous.terminal)),
+    );
+    if (!startsNew && previous) return previous.identity;
+    const identity = `anonymous-command-${++anonymousCounter}`;
+    legacyTracks.set(legacyKey, {
+      identity,
+      terminal: false,
+      sawOutput: false,
+      endOffset: 0,
+      lastOutput: "",
+    });
+    return identity;
+  };
+
+  const record = (frame: CommandFrame): CommandSnapshotPosition | null => {
+    const payload = frame.command;
+    const commandLine = String(payload?.command ?? "").trim();
+    if (!commandLine) return null;
+
+    const outputDelta = String(payload?.outputDelta ?? "");
+    const explicitStart = readOffset(payload?.outputStartOffset);
+    const explicitEnd = readOffset(payload?.outputEndOffset);
+    const terminal = isTerminalStatus(payload?.status);
+    const id = String(payload?.id ?? "").trim();
+    const explicitIdentity = resolveExplicitIdentity((payload ?? {}) as Record<string, unknown>, commandLine);
+    const identity = explicitIdentity ?? resolveLegacyIdentity(commandLine, outputDelta, explicitStart, explicitEnd, terminal);
+    const legacyKey = `${id}\u0000${commandLine}`;
+    const timestamp = normalizeTimestamp(frame.ts, now);
+    const existing = active.get(identity);
+    const entry: ActiveCommand = existing ?? {
+      eventId: commandEventId(identity),
+      identity,
+      id,
+      command: commandLine,
+      output: "",
+      startOffset: explicitStart ?? 0,
+      endOffset: explicitStart ?? 0,
+      revision: 0,
+      startedAt: timestamp,
+      terminal: false,
+      snapshotSeq: null,
+      legacyKey,
+    };
+
+    let changed = !existing;
+    const previousEnd = entry.endOffset;
+    let appendable = outputDelta;
+    if (explicitStart !== null) {
+      const overlap = Math.max(0, previousEnd - explicitStart);
+      if (explicitEnd !== null && explicitEnd <= previousEnd) {
+        appendable = "";
+      } else if (overlap > 0) {
+        appendable = outputDelta.slice(Math.min(outputDelta.length, overlap));
+      }
+    } else if (appendable) {
+      // Legacy producers sometimes send cumulative output. Avoid appending the
+      // same prefix twice while still accepting ordinary output deltas.
+      if (entry.output === appendable || entry.output.endsWith(appendable)) {
+        appendable = "";
+      } else if (appendable.startsWith(entry.output) && entry.output.length > 0) {
+        appendable = appendable.slice(entry.output.length);
+      }
+    }
+
+    if (appendable) {
+      const appendStart = explicitStart ?? entry.endOffset;
+      if (entry.output.length === 0) entry.startOffset = Math.max(0, appendStart);
+      entry.output = `${entry.output}${appendable}`.slice(-COMMAND_SNAPSHOT_MAX_CHARS);
+      entry.endOffset = explicitEnd ?? appendStart + outputDelta.length;
+      entry.startOffset = Math.max(0, entry.endOffset - entry.output.length);
+      changed = true;
+    } else if (explicitEnd !== null && explicitEnd > entry.endOffset) {
+      entry.endOffset = explicitEnd;
+      entry.startOffset = Math.max(0, entry.endOffset - entry.output.length);
+      changed = true;
+    }
+
+    const nextStatus = String(payload?.status ?? "").trim();
+    if (nextStatus && nextStatus !== entry.status) {
+      entry.status = nextStatus;
+      changed = true;
+    }
+    if (isFiniteNumber(payload?.exit_code) && payload.exit_code !== entry.exitCode) {
+      entry.exitCode = payload.exit_code;
+      changed = true;
+    }
+    if (terminal && !entry.terminal) {
+      entry.terminal = true;
+      changed = true;
+    }
+
+    if (!changed && existing) {
+      const track = legacyTracks.get(legacyKey);
+      if (track) {
+        track.terminal = entry.terminal;
+        track.endOffset = entry.endOffset;
+        track.lastOutput = outputDelta || track.lastOutput;
+      }
+      return {
+        eventId: entry.eventId,
+        identity: entry.identity,
+        startOffset: explicitStart ?? entry.endOffset,
+        endOffset: explicitEnd ?? entry.endOffset,
+        snapshotSeq: entry.snapshotSeq,
+        revision: entry.revision,
+        terminal,
+      };
+    }
+
+    entry.revision = Math.max(1, entry.revision + 1);
+    active.set(identity, entry);
+    legacyTracks.set(legacyKey, {
+      identity,
+      terminal: entry.terminal,
+      sawOutput: Boolean(entry.output),
+      endOffset: entry.endOffset,
+      lastOutput: outputDelta || entry.output,
+    });
+    if (id) explicitIdentities.set(legacyKey, identity);
+
+    const snapshotSeq = args.store.appendCoalesced({
+      namespace: args.namespace,
+      laneKey: args.laneKey,
+      type: COMMAND_SNAPSHOT_EVENT_TYPE,
+      eventId: entry.eventId,
+      revision: entry.revision,
+      payload: {
+        type: COMMAND_SNAPSHOT_EVENT_TYPE,
+        active: true,
+        ts: entry.startedAt,
+        eventId: entry.eventId,
+        snapshotSeq: entry.snapshotSeq,
+        command: {
+          id: entry.id,
+          identity: entry.identity,
+          command: entry.command,
+          status: entry.status,
+          exit_code: entry.exitCode,
+          output: entry.output,
+          startOffset: entry.startOffset,
+          endOffset: entry.endOffset,
+          revision: entry.revision,
+        },
+      },
+      ts: timestamp,
+    });
+    if (snapshotSeq !== null) entry.snapshotSeq = snapshotSeq;
+    return {
+      eventId: entry.eventId,
+      identity: entry.identity,
+      startOffset: explicitStart ?? previousEnd,
+      endOffset: explicitEnd ?? entry.endOffset,
+      snapshotSeq: entry.snapshotSeq,
+      revision: entry.revision,
+      terminal,
+    };
+  };
+
+  const finish = (): void => {
+    if (args.store.deleteCoalescedByType) {
+      args.store.deleteCoalescedByType({
+        namespace: args.namespace,
+        laneKey: args.laneKey,
+        type: COMMAND_SNAPSHOT_EVENT_TYPE,
+      });
+    } else {
+      for (const entry of active.values()) {
+        args.store.deleteCoalesced({
+          namespace: args.namespace,
+          laneKey: args.laneKey,
+          type: COMMAND_SNAPSHOT_EVENT_TYPE,
+          eventId: entry.eventId,
+        });
+      }
+    }
+    active.clear();
+    legacyTracks.clear();
+    explicitIdentities.clear();
+    hydrated = true;
+  };
+
+  const getSnapshots = (): Array<Record<string, unknown>> => {
+    hydrate();
+    return [...active.values()].map((entry) => ({
+      type: COMMAND_SNAPSHOT_EVENT_TYPE,
+      eventId: entry.eventId,
+      snapshotSeq: entry.snapshotSeq,
+      revision: entry.revision,
+      active: true,
+      afterSeq: entry.snapshotSeq ?? 0,
+      ts: entry.startedAt,
+      command: {
+        id: entry.id,
+        identity: entry.identity,
+        command: entry.command,
+        status: entry.status,
+        exit_code: entry.exitCode,
+        output: entry.output,
+        startOffset: entry.startOffset,
+        endOffset: entry.endOffset,
+        revision: entry.revision,
+      },
+    }));
+  };
+
+  return {
+    record,
+    finish,
+    getActiveCount: () => active.size,
+    getSnapshots,
+  };
+}

--- a/server/web/server/sync/deltaStream.ts
+++ b/server/web/server/sync/deltaStream.ts
@@ -1,140 +1,295 @@
-import type { SyncEventStore } from "./store.js";
-import { DELTA_SNAPSHOT_EVENT_TYPE } from "./eventClass.js";
 import { randomUUID } from "node:crypto";
 
-/**
- * How often the accumulated stream text is written to the sync log. Per-token
- * frames are broadcast live; only this throttled snapshot is persisted, so a
- * long answer costs one row instead of thousands.
- */
+import type { SyncEventStore } from "./store.js";
+import { DELTA_SNAPSHOT_EVENT_TYPE } from "./eventClass.js";
+
+/** How often accumulated stream text is written to the sync log. */
 export const DELTA_SNAPSHOT_FLUSH_INTERVAL_MS = 750;
 
-/** Upper bound on persisted stream text, so one runaway turn cannot bloat the lane. */
+/** Upper bound of persisted stream text for one assistant phase. */
 export const DELTA_SNAPSHOT_MAX_CHARS = 200_000;
 
 export type DeltaStreamCoalescer = ReturnType<typeof createDeltaStreamCoalescer>;
 
+export type DeltaStreamPosition = {
+  streamId: string;
+  startOffset: number;
+  endOffset: number;
+  snapshotSeq: number | null;
+};
+
+export type DeltaStreamSnapshot = {
+  type: typeof DELTA_SNAPSHOT_EVENT_TYPE;
+  eventId: string;
+  snapshotSeq: number | null;
+  revision: number;
+  active: boolean;
+  afterSeq: number;
+  streamId: string;
+  text: string;
+  startOffset: number;
+  endOffset: number;
+  ts: number;
+};
+
+type CoalescerStore = Pick<SyncEventStore, "appendCoalesced" | "deleteCoalesced"> & {
+  readCoalesced?: (args: { namespace: string; laneKey: string; type?: string }) => Array<{
+    seq: number;
+    eventId?: string;
+    revision: number;
+    payload: Record<string, unknown>;
+    ts: number;
+  }>;
+  markCoalescedInactive?: (args: {
+    namespace: string;
+    laneKey: string;
+    type: string;
+    eventId: string;
+  }) => void;
+};
+
+function normalizeTimestamp(value: unknown, fallback: () => number): number {
+  const timestamp = Number(value);
+  return Number.isFinite(timestamp) && timestamp > 0 ? Math.floor(timestamp) : fallback();
+}
+
+function parsePhase(eventId: string): number {
+  const match = String(eventId ?? "").match(/:(\d+)$/);
+  return match ? Math.max(0, Number(match[1])) : 0;
+}
+
 /**
- * Collapses a stream of `delta` frames into a single coalesced `delta_snapshot`
- * row that always carries the text accumulated so far.
+ * Coalesces transient assistant deltas into one replayable snapshot per phase.
  *
- * This is what makes an in-flight turn resumable: a client reconnecting mid-stream
- * catches up to the snapshot instead of losing everything emitted while it was gone.
- * The row is retired once the turn reaches a terminal frame, because from that
- * point the durable `result` / `error` event and the history bootstrap carry the text.
+ * The WebSocket server keeps one instance per logical lane. A second
+ * connection therefore observes the same offsets and snapshot row instead of
+ * starting an unrelated stream. `hydrate` continues an active row after a
+ * process-level reconnect.
  */
 export function createDeltaStreamCoalescer(args: {
-  store: Pick<SyncEventStore, "appendCoalesced" | "deleteCoalesced"> & {
-    getHighestCoalescedPhase?: (namespace: string, laneKey: string, eventType?: string) => number;
-  };
+  store: CoalescerStore;
   namespace: string;
   laneKey: string;
   flushIntervalMs?: number;
   maxChars?: number;
   now?: () => number;
   initialPhase?: number;
+  hydrate?: boolean;
 }) {
   const flushIntervalMs = Math.max(0, args.flushIntervalMs ?? DELTA_SNAPSHOT_FLUSH_INTERVAL_MS);
   const maxChars = Math.max(1, args.maxChars ?? DELTA_SNAPSHOT_MAX_CHARS);
   const now = args.now ?? (() => Date.now());
-  // A lane can host multiple turns and coalescer instances. Keep snapshot IDs
-  // unique so a later turn cannot replace a sealed snapshot from an earlier one.
-  const streamId = randomUUID();
+  const streamToken = randomUUID();
+
   let currentPhase = Math.max(0, args.initialPhase ?? 0);
-  const getEventId = () => `stream:${args.laneKey}:${streamId}:${currentPhase}`;
-
+  let activeEventId = `stream:${args.laneKey}:${streamToken}:${currentPhase}`;
   let text = "";
+  let totalChars = 0;
   let revision = 0;
+  let startedAt = 0;
   let lastFlushAt = 0;
+  let latestSnapshotSeq: number | null = null;
   let pending = false;
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
+  let hydrated = false;
 
-  const writeSnapshot = (): void => {
+  const clearFlushTimer = (): void => {
+    if (flushTimer === null) return;
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  };
+
+  const scheduleFlush = (): void => {
+    if (flushIntervalMs <= 0 || !pending || flushTimer !== null) return;
+    flushTimer = setTimeout(() => {
+      flushTimer = null;
+      if (pending) writeSnapshot(true);
+    }, flushIntervalMs);
+    flushTimer.unref?.();
+  };
+
+  const writeSnapshot = (active: boolean): number | null => {
+    if (!text) return latestSnapshotSeq;
     revision += 1;
     pending = false;
+    clearFlushTimer();
     lastFlushAt = now();
-    args.store.appendCoalesced({
+    const snapshotSeq = args.store.appendCoalesced({
       namespace: args.namespace,
       laneKey: args.laneKey,
       type: DELTA_SNAPSHOT_EVENT_TYPE,
-      eventId: getEventId(),
+      eventId: activeEventId,
       revision,
-      payload: { type: DELTA_SNAPSHOT_EVENT_TYPE, text, revision },
+      payload: {
+        type: DELTA_SNAPSHOT_EVENT_TYPE,
+        text,
+        revision,
+        streamId: activeEventId,
+        startOffset: Math.max(0, totalChars - text.length),
+        endOffset: totalChars,
+        ts: startedAt || lastFlushAt,
+        active,
+      },
       ts: lastFlushAt,
     });
+    if (snapshotSeq !== null) latestSnapshotSeq = snapshotSeq;
+    return snapshotSeq;
   };
 
+  const hydrate = (): void => {
+    if (hydrated || !args.hydrate || !args.store.readCoalesced) return;
+    hydrated = true;
+    const rows = args.store.readCoalesced({
+      namespace: args.namespace,
+      laneKey: args.laneKey,
+      type: DELTA_SNAPSHOT_EVENT_TYPE,
+    });
+    if (rows.length === 0) return;
+
+    const activeRows = rows.filter((row) => row.payload.active !== false);
+    const row = activeRows.at(-1) ?? null;
+    if (!row) {
+      const highestPhase = rows.reduce(
+        (highest, entry) => Math.max(highest, parsePhase(String(entry.eventId ?? ""))),
+        currentPhase,
+      );
+      currentPhase = highestPhase + 1;
+      return;
+    }
+    const payload = row.payload;
+    const restoredText = String(payload.text ?? "");
+    const restoredEnd = Number(payload.endOffset);
+    const restoredStart = Number(payload.startOffset);
+    if (!restoredText && !Number.isFinite(restoredEnd)) return;
+    text = restoredText.slice(-maxChars);
+    totalChars = Number.isFinite(restoredEnd) && restoredEnd >= 0
+      ? Math.floor(restoredEnd)
+      : Number.isFinite(restoredStart) && restoredStart >= 0
+        ? Math.floor(restoredStart) + text.length
+        : text.length;
+    revision = Math.max(0, Math.floor(Number(payload.revision) || row.revision || 0));
+    startedAt = normalizeTimestamp(payload.ts, () => row.ts || now());
+    lastFlushAt = row.ts || now();
+    latestSnapshotSeq = Number.isFinite(row.seq) && row.seq > 0 ? Math.floor(row.seq) : null;
+    activeEventId = String(payload.streamId ?? row.eventId ?? activeEventId).trim() || activeEventId;
+    currentPhase = parsePhase(activeEventId);
+    pending = false;
+  };
+
+  hydrate();
+
   return {
-    /** Accumulate one live frame. Persists a snapshot at most once per interval. */
-    appendDelta(delta: string): void {
+    /** Accumulate one live frame and return its absolute stream interval. */
+    appendDelta(delta: string, eventTs?: number): DeltaStreamPosition | null {
       const chunk = String(delta ?? "");
-      if (!chunk) return;
+      if (!chunk) return null;
+      if (!startedAt) startedAt = normalizeTimestamp(eventTs, now);
+      const startOffset = totalChars;
+      totalChars += chunk.length;
       text = (text + chunk).slice(-maxChars);
       pending = true;
-      if (now() - lastFlushAt >= flushIntervalMs) {
-        writeSnapshot();
+      if (flushIntervalMs === 0 || now() - lastFlushAt >= flushIntervalMs) {
+        writeSnapshot(true);
+      } else {
+        scheduleFlush();
       }
+      return {
+        streamId: activeEventId,
+        startOffset,
+        endOffset: totalChars,
+        snapshotSeq: latestSnapshotSeq,
+      };
     },
 
-    /** Force out anything still buffered (used before a terminal frame is logged). */
+    /** Force out a pending snapshot before an ordering boundary. */
     flush(): void {
-      if (!pending || !text) return;
-      writeSnapshot();
+      if (pending && text) writeSnapshot(true);
     },
 
-    /**
-     * Seal the active assistant phase so subsequent text lands in a fresh snapshot slot.
-     * Any buffered text is flushed and retained as a durable replay record for catch-up.
-     */
+    /** Seal the current assistant phase while retaining it for catch-up. */
     finishPhase(): void {
-      if (pending && text) {
-        writeSnapshot();
+      clearFlushTimer();
+      if (pending && text) writeSnapshot(true);
+      if (text && args.store.markCoalescedInactive) {
+        args.store.markCoalescedInactive({
+          namespace: args.namespace,
+          laneKey: args.laneKey,
+          type: DELTA_SNAPSHOT_EVENT_TYPE,
+          eventId: activeEventId,
+        });
       }
       text = "";
+      totalChars = 0;
       revision = 0;
+      startedAt = 0;
       lastFlushAt = 0;
+      latestSnapshotSeq = null;
       pending = false;
       currentPhase += 1;
+      activeEventId = `stream:${args.laneKey}:${streamToken}:${currentPhase}`;
     },
 
-    /**
-     * Retire only the unsealed currently-active snapshot once the turn reaches a terminal frame,
-     * because the terminal result/history supersedes it. Sealed intermediate phase snapshots
-     * remain replayable until normal SyncEventStore retention trims them.
-     */
+    /** Retire the currently active snapshot at terminal turn completion. */
     finish(): void {
-      const activeEventId = getEventId();
-      const hadActive = Boolean(text) || revision > 0;
+      clearFlushTimer();
+      const retiringEventId = activeEventId;
+      const hadActive = Boolean(text) || revision > 0 || latestSnapshotSeq !== null;
       text = "";
+      totalChars = 0;
       revision = 0;
+      startedAt = 0;
       lastFlushAt = 0;
+      latestSnapshotSeq = null;
       pending = false;
-      if (!hadActive) return;
-      currentPhase += 1;
-      args.store.deleteCoalesced({
-        namespace: args.namespace,
-        laneKey: args.laneKey,
-        type: DELTA_SNAPSHOT_EVENT_TYPE,
-        eventId: activeEventId,
-      });
+      if (hadActive) {
+        currentPhase += 1;
+        args.store.deleteCoalesced({
+          namespace: args.namespace,
+          laneKey: args.laneKey,
+          type: DELTA_SNAPSHOT_EVENT_TYPE,
+          eventId: retiringEventId,
+        });
+      }
+      activeEventId = `stream:${args.laneKey}:${streamToken}:${currentPhase}`;
     },
 
-    /** Reset coalescer state on lane switch/disconnect without erasing durable history. */
+    /** Reset in-memory state; durable rows are intentionally left untouched. */
     reset(): void {
+      clearFlushTimer();
       text = "";
+      totalChars = 0;
       revision = 0;
+      startedAt = 0;
       lastFlushAt = 0;
+      latestSnapshotSeq = null;
       pending = false;
       currentPhase = 0;
+      activeEventId = `stream:${args.laneKey}:${streamToken}:0`;
     },
 
-    /** Accumulated text so far — exposed for tests and diagnostics. */
-    getText(): string {
-      return text;
+    /** Return the active runtime snapshot, including its cursor barrier. */
+    getSnapshot(): DeltaStreamSnapshot | null {
+      hydrate();
+      if (!text && revision <= 0 && latestSnapshotSeq === null) return null;
+      return {
+        type: DELTA_SNAPSHOT_EVENT_TYPE,
+        eventId: activeEventId,
+        snapshotSeq: latestSnapshotSeq,
+        revision,
+        active: true,
+        afterSeq: latestSnapshotSeq ?? 0,
+        streamId: activeEventId,
+        text,
+        startOffset: Math.max(0, totalChars - text.length),
+        endOffset: totalChars,
+        ts: startedAt || lastFlushAt || now(),
+      };
     },
-
-    /** Current phase index — exposed for tests and diagnostics. */
-    getPhase(): number {
-      return currentPhase;
+    getSnapshots(): DeltaStreamSnapshot[] {
+      const snapshot = this.getSnapshot();
+      return snapshot ? [snapshot] : [];
     },
+    getText: () => text,
+    getPhase: () => currentPhase,
   };
 }

--- a/server/web/server/sync/eventClass.ts
+++ b/server/web/server/sync/eventClass.ts
@@ -27,6 +27,7 @@ export const TRANSIENT_SYNC_EVENT_TYPES: readonly string[] = ["delta", "agents"]
 /** Live decoration already reproducible from the `history` bootstrap. */
 export const EPHEMERAL_SYNC_EVENT_TYPES: readonly string[] = [
   "command",
+  "command_snapshot",
   "explored",
   "patch",
   "workspace",

--- a/server/web/server/sync/store.ts
+++ b/server/web/server/sync/store.ts
@@ -34,6 +34,8 @@ export type SyncEventReadResult = {
   truncated: boolean;
 };
 
+export type CoalescedSyncEventRow = SyncEventRow;
+
 const logger = createLogger("SyncEventStore");
 
 function normalizeLimit(value: number | undefined): number {
@@ -253,6 +255,102 @@ export class SyncEventStore {
       this.deleteCoalescedStmt.run(namespace, laneKey, eventType, eventId);
     } catch (error) {
       logger.warn(`[SyncEventStore] Failed to delete coalesced event`, error);
+    }
+  }
+
+  /** Mark a coalesced snapshot as sealed without allocating a new sequence. */
+  markCoalescedInactive(args: { namespace: string; laneKey: string; type: string; eventId: string }): void {
+    const namespace = String(args.namespace ?? "").trim();
+    const laneKey = String(args.laneKey ?? "").trim();
+    const eventType = String(args.type ?? "").trim();
+    const eventId = String(args.eventId ?? "").trim();
+    if (!namespace || !laneKey || !eventType || !eventId) return;
+    try {
+      const row = this.db
+        .prepare(
+          `SELECT payload FROM sync_events
+           WHERE namespace = ? AND lane_key = ? AND event_type = ? AND event_id = ?
+           ORDER BY seq DESC LIMIT 1`,
+        )
+        .get(namespace, laneKey, eventType, eventId) as { payload?: string } | undefined;
+      if (!row?.payload) return;
+      const payload = safeParsePayload(row.payload);
+      payload.active = false;
+      this.db
+        .prepare(
+          `UPDATE sync_events SET payload = ?
+           WHERE namespace = ? AND lane_key = ? AND event_type = ? AND event_id = ?`,
+        )
+        .run(JSON.stringify(payload), namespace, laneKey, eventType, eventId);
+    } catch (error) {
+      logger.warn(`[SyncEventStore] Failed to mark coalesced event inactive`, error);
+    }
+  }
+
+  /**
+   * Read the current coalesced rows for one lane. Coalesced rows are runtime
+   * snapshots (for example an in-flight assistant stream or command), so they
+   * need a direct lookup rather than a cursor-relative replay query.
+   */
+  readCoalesced(args: {
+    namespace: string;
+    laneKey: string;
+    type?: string;
+  }): CoalescedSyncEventRow[] {
+    const namespace = String(args.namespace ?? "").trim();
+    const laneKey = String(args.laneKey ?? "").trim();
+    const type = String(args.type ?? "").trim();
+    if (!namespace || !laneKey) return [];
+    const whereType = type ? " AND event_type = ?" : "";
+    const params = type ? [namespace, laneKey, type] : [namespace, laneKey];
+    try {
+      const rows = this.db
+        .prepare(
+          `SELECT seq, namespace, lane_key, event_type, event_id, revision, payload, ts, run_id
+           FROM sync_events
+           WHERE namespace = ? AND lane_key = ?${whereType}
+           ORDER BY seq ASC`,
+        )
+        .all(...params) as Array<{
+        seq: number;
+        namespace: string;
+        lane_key: string;
+        event_type: string;
+        event_id: string | null;
+        revision: number;
+        payload: string;
+        ts: number;
+        run_id: string | null;
+      }>;
+      return rows.map((row) => ({
+        seq: Number(row.seq) || 0,
+        namespace: row.namespace,
+        laneKey: row.lane_key,
+        type: row.event_type,
+        eventId: row.event_id ?? undefined,
+        revision: Number(row.revision) || 1,
+        payload: safeParsePayload(row.payload),
+        ts: Number(row.ts) || 0,
+        runId: row.run_id ?? undefined,
+      }));
+    } catch (error) {
+      logger.warn(`[SyncEventStore] Failed to read coalesced events`, error);
+      return [];
+    }
+  }
+
+  /** Remove every coalesced row of a type for one lane. */
+  deleteCoalescedByType(args: { namespace: string; laneKey: string; type: string }): void {
+    const namespace = String(args.namespace ?? "").trim();
+    const laneKey = String(args.laneKey ?? "").trim();
+    const type = String(args.type ?? "").trim();
+    if (!namespace || !laneKey || !type) return;
+    try {
+      this.db
+        .prepare(`DELETE FROM sync_events WHERE namespace = ? AND lane_key = ? AND event_type = ?`)
+        .run(namespace, laneKey, type);
+    } catch (error) {
+      logger.warn(`[SyncEventStore] Failed to delete coalesced events`, error);
     }
   }
 

--- a/server/web/server/ws/bootstrapDelivery.ts
+++ b/server/web/server/ws/bootstrapDelivery.ts
@@ -79,6 +79,8 @@ export function sendInitialBootstrapMessages(args: {
   latestSeq?: number;
   taskLatestSeq?: number;
   laneGeneration?: number;
+  /** Runtime-only snapshots that are not part of durable chat history. */
+  runtimeSnapshots?: Array<Record<string, unknown>>;
 }): void {
   const bootstrapState = buildWsBootstrapState({
     sessionManager: args.sessionManager,
@@ -125,6 +127,16 @@ export function sendInitialBootstrapMessages(args: {
 
   if (historyPayload) {
     args.safeJsonSend(args.ws, historyPayload);
+  }
+  for (const snapshot of args.runtimeSnapshots ?? []) {
+    if (!snapshot || typeof snapshot !== "object" || snapshot.active === false) continue;
+    const snapshotSeq = Number(snapshot.snapshotSeq ?? snapshot.seq ?? snapshot.afterSeq);
+    const afterSeq = Number.isFinite(snapshotSeq) && snapshotSeq >= 0 ? Math.floor(snapshotSeq) : 0;
+    args.safeJsonSend(args.ws, {
+      ...snapshot,
+      bootstrap: true,
+      ...(afterSeq >= 0 ? { afterSeq } : {}),
+    });
   }
   const restoreStatus = buildContextRestoreStatus(bootstrapState.contextMode);
   if (restoreStatus) {

--- a/server/web/server/ws/server.ts
+++ b/server/web/server/ws/server.ts
@@ -30,6 +30,7 @@ import { preflightPersistAndAck } from "./preflight.js";
 import { resolveSharedWorkerSyncLaneKey, resolveSyncLaneKeys, resolveSyncNamespace } from "../sync/lane.js";
 import { isStreamTerminalEvent, isTransientSyncEvent } from "../sync/eventClass.js";
 import { createDeltaStreamCoalescer } from "../sync/deltaStream.js";
+import { createCommandSnapshotCoalescer } from "../sync/commandSnapshot.js";
 import { recordConversationMessage } from "../../../utils/conversationMessageRecorder.js";
 import { WEB_WORKER_NAMESPACE } from "../start/webLaneResources.js";
 
@@ -52,6 +53,7 @@ type WsLaneSnapshot = {
   getWorkspaceLock: WsLaneResources["getWorkspaceLock"];
   orchestrator: WsOrchestrator;
   deltaCoalescer: ReturnType<typeof createDeltaStreamCoalescer> | null;
+  commandSnapshotCoalescer: ReturnType<typeof createCommandSnapshotCoalescer> | null;
 };
 
 /** WebSocket 单帧默认上限：16MB（足够容纳带 base64 图片的 prompt，又能挡住内存型 DoS）。 */
@@ -68,6 +70,42 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
   const laneGenerationStore = state.laneGenerationStore;
   const fallbackLaneGenerations = new Map<string, number>();
   const resetClosingConnections = new WeakSet<WebSocket>();
+  const laneSyncRuntimes = new Map<
+    string,
+    {
+      deltaCoalescer: ReturnType<typeof createDeltaStreamCoalescer>;
+      commandSnapshotCoalescer: ReturnType<typeof createCommandSnapshotCoalescer>;
+    }
+  >();
+
+  const syncRuntimeKey = (namespace: string, laneKey: string): string => `${namespace}\u0000${laneKey}`;
+
+  const getLaneSyncRuntime = (namespace: string, laneKey: string, _inFlight: boolean) => {
+    const key = syncRuntimeKey(namespace, laneKey);
+    const existing = laneSyncRuntimes.get(key);
+    if (existing) return existing;
+    const syncEventStore = state.syncEventStore;
+    if (!syncEventStore) return null;
+    // Runtime rows are the source of truth for a reconnect. Do not clear them
+    // merely because the connection was opened before the in-flight map was
+    // observed; that ordering used to erase the command a reconnect needed.
+    const runtime = {
+      deltaCoalescer: createDeltaStreamCoalescer({
+        store: syncEventStore,
+        namespace,
+        laneKey,
+        hydrate: true,
+      }),
+      commandSnapshotCoalescer: createCommandSnapshotCoalescer({
+        store: syncEventStore,
+        namespace,
+        laneKey,
+        hydrate: true,
+      }),
+    };
+    laneSyncRuntimes.set(key, runtime);
+    return runtime;
+  };
 
   const getFallbackLaneGenerationKey = (namespace: string, logicalLaneKey: string): string =>
     `${String(namespace ?? "").trim()}::${String(logicalLaneKey ?? "").trim()}`;
@@ -340,13 +378,9 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
       generation: laneGeneration,
     });
     const syncEventStore = state.syncEventStore;
-    let deltaCoalescer = syncEventStore
-      ? createDeltaStreamCoalescer({
-          store: syncEventStore,
-          namespace: syncNamespace,
-        laneKey: historyKey,
-      })
-      : null;
+    const laneSyncRuntime = getLaneSyncRuntime(syncNamespace, historyKey, inFlight);
+    let deltaCoalescer = laneSyncRuntime?.deltaCoalescer ?? null;
+    let commandSnapshotCoalescer = laneSyncRuntime?.commandSnapshotCoalescer ?? null;
     const appendSyncEventForLane = (
       lane: WsLaneSnapshot,
       payload: unknown,
@@ -363,25 +397,68 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
       if (isTransientSyncEvent(eventType)) {
         // Live-only frames are broadcast without entering the replay log. Main
         // assistant deltas are folded into one coalesced `delta_snapshot`.
-        if (eventType === "delta" && lane.deltaCoalescer && !String(payloadRecord.source ?? "").trim()) {
-          lane.deltaCoalescer.appendDelta(String(payloadRecord.delta ?? ""));
+        if (eventType === "delta") {
+          const source = String(payloadRecord.source ?? "").trim();
+          const position = !source && lane.deltaCoalescer
+            ? lane.deltaCoalescer.appendDelta(String(payloadRecord.delta ?? ""), Number(payloadRecord.ts))
+            : null;
+          return {
+            ok: true,
+            payload: {
+              ...payloadRecord,
+              afterSeq: syncEventStore.getLatestSeq(lane.laneNamespace, lane.historyKey),
+              ...(position
+                ? {
+                    streamId: position.streamId,
+                    startOffset: position.startOffset,
+                    endOffset: position.endOffset,
+                  }
+                : {}),
+            },
+          };
         }
         return { ok: true, payload };
       }
-      if (lane.deltaCoalescer && isStreamTerminalEvent(eventType)) {
-        lane.deltaCoalescer.finish();
-      } else if (lane.deltaCoalescer && eventType === "phase_complete") {
+      const streamTerminal = isStreamTerminalEvent(eventType);
+      // A command is a hard phase boundary even when the provider omitted an
+      // explicit phase_complete notification. Flush/seal preceding assistant
+      // text before allocating the command sequence.
+      if (lane.deltaCoalescer && (eventType === "command" || eventType === "phase_complete")) {
         lane.deltaCoalescer.finishPhase();
+      } else if (lane.deltaCoalescer && streamTerminal) {
+        lane.deltaCoalescer.finish();
       }
-      const eventId = String(payloadRecord.eventId ?? payloadRecord.event_id ?? "").trim() || undefined;
-      const eventTs = Number(payloadRecord.ts);
+      let eventPayload = payloadRecord;
+      if (eventType === "command" && lane.commandSnapshotCoalescer) {
+        const command = payloadRecord.command && typeof payloadRecord.command === "object" && !Array.isArray(payloadRecord.command)
+          ? (payloadRecord.command as Record<string, unknown>)
+          : null;
+        const snapshotPosition = lane.commandSnapshotCoalescer.record({
+          type: "command",
+          ts: payloadRecord.ts,
+          command: command ?? undefined,
+        });
+        if (snapshotPosition && command) {
+          eventPayload = {
+            ...payloadRecord,
+            command: {
+              ...command,
+              identity: snapshotPosition.identity,
+              outputStartOffset: snapshotPosition.startOffset,
+              outputEndOffset: snapshotPosition.endOffset,
+            },
+          };
+        }
+      }
+      const eventId = String(eventPayload.eventId ?? eventPayload.event_id ?? "").trim() || undefined;
+      const eventTs = Number(eventPayload.ts);
       const seq = syncEventStore.append({
         namespace: lane.laneNamespace,
         laneKey: lane.historyKey,
         type: eventType,
         eventId,
         ts: Number.isFinite(eventTs) && eventTs > 0 ? Math.floor(eventTs) : undefined,
-        payload: payloadRecord,
+        payload: eventPayload,
       });
       if (seq === null) {
         logger.warn(`[WebSocket][Sync] refusing unlogged event type=${eventType} history=${lane.historyKey}`);
@@ -395,7 +472,10 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
         }))();
         return { ok: false, payload };
       }
-      return { ok: true, payload: { ...payloadRecord, seq } };
+      if (streamTerminal) {
+        lane.commandSnapshotCoalescer?.finish();
+      }
+      return { ok: true, payload: { ...eventPayload, seq } };
     };
     const broadcastJsonForLane = (lane: WsLaneSnapshot, payload: unknown): void => {
       if (!isLaneGenerationCurrent(lane)) return;
@@ -505,7 +585,13 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
       getWorkspaceLock,
       orchestrator,
       deltaCoalescer,
+      commandSnapshotCoalescer,
     });
+
+    const collectRuntimeSnapshots = (lane: WsLaneSnapshot): Array<Record<string, unknown>> => [
+      ...(lane.deltaCoalescer?.getSnapshots?.() ?? []),
+      ...(lane.commandSnapshotCoalescer?.getSnapshots?.() ?? []),
+    ];
 
     let currentLane = captureLane();
 
@@ -690,6 +776,7 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
           ? 0
           : state.syncEventStore?.getLatestSeq(WEB_WORKER_NAMESPACE, resolveSharedWorkerSyncLaneKey(sessionId)) ?? 0,
       laneGeneration: currentLane.laneGeneration,
+      runtimeSnapshots: collectRuntimeSnapshots(currentLane),
     });
 
     let messageChain = Promise.resolve();
@@ -875,15 +962,16 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
               generation: laneGeneration,
             });
             deltaCoalescer?.finish();
+            commandSnapshotCoalescer?.finish();
             syncNamespace = nextLaneNamespace;
             syncLaneKeys = nextSyncLaneKeys;
-            deltaCoalescer = syncEventStore
-              ? createDeltaStreamCoalescer({
-                  store: syncEventStore,
-                  namespace: syncNamespace,
-                  laneKey: historyKey,
-                })
-              : null;
+            const nextSyncRuntime = getLaneSyncRuntime(
+              syncNamespace,
+              historyKey,
+              state.interruptControllers.has(historyKey),
+            );
+            deltaCoalescer = nextSyncRuntime?.deltaCoalescer ?? null;
+            commandSnapshotCoalescer = nextSyncRuntime?.commandSnapshotCoalescer ?? null;
             currentLane = captureLane();
 
             sendInitialBootstrapMessages({
@@ -905,6 +993,7 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
                   ? 0
                   : state.syncEventStore?.getLatestSeq(WEB_WORKER_NAMESPACE, resolveSharedWorkerSyncLaneKey(sessionId)) ?? 0,
               laneGeneration: currentLane.laneGeneration,
+              runtimeSnapshots: collectRuntimeSnapshots(currentLane),
             });
 
             logger.info(

--- a/server/web/server/ws/workerPromptHandler.ts
+++ b/server/web/server/ws/workerPromptHandler.ts
@@ -155,6 +155,10 @@ export function attachWorkerPromptHandler(args: {
     args.sessionLogger?.logEvent(event);
     args.logger.debug(`[Event] phase=${event.phase} title=${event.title} detail=${event.detail?.slice(0, 50)}`);
     const raw = event.raw as ThreadEvent;
+    const eventTimestampRaw = Number(event.timestamp);
+    const eventTimestamp = Number.isFinite(eventTimestampRaw) && eventTimestampRaw > 0
+      ? Math.floor(eventTimestampRaw)
+      : Date.now();
     if (raw.type === "turn.started") {
       lastRespondingTextByItemId.clear();
       activeRespondingItemId = null;
@@ -196,7 +200,7 @@ export function attachWorkerPromptHandler(args: {
       const itemId = rawItem && typeof rawItem === "object" ? String(rawItem.id ?? "").trim() || "__unknown__" : "__unknown__";
       if (activeRespondingItemId && activeRespondingItemId !== itemId && !completedRespondingItemIds.has(activeRespondingItemId)) {
         completedRespondingItemIds.add(activeRespondingItemId);
-        args.sendToChat({ type: "phase_complete", phase: "assistant", ts: Date.now() });
+        args.sendToChat({ type: "phase_complete", phase: "assistant", ts: eventTimestamp });
       }
       activeRespondingItemId = itemId;
       const previous = lastRespondingTextByItemId.get(itemId) ?? "";
@@ -208,7 +212,7 @@ export function attachWorkerPromptHandler(args: {
       const delta = previous ? next.slice(previous.length) : next;
       lastRespondingTextByItemId.set(itemId, next);
       if (delta) {
-        args.sendToChat({ type: "delta", delta });
+        args.sendToChat({ type: "delta", delta, ts: eventTimestamp });
       }
       return;
     }
@@ -221,12 +225,12 @@ export function attachWorkerPromptHandler(args: {
           completedRespondingItemIds.add(itemId);
           if (activeRespondingItemId === itemId) {
             activeRespondingItemId = null;
-            args.sendToChat({ type: "phase_complete", phase: "assistant", ts: Date.now() });
+            args.sendToChat({ type: "phase_complete", phase: "assistant", ts: eventTimestamp });
           }
         }
       } else if (activeRespondingItemId === "__unknown__") {
         activeRespondingItemId = null;
-        args.sendToChat({ type: "phase_complete", phase: "assistant", ts: Date.now() });
+        args.sendToChat({ type: "phase_complete", phase: "assistant", ts: eventTimestamp });
       }
     }
 
@@ -259,7 +263,7 @@ export function attachWorkerPromptHandler(args: {
       if (delta) {
         // Emit pure reasoning delta as structured thought event directly,
         // avoiding smearing cognitive reasoning into generic step traces.
-        args.sendToChat({ type: "delta", delta, source: "thought" });
+        args.sendToChat({ type: "delta", delta, source: "thought", ts: eventTimestamp });
       }
       return;
     }
@@ -271,7 +275,7 @@ export function attachWorkerPromptHandler(args: {
         if (hasSubstantiveStepTrace(line)) {
           latestStepTraceText = line;
         }
-        args.sendToChat({ type: "delta", delta: line, source: "step" });
+        args.sendToChat({ type: "delta", delta: line, source: "step", ts: eventTimestamp });
       }
     }
     if (event.phase === "command") {
@@ -328,6 +332,7 @@ export function attachWorkerPromptHandler(args: {
 
       args.sendToChat({
         type: "command",
+        ts: eventTimestamp,
         detail: event.detail ?? event.title,
         command: {
           id: commandPayload.id,

--- a/tests/web/commandSnapshot.test.ts
+++ b/tests/web/commandSnapshot.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { resetStateDatabaseForTests } from "../../server/state/database.js";
+import { WEB_WORKER_NAMESPACE } from "../../server/web/server/start/webLaneResources.js";
+import {
+  COMMAND_SNAPSHOT_EVENT_TYPE,
+  createCommandSnapshotCoalescer,
+} from "../../server/web/server/sync/commandSnapshot.js";
+import { SyncEventStore } from "../../server/web/server/sync/store.js";
+
+describe("server/sync/commandSnapshot", () => {
+  let tmpDir: string;
+  let stateDbPath: string;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ads-command-snapshot-"));
+    stateDbPath = path.join(tmpDir, "state.db");
+    process.env.ADS_STATE_DB_PATH = stateDbPath;
+    resetStateDatabaseForTests();
+  });
+
+  afterEach(() => {
+    resetStateDatabaseForTests();
+    process.env = { ...originalEnv };
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("coalesces duplicate output and preserves absolute offsets", () => {
+    const store = new SyncEventStore({ stateDbPath });
+    const coalescer = createCommandSnapshotCoalescer({
+      store,
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey: "command-lane",
+      now: () => 1000,
+    });
+
+    const first = coalescer.record({
+      type: "command",
+      ts: 1000,
+      command: { id: "cmd-1", command: "npm test", outputDelta: "$ npm test\nPASS one\n", outputStartOffset: 0, outputEndOffset: 17 },
+    });
+    const duplicate = coalescer.record({
+      type: "command",
+      ts: 1001,
+      command: { id: "cmd-1", command: "npm test", outputDelta: "$ npm test\nPASS one\n", outputStartOffset: 0, outputEndOffset: 17 },
+    });
+    const second = coalescer.record({
+      type: "command",
+      ts: 1002,
+      command: { id: "cmd-1", command: "npm test", outputDelta: "PASS two\n", outputStartOffset: 17, outputEndOffset: 27 },
+    });
+
+    assert.equal(first?.identity, "cmd-1");
+    assert.equal(duplicate?.snapshotSeq, first?.snapshotSeq);
+    assert.equal(second?.startOffset, 17);
+    assert.equal(second?.endOffset, 27);
+    const snapshots = store.readCoalesced({
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey: "command-lane",
+      type: COMMAND_SNAPSHOT_EVENT_TYPE,
+    });
+    assert.equal(snapshots.length, 1);
+    assert.equal(snapshots[0]?.payload.command && (snapshots[0].payload.command as Record<string, unknown>).output, "$ npm test\nPASS one\nPASS two\n");
+  });
+
+  it("creates distinct blocks when a command id is reused for another command", () => {
+    const store = new SyncEventStore({ stateDbPath });
+    const coalescer = createCommandSnapshotCoalescer({
+      store,
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey: "command-lane",
+      now: () => 2000,
+    });
+
+    const first = coalescer.record({
+      type: "command",
+      command: { id: "reused", command: "npm test", outputDelta: "$ npm test\n" },
+    });
+    const second = coalescer.record({
+      type: "command",
+      command: { id: "reused", command: "npm run build", outputDelta: "$ npm run build\n" },
+    });
+
+    assert.notEqual(first?.identity, second?.identity);
+    assert.equal(coalescer.getActiveCount(), 2);
+    assert.equal(coalescer.getSnapshots().length, 2);
+  });
+
+  it("hydrates active snapshots after reconnect and removes them only at turn completion", () => {
+    const store = new SyncEventStore({ stateDbPath });
+    const args = {
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey: "command-lane",
+      type: "command" as const,
+      command: { id: "cmd-live", command: "npm test", outputDelta: "$ npm test\nPASS\n" },
+    };
+    const writer = createCommandSnapshotCoalescer({ store, ...args, now: () => 3000 });
+    writer.record(args);
+
+    const reconnect = createCommandSnapshotCoalescer({
+      store,
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey: "command-lane",
+      hydrate: true,
+    });
+    assert.equal(reconnect.getActiveCount(), 1);
+    assert.equal(reconnect.getSnapshots()[0]?.command && (reconnect.getSnapshots()[0]!.command as Record<string, unknown>).output, "$ npm test\nPASS\n");
+
+    writer.finish();
+    assert.equal(store.readCoalesced({ namespace: WEB_WORKER_NAMESPACE, laneKey: "command-lane", type: COMMAND_SNAPSHOT_EVENT_TYPE }).length, 0);
+  });
+});


### PR DESCRIPTION
## Summary

- preserve active command snapshots across WebSocket reconnects
- add ordering barriers and output offsets for live assistant deltas
- create distinct execute blocks for commands emitted after reconnect
- keep thought and plan internal and fold patch metadata into assistant messages
- add server/client regression coverage and ADR 0005

## Verification

- Web tests: 84 files, 446 tests passed
- Relevant server tests and command snapshot tests passed
- 
> ads@0.1.6 build
> tsc -p tsconfig.build.json && node scripts/copy-runtime-assets.js && npm run build:web

[copy-runtime-assets] Templates copied to /tmp/ads-worktree-143/dist/templates
[copy-runtime-assets] Builtin skill assets copied to /tmp/ads-worktree-143/dist/server/skills/builtin (1 files)

> ads@0.1.6 build:web
> vite build --config client/vite.config.ts

vite v6.4.1 building for production...
transforming...
✓ 1620 modules transformed.
rendering chunks...
computing gzip size...
../dist/client/manifest.webmanifest         0.46 kB
../dist/client/index.html                   1.42 kB │ gzip:   0.66 kB
../dist/client/assets/index-BaVn_Rf9.css   85.68 kB │ gzip:  15.56 kB
../dist/client/assets/index-qpyu_MEc.js   491.63 kB │ gzip: 173.72 kB
✓ built in 8.32s

PWA v1.3.0
mode      generateSW
precache  11 entries (848.12 KiB)
files generated
  ../dist/client/sw.js
  ../dist/client/workbox-2fbc6a65.js

> ads@0.1.6 postbuild
> node scripts/chmod-bins.js passed
- 
> ads@0.1.6 lint
> eslint . --ext .ts passed
- Full backend suite: 863 passed, 1 pre-existing flaky  timing test; isolated rerun passed

Closes #147