### PR TITLE
fix(web): prevent phantom execution state after reconnect

### DIFF
--- a/client/src/__tests__/issue-143-reconnect-visible-blocks.test.ts
+++ b/client/src/__tests__/issue-143-reconnect-visible-blocks.test.ts
@@ -355,4 +355,79 @@ describe("Issue #143 follow-up: Reconnect correctness and visible block contract
 
     wrapper.unmount();
   });
+  it("5. does not set busy=true or lock input on stale/terminal command snapshot replay during idle bootstrap (Issue #152)", async () => {
+    const { wrapper, rt } = await mountReconnectHarness();
+
+    // Initial state: idle session
+    expect(rt.busy.value).toBe(false);
+    expect(rt.inputLocked.value).toBe(false);
+
+    // Reconnect on idle session (inFlight: false)
+    lastWs!.onOpen?.();
+    lastWs!.onMessage?.({
+      type: "welcome",
+      inFlight: false,
+      latestSeq: 0,
+      bootstrapHistory: true,
+    });
+    await settleUi(wrapper);
+
+    expect(rt.busy.value).toBe(false);
+    expect(rt.inputLocked.value).toBe(false);
+
+    // Stale completed/failed command snapshot arrives with bootstrap: true
+    lastWs!.onMessage?.({
+      type: "command_snapshot",
+      bootstrap: true,
+      seq: 2,
+      command: {
+        id: "cmd-stale",
+        command: "npm test",
+        output: "PASS tests/stale.test.ts",
+        status: "completed",
+      },
+    });
+    await settleUi(wrapper);
+
+    // Must NOT become busy or lock input
+    expect(rt.busy.value).toBe(false);
+    expect(rt.turnInFlight).toBe(false);
+    expect(rt.inputLocked.value).toBe(false);
+
+    // Terminal command snapshot without bootstrap flag also must not mark turn busy
+    lastWs!.onMessage?.({
+      type: "command_snapshot",
+      seq: 3,
+      command: {
+        id: "cmd-completed-late",
+        command: "git status",
+        output: "nothing to commit",
+        status: "completed",
+      },
+    });
+    await settleUi(wrapper);
+
+    expect(rt.busy.value).toBe(false);
+    expect(rt.turnInFlight).toBe(false);
+    expect(rt.inputLocked.value).toBe(false);
+
+    // Genuine running command outside bootstrap sets busy=true
+    lastWs!.onMessage?.({
+      type: "command",
+      seq: 4,
+      command: {
+        id: "cmd-active",
+        command: "cargo build",
+        outputDelta: "Compiling...",
+        status: "running",
+      },
+    });
+    await settleUi(wrapper);
+
+    expect(rt.busy.value).toBe(true);
+    expect(rt.turnInFlight).toBe(true);
+
+    wrapper.unmount();
+  });
+
 });

--- a/client/src/app/projectsWs/wsMessage.ts
+++ b/client/src/app/projectsWs/wsMessage.ts
@@ -1457,8 +1457,11 @@ export function createWsMessageHandler(args: WsMessageHandlerArgs) {
       const eventTs = finiteTimestamp((msg as Record<string, unknown>).ts ?? snapshot?.ts);
       const revision = Number(snapshot?.revision);
       const snapshotSequence = Number((msg as Record<string, unknown>).seq ?? snapshot?.snapshotSeq ?? snapshot?.afterSeq);
-      rt.busy.value = true;
-      rt.turnInFlight = true;
+      const isBootstrapSnapshot = (msg as Record<string, unknown>).bootstrap === true;
+      if (!isBootstrapSnapshot && !terminal) {
+        rt.busy.value = true;
+        rt.turnInFlight = true;
+      }
       clearRecoveredBackendStatus();
       ingestCommand(cmd, rt, identity || null);
       upsertExecuteBlock(key, cmd, String(snapshot?.output ?? ""), rt, {

--- a/server/web/server/sync/commandSnapshot.ts
+++ b/server/web/server/sync/commandSnapshot.ts
@@ -166,13 +166,20 @@ export function createCommandSnapshotCoalescer(args: {
       if (command) {
         const identity = String(command.identity ?? command.id ?? "").trim();
         const commandLine = String(command.command ?? "").trim();
-        if (identity && commandLine) {
+        const status = String(command.status ?? "").trim() || undefined;
+        const terminal = isTerminalStatus(status);
+        if (terminal && row.eventId) {
+          args.store.deleteCoalesced({
+            namespace: args.namespace,
+            laneKey: args.laneKey,
+            type: COMMAND_SNAPSHOT_EVENT_TYPE,
+            eventId: row.eventId,
+          });
+        } else if (identity && commandLine) {
           const output = String(command.output ?? "").slice(-COMMAND_SNAPSHOT_MAX_CHARS);
           const endOffset = readOffset(command.endOffset) ?? output.length;
           const startOffset = readOffset(command.startOffset) ?? Math.max(0, endOffset - output.length);
           const id = String(command.id ?? "").trim();
-          const status = String(command.status ?? "").trim() || undefined;
-          const terminal = isTerminalStatus(status);
           const eventId = String(row.eventId ?? commandEventId(identity)).trim() || commandEventId(identity);
           const entry: ActiveCommand = {
             eventId,

--- a/server/web/server/ws/bootstrapDelivery.ts
+++ b/server/web/server/ws/bootstrapDelivery.ts
@@ -126,7 +126,7 @@ export function sendInitialBootstrapMessages(args: {
   if (historyPayload) {
     args.safeJsonSend(args.ws, historyPayload);
   }
-  for (const snapshot of args.runtimeSnapshots ?? []) {
+  for (const snapshot of (args.inFlight ? (args.runtimeSnapshots ?? []) : [])) {
     if (!snapshot || typeof snapshot !== "object" || snapshot.active === false) continue;
     const snapshotSeq = Number(snapshot.snapshotSeq ?? snapshot.seq ?? snapshot.afterSeq);
     const afterSeq = Number.isFinite(snapshotSeq) && snapshotSeq >= 0 ? Math.floor(snapshotSeq) : 0;

--- a/server/web/server/ws/server.ts
+++ b/server/web/server/ws/server.ts
@@ -601,10 +601,13 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
       commandSnapshotCoalescer,
     });
 
-    const collectRuntimeSnapshots = (lane: WsLaneSnapshot): Array<Record<string, unknown>> => [
-      ...(lane.deltaCoalescer?.getSnapshots?.() ?? []),
-      ...(lane.commandSnapshotCoalescer?.getSnapshots?.() ?? []),
-    ];
+    const collectRuntimeSnapshots = (lane: WsLaneSnapshot, inFlightForLane: boolean): Array<Record<string, unknown>> => {
+      if (!inFlightForLane) return [];
+      return [
+        ...(lane.deltaCoalescer?.getSnapshots?.() ?? []),
+        ...(lane.commandSnapshotCoalescer?.getSnapshots?.() ?? []),
+      ];
+    };
 
     let currentLane = captureLane();
 
@@ -785,7 +788,7 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
       historyKey: currentLane.historyKey,
       latestSeq: state.syncEventStore?.getLatestSeqForLanes(currentLane.laneNamespace, currentLane.syncLaneKeys) ?? 0,
       laneGeneration: currentLane.laneGeneration,
-      runtimeSnapshots: collectRuntimeSnapshots(currentLane),
+      runtimeSnapshots: collectRuntimeSnapshots(currentLane, inFlight),
     });
 
     let messageChain = Promise.resolve();
@@ -974,10 +977,11 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
             commandSnapshotCoalescer?.finish();
             syncNamespace = nextLaneNamespace;
             syncLaneKeys = nextSyncLaneKeys;
+            const nextInFlight = state.interruptControllers.has(historyKey);
             const nextSyncRuntime = getLaneSyncRuntime(
               syncNamespace,
               historyKey,
-              state.interruptControllers.has(historyKey),
+              nextInFlight,
             );
             deltaCoalescer = nextSyncRuntime?.deltaCoalescer ?? null;
             commandSnapshotCoalescer = nextSyncRuntime?.commandSnapshotCoalescer ?? null;
@@ -993,12 +997,12 @@ export function attachWebSocketServer(deps: AttachWebSocketServerDeps): WebSocke
               sessionId,
               chatSessionId: currentLane.chatSessionId,
               workspace: getWorkspaceState(currentLane.currentCwd),
-              inFlight: false,
+              inFlight: nextInFlight,
               historyStore: currentLane.historyStore,
               historyKey: currentLane.historyKey,
               latestSeq: state.syncEventStore?.getLatestSeqForLanes(currentLane.laneNamespace, currentLane.syncLaneKeys) ?? 0,
               laneGeneration: currentLane.laneGeneration,
-              runtimeSnapshots: collectRuntimeSnapshots(currentLane),
+              runtimeSnapshots: collectRuntimeSnapshots(currentLane, nextInFlight),
             });
 
             logger.info(

--- a/tests/web/bootstrapDelivery.test.ts
+++ b/tests/web/bootstrapDelivery.test.ts
@@ -549,4 +549,59 @@ describe("web/ws/bootstrapDelivery", () => {
       historyStore.clear("history-1");
     }
   });
+  it("delivers runtime snapshots only when inFlight is true", () => {
+    const sentIdle: unknown[] = [];
+    const historyStore = new HistoryStore({ namespace: "test-bootstrap-delivery-snapshots", maxEntriesPerSession: 20 });
+    const runtimeSnapshots = [
+      {
+        type: "command_snapshot",
+        eventId: "active-cmd-1",
+        active: true,
+        command: { id: "cmd-1", command: "npm test", status: "completed" },
+      },
+    ];
+
+    const baseArgs = {
+      ws: {} as any,
+      sessionManager: {
+        getSavedThreadId: () => undefined,
+        getContextRestoreMode: () => "fresh",
+        getEffectiveState: () => ({ model: "gpt-4o", modelReasoningEffort: "high", activeAgentId: "codex" }),
+      } as any,
+      orchestrator: {
+        getActiveAgentId: () => "codex",
+        getThreadId: () => null,
+        listAgents: () => [{ metadata: { id: "codex", name: "Codex" }, status: { ready: true, streaming: true } }],
+      } as any,
+      userId: 7,
+      agentAvailability: { mergeStatus: (_agentId: unknown, status: unknown) => status } as any,
+      sessionId: "session-1",
+      chatSessionId: "main",
+      workspace: { path: "/tmp/project" },
+      historyStore,
+      historyKey: "history-1",
+      runtimeSnapshots,
+    };
+
+    // When idle (inFlight: false), server must not deliver stale runtime snapshots
+    sendInitialBootstrapMessages({
+      ...baseArgs,
+      inFlight: false,
+      safeJsonSend: (_ws, payload) => sentIdle.push(payload),
+    });
+    assert.equal(sentIdle.some((p: any) => p.type === "command_snapshot"), false);
+
+    // When genuinely in flight, server delivers runtime snapshots with bootstrap: true
+    const sentInFlight: unknown[] = [];
+    sendInitialBootstrapMessages({
+      ...baseArgs,
+      inFlight: true,
+      safeJsonSend: (_ws, payload) => sentInFlight.push(payload),
+    });
+    const snapshotMsg = sentInFlight.find((p: any) => p.type === "command_snapshot") as any;
+    assert.ok(snapshotMsg);
+    assert.equal(snapshotMsg.bootstrap, true);
+    assert.equal(snapshotMsg.command?.id, "cmd-1");
+  });
+
 });

--- a/tests/web/commandSnapshot.test.ts
+++ b/tests/web/commandSnapshot.test.ts
@@ -151,4 +151,30 @@ describe("server/sync/commandSnapshot", () => {
       "npm run build",
     );
   });
+  it("does not hydrate terminal command snapshots as active", () => {
+    const store = new SyncEventStore({ stateDbPath });
+    // Simulate a previous turn where finish() was never called, but status was completed
+    const writer = createCommandSnapshotCoalescer({
+      store,
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey: "command-lane",
+      now: () => 5000,
+    });
+    writer.record({
+      type: "command",
+      ts: 5000,
+      command: { id: "cmd-done", command: "npm test", outputDelta: "$ npm test\nPASS\n", status: "completed" },
+    });
+
+    // After server restart/reconnect, hydrate should ignore terminal snapshots
+    const reconnect = createCommandSnapshotCoalescer({
+      store,
+      namespace: WEB_WORKER_NAMESPACE,
+      laneKey: "command-lane",
+      hydrate: true,
+    });
+    assert.equal(reconnect.getActiveCount(), 0);
+    assert.equal(reconnect.getSnapshots().length, 0);
+  });
+
 });


### PR DESCRIPTION
Closes #152

## Summary
- suppress runtime command snapshots during idle bootstrap
- discard terminal snapshots during hydration
- keep bootstrap and terminal snapshots from marking the client busy
- preserve active snapshots when an in-flight lane is selected

## Verification
- npm run lint
- npm run build
- npm test (750 passed)
- npm run test:web (438 passed)
- focused reconnect and bootstrap tests