### PR TITLE
fix: prevent advisor command deadlocks

### DIFF
--- a/server/agents/adapters/codexAppServerAdapter.ts
+++ b/server/agents/adapters/codexAppServerAdapter.ts
@@ -1169,6 +1169,7 @@ export class CodexAppServerAdapter implements AgentAdapter {
     const params: Record<string, unknown> = {
       experimentalRawEvents: false,
       persistExtendedHistory: false,
+      approvalPolicy: "never",
     };
     if (this.workingDirectory) params.cwd = this.workingDirectory;
     if (this.model) params.model = this.model;
@@ -1187,6 +1188,7 @@ export class CodexAppServerAdapter implements AgentAdapter {
     const params: Record<string, unknown> = {
       threadId,
       persistExtendedHistory: false,
+      approvalPolicy: "never",
     };
     if (this.workingDirectory) params.cwd = this.workingDirectory;
     if (this.model) params.model = this.model;

--- a/server/codex/appServer/rpcClient.ts
+++ b/server/codex/appServer/rpcClient.ts
@@ -260,13 +260,13 @@ export class CodexAppServerClient {
       return;
     }
     const obj = parsed as Record<string, unknown>;
-    if ("id" in obj && (typeof obj.id === "number" || typeof obj.id === "string")) {
-      // Response (success or error). Server-initiated requests will also have
-      // an `id` plus a `method`; we currently treat those as notifications.
-      if ("method" in obj && typeof obj.method === "string") {
-        this.dispatchNotification(obj.method, obj.params);
-        return;
-      }
+    const hasRequestId =
+      "id" in obj && (typeof obj.id === "number" || typeof obj.id === "string");
+    if (hasRequestId && typeof obj.method === "string") {
+      this.rejectServerRequest(obj.id as number | string, obj.method);
+      return;
+    }
+    if (hasRequestId) {
       this.dispatchResponse(obj as unknown as JsonRpcSuccessResponse | JsonRpcErrorResponse);
       return;
     }
@@ -275,6 +275,28 @@ export class CodexAppServerClient {
       return;
     }
     logger.debug(`unrouted JSON-RPC payload: ${line.slice(0, 200)}`);
+  }
+
+  private rejectServerRequest(id: number | string, method: string): void {
+    if (!this.handle || this.closed) {
+      logger.debug(`cannot reject server request after client close: ${method}`);
+      return;
+    }
+    const response: JsonRpcErrorResponse = {
+      jsonrpc: "2.0",
+      id,
+      error: {
+        code: -32601,
+        message: `Unsupported server request: ${method}`,
+      },
+    };
+    try {
+      this.handle.stdin.write(`${JSON.stringify(response)}\n`);
+    } catch (err) {
+      logger.debug(
+        `failed to reject server request ${method}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   private dispatchResponse(payload: JsonRpcSuccessResponse | JsonRpcErrorResponse): void {

--- a/templates/planner-instructions.md
+++ b/templates/planner-instructions.md
@@ -20,3 +20,12 @@ GitHub 是项目问题和交付记录的唯一事实来源。对通常的 bugfix
 ### 读取与安全
 
 整个项目对你可读，应该主动阅读相关代码、配置和 GitHub 上的协作记录。先核对事实，再形成简洁、可审阅的结论。需要改代码时，把实现交给 Worker；不要在 Advisor 轮次中直接修改代码。
+
+### Shell Command Safety
+
+When running commands or invoking GitHub CLI during Advisor turns:
+
+- Never interpolate Markdown or backticks into double-quoted `bash -lc` strings. Shell expansion interprets backticks as command substitutions, executing arbitrary text and causing commands to hang or deadlock.
+- Use `gh issue/pr --body-file`, stdin, or argv/process APIs instead of inlining Markdown bodies into command strings.
+- Create body files safely and clean them only after the producer command has completed.
+- Preserve shell metacharacters literally; ensure backticks, quotes, and dollar signs in descriptions are not evaluated by the shell.

--- a/tests/codex/appServer/codexAppServerAdapter.test.ts
+++ b/tests/codex/appServer/codexAppServerAdapter.test.ts
@@ -166,6 +166,7 @@ describe("CodexAppServerAdapter", () => {
     // Verify request shape sent to the daemon.
     const threadStartRequest = fake.requests.find((r) => r.method === "thread/start");
     assert(threadStartRequest, "expected thread/start request");
+    assert.equal((threadStartRequest.params as any).approvalPolicy, "never");
     const turnStartRequest = fake.requests.find((r) => r.method === "turn/start");
     assert(turnStartRequest, "expected turn/start request");
     assert.equal((turnStartRequest!.params as any).threadId, "thread-1");
@@ -368,6 +369,9 @@ describe("CodexAppServerAdapter", () => {
     assert.equal(adapter.getThreadId(), "thread-persisted-abc");
     assert.equal(resumeCalls, 1);
     assert.equal(fake.requests.filter((request) => request.method === "thread/start").length, 0);
+    const resumeRequest = fake.requests.find((request) => request.method === "thread/resume");
+    assert(resumeRequest, "expected thread/resume request");
+    assert.equal((resumeRequest.params as any).approvalPolicy, "never");
     assert.equal(
       (fake.requests.find((request) => request.method === "turn/start")?.params as any)?.threadId,
       "thread-persisted-abc",

--- a/tests/codex/appServer/rpcClient.test.ts
+++ b/tests/codex/appServer/rpcClient.test.ts
@@ -186,4 +186,55 @@ describe("CodexAppServerClient", () => {
     assert.equal(closed, true);
     await client.close();
   });
+
+  it("rejects server-initiated requests with error response without notifying", async () => {
+    const { client, stdin, stdout } = await buildStartedClient();
+
+    const notifications: Array<{ method: string; params: unknown }> = [];
+    client.onNotification("item/commandExecution/requestApproval", (params, method) => {
+      notifications.push({ method, params });
+    });
+    client.onNotification("*", (params, method) => {
+      notifications.push({ method, params });
+    });
+
+    const requestId = "srv-approval-1";
+    const startMs = Date.now();
+    let lineDetach: (() => void) | null = null;
+    const responsePromise = new Promise<JsonRpcLine>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("timed out waiting for rejection response")),
+        1000,
+      );
+      lineDetach = readLines(stdin, (msg) => {
+        if (msg.id === requestId) {
+          clearTimeout(timer);
+          resolve(msg);
+        }
+      });
+    });
+
+    send(stdout, {
+      jsonrpc: "2.0",
+      id: requestId,
+      method: "item/commandExecution/requestApproval",
+      params: { itemId: "item-1", command: "echo test" },
+    });
+
+    const response = await responsePromise;
+    const elapsedMs = Date.now() - startMs;
+    lineDetach?.();
+
+    assert(elapsedMs < 1000, `response should be fast (<1000ms), took ${elapsedMs}ms`);
+    assert.equal(response.jsonrpc, "2.0");
+    assert.equal(response.id, requestId);
+    assert.equal(response.error?.code, -32601);
+    assert.match(response.error?.message ?? "", /Unsupported server request/);
+    assert.equal(response.result, undefined);
+
+    await new Promise((r) => setTimeout(r, 20));
+    assert.equal(notifications.length, 0, "server request should not be dispatched to notification handlers");
+
+    await client.close();
+  });
 });

--- a/tests/systemPrompt/plannerInstructions.test.ts
+++ b/tests/systemPrompt/plannerInstructions.test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { SystemPromptManager } from "../../server/systemPrompt/manager.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..", "..");
+const templatePath = path.join(repoRoot, "templates", "planner-instructions.md");
+
+describe("systemPrompt/planner instructions safety", () => {
+  it("includes shell safety guidance for markdown and command execution", () => {
+    assert.ok(fs.existsSync(templatePath), "templates/planner-instructions.md must exist");
+    const content = fs.readFileSync(templatePath, "utf8");
+
+    assert.match(
+      content,
+      /never interpolate markdown/i,
+      "instructions must warn against interpolating markdown into bash strings",
+    );
+    assert.match(
+      content,
+      /backticks/i,
+      "instructions must explicitly mention backticks",
+    );
+    assert.match(
+      content,
+      /bash -lc/i,
+      "instructions must reference bash -lc strings",
+    );
+    assert.match(
+      content,
+      /gh issue\/pr --body-file/i,
+      "instructions must recommend --body-file",
+    );
+    assert.match(
+      content,
+      /stdin|argv|process/i,
+      "instructions must mention stdin or argv/process APIs",
+    );
+    assert.match(
+      content,
+      /clean.*only after.*completed/i,
+      "instructions must instruct cleaning body files only after producer command completion",
+    );
+    assert.match(
+      content,
+      /preserve shell metacharacters literally/i,
+      "instructions must instruct preserving shell metacharacters literally",
+    );
+  });
+
+  it("injects planner safety instructions into prompt via SystemPromptManager", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ads-planner-test-"));
+    try {
+      const manager = new SystemPromptManager({
+        workspaceRoot: tmpDir,
+        templateRoot: path.join(repoRoot, "templates"),
+        laneInstructionsFile: "planner-instructions.md",
+      });
+
+      const injection = manager.maybeInject();
+      assert.ok(injection, "injection must be generated");
+      assert.match(injection.text, /never interpolate markdown/i);
+      assert.match(injection.text, /--body-file/i);
+      assert.match(injection.text, /preserve shell metacharacters literally/i);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #161\n\nFixes Advisor command hangs caused by shell command substitution and unhandled app-server server requests. Explicitly sets approvalPolicy to never for thread start/resume, rejects unsupported server requests promptly, and adds regression coverage.