### PR TITLE
feat(telegram): add global model selector

### DIFF
--- a/connectors/telegram/src/bot.ts
+++ b/connectors/telegram/src/bot.ts
@@ -5,6 +5,15 @@ import { createAuthMiddleware } from "./middleware/auth.js";
 import { createRateLimitMiddleware } from "./middleware/rateLimit.js";
 import { escapeTelegramMarkdownV2 } from "./utils/markdown.js";
 import { chunkMessage } from "./utils/chunkMessage.js";
+import {
+  allowedReasoningEfforts,
+  buildModelKeyboard,
+  findModel,
+  formatModelMenu,
+  formatModelStatus,
+  parseModelCallback,
+  parseModelCommand,
+} from "./modelCommands.js";
 
 export function createTelegramBot(options?: {
   config?: TelegramConnectorConfig;
@@ -78,6 +87,76 @@ export function createTelegramBot(options?: {
     await ctx.reply("Interrupted running turn.");
   });
 
+  bot.command("model", async (ctx) => {
+    const chatClient = getChatClient(ctx.chat.id);
+    try {
+      await chatClient.connect();
+      await chatClient.waitForWelcome();
+      const models = await chatClient.getModels();
+      const state = chatClient.getModelState();
+      const parsed = parseModelCommand(typeof ctx.match === "string" ? ctx.match : "");
+      if (!parsed.modelId) {
+        await ctx.reply(formatModelMenu(models, state), { reply_markup: buildModelKeyboard(models, state.model) });
+        return;
+      }
+
+      const model = findModel(models, parsed.modelId);
+      if (!model) {
+        await ctx.reply(`Unknown or disabled model: ${parsed.modelId}`);
+        return;
+      }
+      if (parsed.reasoningEffort && !allowedReasoningEfforts(model).includes(parsed.reasoningEffort)) {
+        await ctx.reply(`Invalid reasoning effort for ${model.modelId}: ${parsed.reasoningEffort}`);
+        return;
+      }
+      const next = await chatClient.setModel(model.modelId, parsed.reasoningEffort);
+      await ctx.reply(`Model switched to ${next.model || model.modelId}${next.reasoningEffort ? ` (${next.reasoningEffort})` : ""}.`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await ctx.reply(`Unable to switch model: ${message}`);
+    }
+  });
+
+  bot.command("status", async (ctx) => {
+    const chatClient = getChatClient(ctx.chat.id);
+    try {
+      await chatClient.connect();
+      await chatClient.waitForWelcome();
+      await ctx.reply(formatModelStatus(chatClient.getModelState()));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await ctx.reply(`Unable to read status: ${message}`);
+    }
+  });
+
+  bot.callbackQuery(/^model:/, async (ctx) => {
+    const modelId = parseModelCallback(ctx.callbackQuery.data);
+    if (!modelId) {
+      await ctx.answerCallbackQuery({ text: "Invalid model selection", show_alert: true });
+      return;
+    }
+    try {
+      const chatId = ctx.chat?.id;
+      if (chatId === undefined) {
+        await ctx.answerCallbackQuery({ text: "This selection is not tied to a chat", show_alert: true });
+        return;
+      }
+      const chatClient = getChatClient(chatId);
+      const models = await chatClient.getModels();
+      const model = findModel(models, modelId);
+      if (!model) {
+        await ctx.answerCallbackQuery({ text: "Unknown or disabled model", show_alert: true });
+        return;
+      }
+      const next = await chatClient.setModel(model.modelId);
+      await ctx.answerCallbackQuery({ text: `Switched to ${next.model || model.modelId}` });
+      await ctx.editMessageText(formatModelMenu(models, next), { reply_markup: buildModelKeyboard(models, next.model) });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await ctx.answerCallbackQuery({ text: message.slice(0, 190), show_alert: true });
+    }
+  });
+
   bot.on("message:text", async (ctx) => {
     const text = ctx.message.text.trim();
     if (!text || text.startsWith("/")) return;
@@ -120,6 +199,16 @@ export function createTelegramBot(options?: {
     start: async () => {
       await client.connect().catch((err) => {
         console.warn(`[telegram-connector] Could not connect to ADS Core on startup: ${err.message}. Will retry on turn.`);
+      });
+      await bot.api.setMyCommands([
+        { command: "start", description: "Connect to ADS" },
+        { command: "model", description: "Select the active model" },
+        { command: "status", description: "Show model status" },
+        { command: "new", description: "Clear session history" },
+        { command: "stop", description: "Interrupt the current turn" },
+      ]).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(`[telegram-connector] Could not register bot commands: ${message}`);
       });
       await bot.start();
     },

--- a/connectors/telegram/src/client/adsClient.ts
+++ b/connectors/telegram/src/client/adsClient.ts
@@ -19,6 +19,21 @@ export interface PromptTurnOptions {
   timeoutMs?: number;
 }
 
+export interface ModelOption {
+  id: string;
+  modelId: string;
+  displayName: string;
+  provider: string;
+  isEnabled: boolean;
+  isDefault: boolean;
+  configJson: Record<string, unknown> | null;
+}
+
+export interface ModelState {
+  model?: string;
+  reasoningEffort?: string;
+}
+
 export interface AdsEvent {
   type: string;
   [key: string]: unknown;
@@ -29,6 +44,9 @@ export class AdsCoreClient {
   private isConnected = false;
   private closed = false;
   private reconnectTimer: NodeJS.Timeout | null = null;
+  private connectPromise: Promise<void> | null = null;
+  private welcomeReceived = false;
+  private readonly welcomeWaiters = new Set<() => void>();
   private readonly eventListeners = new Set<(event: AdsEvent) => void>();
   private pendingPrompts = new Map<string, {
     resolve: (reply: string) => void;
@@ -36,12 +54,22 @@ export class AdsCoreClient {
     accumulatedText: string;
     timer: NodeJS.Timeout;
   }>();
+  private pendingControls = new Map<string, {
+    resolve: (state: ModelState) => void;
+    reject: (err: Error) => void;
+    timer: NodeJS.Timeout;
+  }>();
+  private modelState: ModelState = {};
 
   constructor(private readonly options: AdsClientOptions) {}
 
   async connect(): Promise<void> {
+    if (this.ws?.readyState === WebSocket.OPEN) return;
+    if (this.connectPromise) return this.connectPromise;
+
     this.closed = false;
-    return new Promise((resolve, reject) => {
+    this.welcomeReceived = false;
+    const connectionPromise = new Promise<void>((resolve, reject) => {
       const headers: Record<string, string> = {};
       if (this.options.token) {
         headers["Authorization"] = `Bearer ${this.options.token}`;
@@ -86,6 +114,12 @@ export class AdsCoreClient {
         }
       });
     });
+    this.connectPromise = connectionPromise;
+    try {
+      await connectionPromise;
+    } finally {
+      if (this.connectPromise === connectionPromise) this.connectPromise = null;
+    }
   }
 
   private scheduleReconnect(): void {
@@ -124,6 +158,33 @@ export class AdsCoreClient {
         clearTimeout(pending.timer);
         this.pendingPrompts.delete(resolvedId);
         pending.reject(new Error(String(parsed.error ?? "ADS Core prompt failed")));
+      }
+
+      if (parsed.type === "welcome") {
+        this.modelState = {
+          model: typeof parsed.effectiveModel === "string" ? parsed.effectiveModel : undefined,
+          reasoningEffort: typeof parsed.effectiveModelReasoningEffort === "string" ? parsed.effectiveModelReasoningEffort : undefined,
+        };
+        this.welcomeReceived = true;
+        for (const resolve of this.welcomeWaiters) resolve();
+        this.welcomeWaiters.clear();
+      }
+      if (parsed.type === "result" && parsed.kind === "model_override") {
+        const controlId = typeof parsed.client_message_id === "string" ? parsed.client_message_id : "";
+        const control = this.pendingControls.get(controlId);
+        if (control) {
+          clearTimeout(control.timer);
+          this.pendingControls.delete(controlId);
+          if (parsed.ok === false) {
+            control.reject(new Error(String(parsed.output ?? "Model override failed")));
+          } else {
+            this.modelState = {
+              model: typeof parsed.model === "string" ? parsed.model : undefined,
+              reasoningEffort: typeof parsed.model_reasoning_effort === "string" ? parsed.model_reasoning_effort : undefined,
+            };
+            control.resolve({ ...this.modelState });
+          }
+        }
       }
     } catch {
       // ignore malformed frame
@@ -175,6 +236,67 @@ export class AdsCoreClient {
     await this.sendControl("clear_history");
   }
 
+  async getModels(): Promise<ModelOption[]> {
+    const headers: Record<string, string> = {};
+    if (this.options.token) headers.Authorization = `Bearer ${this.options.token}`;
+    const response = await fetch(`${this.options.coreUrl.replace(/\/$/, "")}/api/models`, { headers });
+    if (!response.ok) throw new Error(`Failed to load models (${response.status})`);
+    const payload = await response.json() as unknown;
+    if (!Array.isArray(payload)) throw new Error("Invalid model list from ADS Core");
+    return payload
+      .filter((value): value is Record<string, unknown> => Boolean(value) && typeof value === "object" && !Array.isArray(value))
+      .map((value) => ({
+        id: String(value.id ?? ""),
+        modelId: String(value.modelId ?? "").trim(),
+        displayName: String(value.displayName ?? value.modelId ?? "").trim(),
+        provider: String(value.provider ?? "").trim(),
+        isEnabled: value.isEnabled !== false,
+        isDefault: value.isDefault === true,
+        configJson: value.configJson && typeof value.configJson === "object" && !Array.isArray(value.configJson)
+          ? value.configJson as Record<string, unknown>
+          : null,
+      }))
+      .filter((model) => model.modelId && model.isEnabled);
+  }
+
+  getModelState(): ModelState {
+    return { ...this.modelState };
+  }
+
+  async waitForWelcome(timeoutMs = 1_000): Promise<void> {
+    if (this.welcomeReceived) return;
+    await new Promise<void>((resolve) => {
+      const waiter = () => {
+        clearTimeout(timeout);
+        this.welcomeWaiters.delete(waiter);
+        resolve();
+      };
+      const timeout = setTimeout(() => {
+        this.welcomeWaiters.delete(waiter);
+        resolve();
+      }, Math.max(0, timeoutMs));
+      this.welcomeWaiters.add(waiter);
+    });
+  }
+
+  async setModel(model: string, reasoningEffort?: string): Promise<ModelState> {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) await this.connect();
+    const clientMessageId = `tg-model-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const finalState = new Promise<ModelState>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingControls.delete(clientMessageId);
+        reject(new Error("Model switch timed out"));
+      }, 15_000);
+      this.pendingControls.set(clientMessageId, { resolve, reject, timer });
+    });
+    this.ws!.send(JSON.stringify({
+      type: "model_override",
+      client_message_id: clientMessageId,
+      payload: { model, ...(reasoningEffort ? { model_reasoning_effort: reasoningEffort } : {}) },
+    }));
+    return finalState;
+  }
+
   private async sendControl(type: "interrupt" | "clear_history"): Promise<void> {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       await this.connect();
@@ -200,6 +322,11 @@ export class AdsCoreClient {
       pending.reject(new Error("Client closed"));
     }
     this.pendingPrompts.clear();
+    for (const [, pending] of this.pendingControls) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error("Client closed"));
+    }
+    this.pendingControls.clear();
     if (this.ws) {
       try { this.ws.close(); } catch { /* ignore */ }
       this.ws = null;

--- a/connectors/telegram/src/modelCommands.ts
+++ b/connectors/telegram/src/modelCommands.ts
@@ -1,0 +1,57 @@
+import { InlineKeyboard } from "grammy";
+import type { ModelOption, ModelState } from "./client/adsClient.js";
+
+export const REASONING_EFFORTS = ["off", "none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"] as const;
+
+export type ParsedModelCommand = { modelId?: string; reasoningEffort?: string };
+
+export function parseModelCommand(raw: string): ParsedModelCommand {
+  const parts = String(raw ?? "").trim().split(/\s+/).filter(Boolean);
+  const modelId = parts[0]?.trim();
+  const reasoningEffort = parts[1]?.trim().toLowerCase();
+  return {
+    ...(modelId ? { modelId } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+  };
+}
+
+export function allowedReasoningEfforts(model: ModelOption): string[] {
+  const configured = model.configJson?.reasoningEfforts;
+  if (!Array.isArray(configured) || configured.length === 0) return [...REASONING_EFFORTS];
+  return configured.map((value) => String(value).trim().toLowerCase()).filter((value) => REASONING_EFFORTS.includes(value as typeof REASONING_EFFORTS[number]));
+}
+
+export function findModel(models: ModelOption[], modelId: string): ModelOption | undefined {
+  const normalized = String(modelId ?? "").trim().toLowerCase();
+  return models.find((model) => model.isEnabled && model.modelId.toLowerCase() === normalized);
+}
+
+export function buildModelKeyboard(models: ModelOption[], activeModel?: string): InlineKeyboard {
+  const keyboard = new InlineKeyboard();
+  const active = String(activeModel ?? "").trim().toLowerCase();
+  for (const model of models.filter((entry) => entry.isEnabled)) {
+    const marker = model.modelId.toLowerCase() === active ? "✓ " : "";
+    keyboard.text(`${marker}${model.displayName || model.modelId}`, `model:${encodeURIComponent(model.modelId)}`).row();
+  }
+  return keyboard;
+}
+
+export function parseModelCallback(data: string): string | null {
+  const prefix = "model:";
+  if (!data.startsWith(prefix)) return null;
+  try {
+    const modelId = decodeURIComponent(data.slice(prefix.length)).trim();
+    return modelId || null;
+  } catch {
+    return null;
+  }
+}
+
+export function formatModelStatus(state: ModelState): string {
+  return `Active model: ${state.model || "default"}\nReasoning effort: ${state.reasoningEffort || "default"}`;
+}
+
+export function formatModelMenu(models: ModelOption[], state: ModelState): string {
+  if (models.length === 0) return "No enabled models are configured in ADS Core.";
+  return `Select a model (active: ${state.model || "default"}):`;
+}

--- a/connectors/telegram/tests/client.test.ts
+++ b/connectors/telegram/tests/client.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { WebSocketServer } from "ws";
+import { createServer } from "node:http";
 import { AdsCoreClient } from "../src/client/adsClient.js";
 
 type PromptMessage = {
@@ -149,5 +150,92 @@ describe("AdsCoreClient", () => {
 
     client.close();
     await new Promise<void>((resolve) => wss.close(() => resolve()));
+  });
+
+  it("sends a per-chat model override and tracks the Core acknowledgement", async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    await new Promise<void>((resolve, reject) => {
+      wss.once("listening", () => resolve());
+      wss.once("error", reject);
+    });
+    const address = wss.address();
+    if (!address || typeof address === "string") throw new Error("WebSocket test server did not expose a TCP address");
+    wss.on("connection", (ws) => {
+      ws.on("message", (raw) => {
+        const message = JSON.parse(String(raw)) as { type?: string; client_message_id?: string; payload?: { model?: string; model_reasoning_effort?: string } };
+        if (message.type === "model_override") {
+          ws.send(JSON.stringify({
+            type: "result",
+            kind: "model_override",
+            ok: true,
+            model: message.payload?.model,
+            model_reasoning_effort: message.payload?.model_reasoning_effort,
+            client_message_id: message.client_message_id,
+          }));
+        }
+      });
+    });
+
+    const client = new AdsCoreClient({
+      coreUrl: `http://127.0.0.1:${address.port}`,
+      coreWsUrl: `ws://127.0.0.1:${address.port}`,
+      sessionId: "telegram",
+      chatSessionId: "chat-42",
+    });
+    const state = await client.setModel("gemini-3.8-flash-high", "xhigh");
+    assert.deepEqual(state, { model: "gemini-3.8-flash-high", reasoningEffort: "xhigh" });
+    assert.deepEqual(client.getModelState(), state);
+    client.close();
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+  });
+
+  it("waits for the Core welcome frame before reporting the active model", async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    await new Promise<void>((resolve, reject) => {
+      wss.once("listening", () => resolve());
+      wss.once("error", reject);
+    });
+    const address = wss.address();
+    if (!address || typeof address === "string") throw new Error("WebSocket test server did not expose a TCP address");
+    wss.on("connection", (ws) => {
+      ws.send(JSON.stringify({
+        type: "welcome",
+        effectiveModel: "gpt-5.6-sol",
+        effectiveModelReasoningEffort: "high",
+      }));
+    });
+
+    const client = new AdsCoreClient({
+      coreUrl: `http://127.0.0.1:${address.port}`,
+      coreWsUrl: `ws://127.0.0.1:${address.port}`,
+    });
+    await client.connect();
+    await client.waitForWelcome();
+    assert.deepEqual(client.getModelState(), { model: "gpt-5.6-sol", reasoningEffort: "high" });
+    client.close();
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+  });
+
+  it("loads only enabled model options from the Core API", async () => {
+    const server = createServer((req, res) => {
+      assert.equal(req.headers.authorization, "Bearer connector-token");
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify([
+        { id: "one", modelId: "gpt-5.6-sol", displayName: "Sol", provider: "openai", isEnabled: true, isDefault: true, configJson: null },
+        { id: "two", modelId: "disabled", displayName: "Disabled", provider: "openai", isEnabled: false, isDefault: false, configJson: null },
+      ]));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("HTTP test server did not expose a TCP address");
+    const client = new AdsCoreClient({
+      coreUrl: `http://127.0.0.1:${address.port}`,
+      coreWsUrl: `ws://127.0.0.1:${address.port}`,
+      token: "connector-token",
+    });
+    const models = await client.getModels();
+    assert.deepEqual(models.map((model) => model.modelId), ["gpt-5.6-sol"]);
+    client.close();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
   });
 });

--- a/connectors/telegram/tests/modelCommands.test.ts
+++ b/connectors/telegram/tests/modelCommands.test.ts
@@ -1,0 +1,47 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  allowedReasoningEfforts,
+  buildModelKeyboard,
+  findModel,
+  formatModelStatus,
+  parseModelCallback,
+  parseModelCommand,
+} from "../src/modelCommands.js";
+import type { ModelOption } from "../src/client/adsClient.js";
+
+const models: ModelOption[] = [
+  { id: "one", modelId: "gpt-5.6-sol", displayName: "Sol", provider: "openai", isEnabled: true, isDefault: true, configJson: { reasoningEfforts: ["high", "max"] } },
+  { id: "two", modelId: "disabled", displayName: "Disabled", provider: "openai", isEnabled: false, isDefault: false, configJson: null },
+];
+
+describe("Telegram model commands", () => {
+  it("parses direct model and reasoning effort syntax", () => {
+    assert.deepEqual(parseModelCommand("gemini-3.8-flash-high xhigh"), {
+      modelId: "gemini-3.8-flash-high",
+      reasoningEffort: "xhigh",
+    });
+    assert.deepEqual(parseModelCommand(""), {});
+  });
+
+  it("finds enabled models only and respects configured reasoning efforts", () => {
+    assert.equal(findModel(models, "GPT-5.6-SOL")?.modelId, "gpt-5.6-sol");
+    assert.equal(findModel(models, "disabled"), undefined);
+    assert.deepEqual(allowedReasoningEfforts(models[0]!), ["high", "max"]);
+    assert.deepEqual(allowedReasoningEfforts({ ...models[0]!, configJson: { reasoningEfforts: [] } }), [
+      "off", "none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra",
+    ]);
+  });
+
+  it("marks the active model and round-trips callback data", () => {
+    const keyboard = buildModelKeyboard(models, "gpt-5.6-sol");
+    const first = keyboard.inline_keyboard[0]?.[0];
+    assert.equal(first?.text, "✓ Sol");
+    assert.equal(parseModelCallback(String(first?.callback_data)), "gpt-5.6-sol");
+  });
+
+  it("formats the active model status", () => {
+    assert.equal(formatModelStatus({ model: "gpt-5.6-sol", reasoningEffort: "high" }), "Active model: gpt-5.6-sol\nReasoning effort: high");
+  });
+});

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -36,11 +36,16 @@ node connectors/telegram/bin/ads-telegram.js start
 | Command | Arguments | Behavior |
 |---|---|---|
 | `/start` | None | Confirms that the connector is available. |
+| `/model` | None | Shows an inline keyboard of enabled models from the global ADS model registry. |
+| `/model` | `<modelId> [reasoningEffort]` | Switches the current Telegram chat to the selected global model and optional reasoning effort. |
+| `/status` | None | Shows the active model and reasoning effort for the current Telegram chat. |
 | `/new` | None | Clears history for the current Telegram chat only. |
 | `/stop` | None | Interrupts an active turn for the current Telegram chat only. |
 | Text message | Any non-command text | Sends a `channel: "telegram"` prompt to ADS Core. |
 
 Each Telegram chat uses an independent Core chat session. History, `/new`, and `/stop` actions are scoped to that chat and cannot affect another chat.
+
+The `/model` list is read from ADS Core's global model configuration registry (`/api/models`). Model configuration is not workspace-scoped. A model selection is stored in the chat's Core session, so changing it in one Telegram chat does not change another chat's active model.
 
 The connector receives Core `task_terminal` events. A scheduled task with an explicit Telegram `chatId` is delivered to that chat; `TELEGRAM_NOTIFICATION_CHAT_ID` is an optional fallback.
 

--- a/server/web/server/startWebServer.ts
+++ b/server/web/server/startWebServer.ts
@@ -352,7 +352,7 @@ export async function startWebServer(): Promise<void> {
       authenticateRequest: (req) => {
         const auth = authenticateWebRequest(req, { sessionTtlSeconds, sessionPepper });
         return auth.ok
-          ? { ok: true as const, userId: auth.userId, tokenHash: auth.tokenHash }
+          ? { ok: true as const, userId: auth.userId, tokenHash: auth.tokenHash, connector: auth.connector }
           : { ok: false as const };
       },
       revalidateSession: (tokenHash) => isSessionActiveByTokenHash({ tokenHash }),

--- a/server/web/server/ws/messageControl.ts
+++ b/server/web/server/ws/messageControl.ts
@@ -1,6 +1,8 @@
 import type { WebSocket } from "ws";
 
 import type { SessionManager } from "../../../sessions/sessionManager.js";
+import { getStateDatabase } from "../../../state/database.js";
+import { createGlobalModelConfigStore } from "../../../state/globalModelConfigStore.js";
 import type { HistoryStore } from "../../../utils/historyStore.js";
 import type {
   WsLaneValidityCheck,
@@ -15,6 +17,37 @@ import { handleTaskResumeMessage } from "./handleTaskResume.js";
 import type { WsMessage } from "./schema.js";
 
 type ClearHistoryScope = "lane" | "shared";
+
+const STANDARD_REASONING_EFFORTS = new Set(["off", "none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]);
+
+function readModelOverridePayload(payload: unknown): { model: string; effort?: string } | { error: string } {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return { error: "Model override payload must be an object" };
+  }
+  const record = payload as Record<string, unknown>;
+  const model = String(record.model ?? record.modelId ?? record.model_id ?? "").trim();
+  if (!model) {
+    return { error: "Model id is required" };
+  }
+  const rawEffort = record.model_reasoning_effort ?? record.modelReasoningEffort;
+  if (rawEffort === undefined || rawEffort === null || String(rawEffort).trim() === "") {
+    return { model };
+  }
+  const effort = String(rawEffort).trim().toLowerCase();
+  if (effort === "default") {
+    return { model };
+  }
+  if (!STANDARD_REASONING_EFFORTS.has(effort)) {
+    return { error: `Invalid reasoning effort: ${effort}` };
+  }
+  return { model, effort };
+}
+
+function readConfiguredReasoningEfforts(configJson: unknown): string[] {
+  if (!configJson || typeof configJson !== "object" || Array.isArray(configJson)) return [];
+  const values = (configJson as Record<string, unknown>).reasoningEfforts;
+  return Array.isArray(values) ? values.map((value) => String(value).trim().toLowerCase()).filter(Boolean) : [];
+}
 
 function resolveClearHistoryScope(payload: unknown, chatSessionId: string): ClearHistoryScope {
   if (String(chatSessionId ?? "").trim() === "planner") {
@@ -67,6 +100,45 @@ export async function handleWsControlMessage(args: {
   handled: boolean;
   orchestrator: ReturnType<SessionManager["getOrCreate"]>;
 }> {
+  if (args.parsed.type === "model_override") {
+    const requestId = String(args.parsed.client_message_id ?? "").trim() || undefined;
+    const parsed = readModelOverridePayload(args.parsed.payload);
+    if ("error" in parsed) {
+      args.sendJson({ type: "result", ok: false, kind: "model_override", output: parsed.error, client_message_id: requestId });
+      return { handled: true, orchestrator: args.orchestrator };
+    }
+
+    const modelStore = createGlobalModelConfigStore(getStateDatabase());
+    const modelConfig = modelStore.getModelConfigByAgentModelId(parsed.model) ?? modelStore.getModelConfig(parsed.model);
+    if (!modelConfig || !modelConfig.isEnabled) {
+      args.sendJson({ type: "result", ok: false, kind: "model_override", output: `Unknown or disabled model: ${parsed.model}`, client_message_id: requestId });
+      return { handled: true, orchestrator: args.orchestrator };
+    }
+    const allowedEfforts = readConfiguredReasoningEfforts(modelConfig.configJson);
+    if (parsed.effort && allowedEfforts.length > 0 && !allowedEfforts.includes(parsed.effort)) {
+      args.sendJson({ type: "result", ok: false, kind: "model_override", output: `Reasoning effort "${parsed.effort}" is not available for ${modelConfig.modelId}`, client_message_id: requestId });
+      return { handled: true, orchestrator: args.orchestrator };
+    }
+
+    const modelId = String(modelConfig.modelId ?? modelConfig.id ?? parsed.model).trim();
+    args.sessionManager.setUserModel(args.userId, modelId);
+    if (parsed.effort !== undefined) {
+      args.sessionManager.setUserModelReasoningEffort(args.userId, parsed.effort);
+    }
+    args.orchestrator.setModelConfig?.(modelConfig.configJson ?? null);
+    const effective = args.sessionManager.getEffectiveState(args.userId);
+    args.sendJson({
+      type: "result",
+      ok: true,
+      kind: "model_override",
+      output: `Model switched to ${modelId}${effective.modelReasoningEffort ? ` (${effective.modelReasoningEffort})` : ""}`,
+      model: effective.model,
+      model_reasoning_effort: effective.modelReasoningEffort,
+      client_message_id: requestId,
+    });
+    return { handled: true, orchestrator: args.orchestrator };
+  }
+
   if (args.parsed.type === "clear_history") {
     const scope = resolveClearHistoryScope(args.parsed.payload, args.chatSessionId);
     if (args.interruptControllers) {

--- a/tests/web/messageControl.test.ts
+++ b/tests/web/messageControl.test.ts
@@ -2,6 +2,8 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import { ensureWsSessionLogger, handleWsControlMessage } from "../../server/web/server/ws/messageControl.js";
+import { getStateDatabase } from "../../server/state/database.js";
+import { createGlobalModelConfigStore } from "../../server/state/globalModelConfigStore.js";
 
 describe("web/ws/messageControl", () => {
   it("returns null and warns when session logger initialization fails", () => {
@@ -176,6 +178,123 @@ describe("web/ws/messageControl", () => {
       ok: true,
       output: "已清空历史缓存并重置会话",
       kind: "clear_history",
+    });
+  });
+
+  it("validates and applies a connector-safe model override per session", async () => {
+    const modelStore = createGlobalModelConfigStore(getStateDatabase());
+    modelStore.upsertModelConfig({
+      id: "telegram-model-control",
+      modelId: "telegram-test-model",
+      displayName: "Telegram Test Model",
+      provider: "test",
+      isEnabled: true,
+      isDefault: false,
+      configJson: { reasoningEfforts: ["high", "xhigh"] },
+    });
+    let model: string | undefined;
+    let effort: string | undefined;
+    const sent: unknown[] = [];
+    const result = await handleWsControlMessage({
+      parsed: {
+        type: "model_override",
+        client_message_id: "control-1",
+        payload: { model: "telegram-test-model", model_reasoning_effort: "xhigh" },
+      },
+      chatSessionId: "chat-42",
+      userId: 42,
+      historyKey: "telegram-history-42",
+      currentCwd: "/tmp/project",
+      sessionManager: {
+        setUserModel: (_userId: number, value?: string) => { model = value; },
+        setUserModelReasoningEffort: (_userId: number, value?: string) => { effort = value; },
+        getEffectiveState: () => ({ model, modelReasoningEffort: effort, activeAgentId: "codex" }),
+      } as any,
+      orchestrator: { setModelConfig: () => {} } as any,
+      getWorkspaceLock: (() => null) as any,
+      historyStore: { clear: () => {} },
+      sendJson: (payload) => sent.push(payload),
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    assert.equal(result.handled, true);
+    assert.equal(model, "telegram-test-model");
+    assert.equal(effort, "xhigh");
+    assert.deepEqual(sent[0], {
+      type: "result",
+      ok: true,
+      kind: "model_override",
+      output: "Model switched to telegram-test-model (xhigh)",
+      model: "telegram-test-model",
+      model_reasoning_effort: "xhigh",
+      client_message_id: "control-1",
+    });
+  });
+
+  it("rejects unavailable reasoning efforts without changing session state", async () => {
+    const sent: unknown[] = [];
+    const result = await handleWsControlMessage({
+      parsed: { type: "model_override", payload: { model: "telegram-test-model", model_reasoning_effort: "low" } },
+      chatSessionId: "chat-42",
+      userId: 42,
+      historyKey: "telegram-history-42",
+      currentCwd: "/tmp/project",
+      sessionManager: { setUserModel: () => { throw new Error("must not change"); } } as any,
+      orchestrator: {} as any,
+      getWorkspaceLock: (() => null) as any,
+      historyStore: { clear: () => {} },
+      sendJson: (payload) => sent.push(payload),
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    assert.equal(result.handled, true);
+    assert.equal((sent[0] as { ok: boolean }).ok, false);
+    assert.match(String((sent[0] as { output: string }).output), /not available/);
+  });
+
+  it("preserves the existing reasoning effort when only the model changes", async () => {
+    const modelStore = createGlobalModelConfigStore(getStateDatabase());
+    modelStore.upsertModelConfig({
+      id: "telegram-model-preserve-effort",
+      modelId: "telegram-preserve-model",
+      displayName: "Telegram Preserve Model",
+      provider: "test",
+      isEnabled: true,
+      isDefault: false,
+      configJson: { reasoningEfforts: ["high"] },
+    });
+    const sent: unknown[] = [];
+    const result = await handleWsControlMessage({
+      parsed: {
+        type: "model_override",
+        client_message_id: "control-preserve-effort",
+        payload: { model: "telegram-preserve-model" },
+      },
+      chatSessionId: "chat-42",
+      userId: 42,
+      historyKey: "telegram-history-42",
+      currentCwd: "/tmp/project",
+      sessionManager: {
+        setUserModel: () => {},
+        setUserModelReasoningEffort: () => { throw new Error("must preserve existing effort"); },
+        getEffectiveState: () => ({ model: "telegram-preserve-model", modelReasoningEffort: "high", activeAgentId: "codex" }),
+      } as any,
+      orchestrator: { setModelConfig: () => {} } as any,
+      getWorkspaceLock: (() => null) as any,
+      historyStore: { clear: () => {} },
+      sendJson: (payload) => sent.push(payload),
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    assert.equal(result.handled, true);
+    assert.deepEqual(sent[0], {
+      type: "result",
+      ok: true,
+      kind: "model_override",
+      output: "Model switched to telegram-preserve-model (high)",
+      model: "telegram-preserve-model",
+      model_reasoning_effort: "high",
+      client_message_id: "control-preserve-effort",
     });
   });
 


### PR DESCRIPTION
## Summary

- replace the retired Telegram `/agent` surface with `/model` and `/status`
- read enabled models from the global ADS model registry and apply per-chat model overrides over WebSocket
- support inline keyboard selection and `/model <modelId> [reasoningEffort]`
- preserve existing reasoning effort when only the model changes
- keep standalone connector authentication and startup command registration reliable
- document the global (not workspace-scoped) model configuration boundary

Closes #138

## Verification

- `npm run build`
- `npm run lint`
- `npm test` (820 tests)
- `npm run build --prefix connectors/telegram`
- `npm test --prefix connectors/telegram` (16 tests)