### PR TITLE
feat(ui): add lane connection status indicator

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -617,29 +617,41 @@
   cursor: pointer;
   white-space: nowrap;
   flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
   transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
 
-.laneTab--connected {
-  color: #059669;
+.laneTabStatusDot {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 6px;
+  border-radius: 50%;
+  background: #94a3b8;
 }
 
-.laneTab--disconnected {
-  color: #94a3b8;
+.laneTabStatusDot--connected {
+  background: #059669;
 }
 
-.laneTab:hover {
-  color: #0f172a;
+.laneTabStatusDot--disconnected {
+  background: #94a3b8;
 }
 
 .laneTab.active {
   background: white;
   color: #0f172a;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  font-weight: 800;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.1), 0 1px 2px rgba(15, 23, 42, 0.06);
 }
 
-.laneTab.active.laneTab--connected {
-  color: #059669;
+.laneTab:not(.active) {
+  color: #64748b;
+}
+
+.laneTab:not(.active):hover {
+  color: #334155;
 }
 
 .laneTab:focus-visible {

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -455,7 +455,7 @@ const plannerConnectionStatus = computed(() => {
       <div class="right">
         <button
           v-if="!isMobile"
-            type="button"
+          type="button"
           class="topbarIconBtn"
           title="管理模型"
           aria-label="管理模型"
@@ -628,7 +628,7 @@ const plannerConnectionStatus = computed(() => {
             v-for="tab in workspaceTabs"
             :id="`lane-tab-${tab.id}`"
             :key="tab.id"
-          type="button"
+            type="button"
             class="laneTab"
             :class="{ active: activeWorkspaceTab === tab.id }"
             role="tab"

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -455,7 +455,7 @@ const plannerConnectionStatus = computed(() => {
       <div class="right">
         <button
           v-if="!isMobile"
-          type="button"
+            type="button"
           class="topbarIconBtn"
           title="管理模型"
           aria-label="管理模型"
@@ -628,20 +628,24 @@ const plannerConnectionStatus = computed(() => {
             v-for="tab in workspaceTabs"
             :id="`lane-tab-${tab.id}`"
             :key="tab.id"
-            type="button"
-          class="laneTab"
-          :class="{
-            active: activeWorkspaceTab === tab.id,
-            'laneTab--connected': isLaneConnected(tab.id, { planner: plannerConnected, worker: connected }),
-            'laneTab--disconnected': !isLaneConnected(tab.id, { planner: plannerConnected, worker: connected }),
-          }"
-          role="tab"
+          type="button"
+            class="laneTab"
+            :class="{ active: activeWorkspaceTab === tab.id }"
+            role="tab"
             :aria-selected="activeWorkspaceTab === tab.id"
             :aria-controls="`lane-panel-${tab.id}`"
             :data-testid="`lane-tab-${tab.id}`"
             @click="selectWorkspaceTab(tab.id)"
           >
-            {{ tab.label }}
+            <span
+              class="laneTabStatusDot"
+              :class="isLaneConnected(tab.id, { planner: plannerConnected, worker: connected })
+                ? 'laneTabStatusDot--connected'
+                : 'laneTabStatusDot--disconnected'"
+              :data-testid="`lane-tab-status-${tab.id}`"
+              aria-hidden="true"
+            />
+            <span class="laneTabLabel">{{ tab.label }}</span>
           </button>
           <span v-if="!isMobile" class="laneTabSpacer" />
           <button

--- a/client/src/__tests__/lane-connection-status.test.ts
+++ b/client/src/__tests__/lane-connection-status.test.ts
@@ -22,11 +22,20 @@ describe("lane connection status", () => {
     expect(isLaneConnected("planner", { planner: false, worker: true })).toBe(false);
   });
 
-  it("keeps connected lane text green when the tab is active", () => {
+  it("renders connection state with an independent six-pixel status dot", () => {
     const css = readAppCss();
 
-    expect(css).toMatch(
-      /\.laneTab\.active\.laneTab--connected\s*\{[\s\S]*?color:\s*#059669\s*;/,
-    );
+    expect(css).toMatch(/\.laneTabStatusDot\s*\{[\s\S]*?width:\s*6px;[\s\S]*?height:\s*6px;/);
+    expect(css).toMatch(/\.laneTabStatusDot--connected\s*\{[\s\S]*?background:\s*#059669\s*;/);
+    expect(css).toMatch(/\.laneTabStatusDot--disconnected\s*\{[\s\S]*?background:\s*#94a3b8\s*;/);
+    expect(css).not.toMatch(/\.laneTab\.active\.laneTab--connected/);
+  });
+
+  it("keeps the active lane tab text high contrast", () => {
+    const css = readAppCss();
+
+    expect(css).toMatch(/\.laneTab\.active\s*\{[\s\S]*?color:\s*#0f172a\s*;/);
+    expect(css).toMatch(/\.laneTab:not\(\.active\)\s*\{[\s\S]*?color:\s*#64748b\s*;/);
+    expect(css).toMatch(/\.laneTab:not\(\.active\):hover\s*\{[\s\S]*?color:\s*#334155\s*;/);
   });
 });

--- a/client/src/__tests__/mobile-navigation-behavior.test.ts
+++ b/client/src/__tests__/mobile-navigation-behavior.test.ts
@@ -136,6 +136,8 @@ describe("mobile navigation behavior", () => {
     expect(wrapper.find(".chatShell").exists()).toBe(true);
     expect(wrapper.find(".mobileMainPanel").exists()).toBe(false);
     expect(wrapper.findAll(".laneTab").map((tab) => tab.text())).toEqual(["Advisor", "Worker"]);
+    expect(wrapper.find('[data-testid="lane-tab-status-planner"]').classes()).toContain("laneTabStatusDot--connected");
+    expect(wrapper.find('[data-testid="lane-tab-status-worker"]').classes()).toContain("laneTabStatusDot--connected");
     expect(wrapper.find('[data-testid="lane-tab-planner"]').classes()).toContain("active");
 
     await wrapper.find('[data-testid="mobile-context-menu-toggle"]').trigger("click");


### PR DESCRIPTION
Closes #155

## Summary
- add a dedicated connected or disconnected status dot to each lane tab
- restore clear active-tab contrast without coloring the whole label green
- remove obsolete lane connection classes and cover mobile rendering

## Verification
- npm run lint
- npm run build
- npm test (748 passed)
- npm run test:web (438 passed)