### PR TITLE
feat(middleware): integrate cf-mem client

### DIFF
--- a/server/agents/turn.ts
+++ b/server/agents/turn.ts
@@ -20,6 +20,14 @@ export interface AgentTurnResult extends AgentRunResult {
   explored?: ExploredEntry[];
 }
 
+function extractInputText(input: Input): string {
+  if (typeof input === "string") return input;
+  return input
+    .filter((part): part is { type: "text"; text: string } => part.type === "text")
+    .map((part) => part.text)
+    .join("\n");
+}
+
 export async function runAgentTurn(
   orchestrator: HybridOrchestrator,
   input: Input,
@@ -40,21 +48,30 @@ export async function runAgentTurn(
 
   const activeAgentId = orchestrator.getActiveAgentId();
   const workspaceRoot = options.workspaceRoot ?? detectWorkspaceFrom(options.cwd ?? process.cwd());
+  const inputText = extractInputText(input);
   const middlewareContext: TurnContext | undefined = options.middleware
     ? {
         turnId: options.middlewareContext?.turnId ?? options.historySessionId ?? "agent-turn",
         sessionId: options.middlewareContext?.sessionId ?? options.historySessionId ?? "agent-session",
         workspaceRoot: options.middlewareContext?.workspaceRoot ?? workspaceRoot,
         channel: options.middlewareContext?.channel ?? "web",
-        prompt: typeof input === "string" ? input : "",
+        prompt: inputText,
+        originalPrompt: options.middlewareContext?.originalPrompt ?? inputText,
         metadata: options.middlewareContext?.metadata,
       }
     : undefined;
   let effectiveInput = input;
   if (options.middleware && middlewareContext) {
     const middlewarePrompt = await options.middleware.executeBeforeInput(middlewareContext);
-    if (typeof input === "string") effectiveInput = middlewarePrompt;
-    middlewareContext.prompt = typeof effectiveInput === "string" ? effectiveInput : middlewareContext.prompt;
+    if (typeof input === "string") {
+      effectiveInput = middlewarePrompt;
+    } else if (middlewarePrompt !== inputText) {
+      effectiveInput = [
+        { type: "text", text: middlewarePrompt },
+        ...input.filter((part) => part.type !== "text"),
+      ];
+    }
+    middlewareContext.prompt = middlewarePrompt;
     await options.middleware.executeTurnStart(middlewareContext);
   }
   const sendOptions: AgentSendOptions = {
@@ -72,12 +89,12 @@ export async function runAgentTurn(
       sessionId: options.historySessionId,
     });
     const cleanedResponse = stripToolDirectives(result.response);
+    if (options.middleware && middlewareContext) {
+      await options.middleware.executeAfterOutput(middlewareContext, cleanedResponse);
+    }
     let response = cleanedResponse;
     if (toolResults.length > 0) {
       response = [cleanedResponse, "", ...toolResults].join("\n").trim();
-    }
-    if (options.middleware && middlewareContext) {
-      await options.middleware.executeAfterOutput(middlewareContext, response);
     }
 
     const explored = exploredTracker

--- a/server/middleware/builtin/cfMemClient.ts
+++ b/server/middleware/builtin/cfMemClient.ts
@@ -1,0 +1,242 @@
+import { createHash } from "node:crypto";
+
+import type { TurnContext } from "../types.js";
+import { createLogger } from "../../utils/logger.js";
+import { resolveCfMemScope, type CfMemScope } from "./cfMemScope.js";
+
+const logger = createLogger("CfMem");
+
+const DEFAULT_RECALL_LIMIT = 5;
+const DEFAULT_TIMEOUT_MS = 5_000;
+const MAX_RECALL_QUERY_CHARS = 4_000;
+const MAX_RECALLED_MEMORY_CHARS = 4_000;
+const MAX_CLAIM_CHARS = 1_000;
+const MAX_INGEST_TEXT_CHARS = 8_000;
+const MAX_SESSION_ID_CHARS = 256;
+
+export interface CfMemClientOptions {
+  apiBase: string;
+  apiKey: string;
+  recallTopK?: number;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+export interface CfMemClient {
+  recall(ctx: TurnContext): Promise<string | null>;
+  ingest(ctx: TurnContext, assistantReply: string): Promise<void>;
+}
+
+export function normalizeCfMemUrl(value: string): string | null {
+  const raw = value.trim();
+  if (!raw) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  if (parsed.username || parsed.password || parsed.search || parsed.hash) return null;
+
+  const pathname = parsed.pathname.replace(/\/+$/, "");
+  parsed.pathname = !pathname || pathname === "/"
+    ? "/memory"
+    : pathname.endsWith("/memory")
+      ? pathname
+      : `${pathname}/memory`;
+  return parsed.toString().replace(/\/$/, "");
+}
+
+function boundedText(value: unknown, maxLength: number): string {
+  if (typeof value !== "string") return "";
+  let sanitized = "";
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if ((code < 32 && code !== 9 && code !== 10) || code === 127) {
+      sanitized += " ";
+    } else if (code !== 13) {
+      sanitized += character;
+    }
+  }
+  return sanitized.trim().slice(0, maxLength);
+}
+
+function stripRecalledMemory(value: string): string {
+  return value.replace(/<recalled_memory(?:\s[^>]*)?>[\s\S]*?<\/recalled_memory>\s*/gi, "").trim();
+}
+
+function resolveOriginalPrompt(ctx: TurnContext): string {
+  return boundedText(
+    stripRecalledMemory(ctx.originalPrompt ?? ctx.prompt),
+    MAX_RECALL_QUERY_CHARS,
+  );
+}
+
+function resolveServerUserId(ctx: TurnContext): string | null {
+  const value = ctx.metadata?.authUserId;
+  const userId = boundedText(value, 256);
+  return userId || null;
+}
+
+function resolveSessionId(ctx: TurnContext): string | null {
+  const sessionId = boundedText(ctx.sessionId, MAX_SESSION_ID_CHARS);
+  return sessionId || null;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  if (!Number.isFinite(value)) return DEFAULT_RECALL_LIMIT;
+  return Math.max(1, Math.min(20, Math.floor(value ?? DEFAULT_RECALL_LIMIT)));
+}
+
+function normalizeTimeout(value: number | undefined): number {
+  if (!Number.isFinite(value)) return DEFAULT_TIMEOUT_MS;
+  return Math.max(100, Math.min(30_000, Math.floor(value ?? DEFAULT_TIMEOUT_MS)));
+}
+
+function extractClaimText(value: unknown): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const claim = value as Record<string, unknown>;
+  const candidates = [claim.canonical_text, claim.text, claim.value];
+  for (const candidate of candidates) {
+    const text = boundedText(candidate, MAX_CLAIM_CHARS);
+    if (text) return stripRecalledMemory(text);
+  }
+  return null;
+}
+
+function formatRecalledMemory(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+  const claims = (payload as Record<string, unknown>).claims;
+  if (!Array.isArray(claims)) return null;
+
+  const lines: string[] = [];
+  let totalLength = 0;
+  for (const claim of claims) {
+    const text = extractClaimText(claim);
+    if (!text) continue;
+    const remaining = MAX_RECALLED_MEMORY_CHARS - totalLength;
+    if (remaining <= 0) break;
+    const bounded = text.slice(0, remaining);
+    lines.push(`- ${bounded}`);
+    totalLength += bounded.length + 3;
+  }
+  return lines.length > 0 ? lines.join("\n").slice(0, MAX_RECALLED_MEMORY_CHARS) : null;
+}
+
+function stripInternalOutput(value: string): string {
+  const cleaned = value
+    .replace(/<recalled_memory(?:\s[^>]*)?>[\s\S]*?<\/recalled_memory>\s*/gi, "")
+    .replace(/<<<tool\.[a-z0-9_.-]+[^>]*>>>[\s\S]*?>>>/gi, "")
+    .replace(/<(?:analysis|reasoning|thinking|thought|plan|patch|command|tool_trace)(?:\s[^>]*)?>[\s\S]*?<\/(?:analysis|reasoning|thinking|thought|plan|patch|command|tool_trace)>/gi, "")
+    .trim();
+  return boundedText(cleaned, MAX_INGEST_TEXT_CHARS);
+}
+
+function createEventId(turnId: string, role: "user" | "assistant"): string {
+  return `ads-${createHash("sha256").update(`${turnId}\n${role}`).digest("hex").slice(0, 32)}`;
+}
+
+function resolveScope(ctx: TurnContext): { scope: CfMemScope; userId: string; sessionId: string } | null {
+  const scope = resolveCfMemScope(ctx.workspaceRoot);
+  const userId = resolveServerUserId(ctx);
+  const sessionId = resolveSessionId(ctx);
+  if (!scope || !userId || !sessionId) return null;
+  return { scope, userId, sessionId };
+}
+
+export function createCfMemClient(options: CfMemClientOptions): CfMemClient {
+  const apiBase = normalizeCfMemUrl(options.apiBase);
+  if (!apiBase) throw new Error("CFMEM_URL is invalid");
+  const apiKey = options.apiKey.trim();
+  if (!apiKey) throw new Error("CFMEM_API_KEY is required");
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const recallTopK = normalizeLimit(options.recallTopK);
+  const timeoutMs = normalizeTimeout(options.timeoutMs);
+
+  async function post(
+    pathname: string,
+    body: Record<string, unknown>,
+    projectId: string,
+    operation: string,
+  ): Promise<unknown | null> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    let timedOut = false;
+    const timeoutHandler = () => {
+      timedOut = true;
+    };
+    controller.signal.addEventListener("abort", timeoutHandler, { once: true });
+    try {
+      const response = await fetchImpl(`${apiBase}${pathname}`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+          "X-Project-Id": projectId,
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        logger.warn(`[CfMem] ${operation} failed status=${response.status}`);
+        return null;
+      }
+      try {
+        return await response.json() as unknown;
+      } catch {
+        logger.warn(`[CfMem] ${operation} failed reason=malformed_response`);
+        return null;
+      }
+    } catch {
+      logger.warn(`[CfMem] ${operation} failed reason=${timedOut ? "timeout" : "network"}`);
+      return null;
+    } finally {
+      clearTimeout(timeout);
+      controller.signal.removeEventListener("abort", timeoutHandler);
+    }
+  }
+
+  return {
+    async recall(ctx: TurnContext): Promise<string | null> {
+      const resolved = resolveScope(ctx);
+      const query = resolveOriginalPrompt(ctx);
+      if (!resolved || !query) return null;
+
+      const response = await post("/context", {
+        user_id: resolved.userId,
+        session_id: resolved.sessionId,
+        query,
+        categories: ["rule", "user_profile", "domain_fact"],
+        workspace_id: resolved.scope.workspaceId,
+        limit: recallTopK,
+      }, resolved.scope.projectId, "recall");
+      return formatRecalledMemory(response);
+    },
+
+    async ingest(ctx: TurnContext, assistantReply: string): Promise<void> {
+      const resolved = resolveScope(ctx);
+      if (!resolved) return;
+
+      const entries: Array<{ role: "user" | "assistant"; text: string }> = [
+        { role: "user", text: resolveOriginalPrompt(ctx) },
+        { role: "assistant", text: stripInternalOutput(assistantReply) },
+      ];
+      for (const entry of entries) {
+        if (!entry.text) continue;
+        await post("/profile/ingest", {
+          text: entry.text,
+          role: entry.role,
+          source_app: "codex",
+          external_session_id: resolved.sessionId,
+          workspace_id: resolved.scope.workspaceId,
+          workspace_name: resolved.scope.workspaceName,
+          event_id: createEventId(ctx.turnId, entry.role),
+        }, resolved.scope.projectId, "ingest");
+      }
+    },
+  };
+}

--- a/server/middleware/builtin/cfMemScope.ts
+++ b/server/middleware/builtin/cfMemScope.ts
@@ -1,0 +1,149 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+export interface CfMemScope {
+  projectId: string;
+  workspaceId: string;
+  workspaceName: string;
+  repositoryRoot: string;
+}
+
+// Project id must start with an ASCII alphanumeric character and be followed by up to 31 ASCII alphanumeric/._:- characters (1-32 chars total).
+const PROJECT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,31}$/;
+
+function resolveWorktreeRepositoryRoot(realWorkspaceRoot: string, gitFilePath: string): string | null {
+  let gitContent: string;
+  try {
+    gitContent = fs.readFileSync(gitFilePath, "utf-8");
+  } catch {
+    return null;
+  }
+
+  const gitdirMatch = gitContent.match(/^gitdir:\s*(.+)$/m);
+  if (!gitdirMatch) {
+    return null;
+  }
+
+  const rawGitDir = gitdirMatch[1].trim();
+  if (!rawGitDir) {
+    return null;
+  }
+
+  const worktreeGitDir = path.resolve(realWorkspaceRoot, rawGitDir);
+  try {
+    const worktreeGitDirStat = fs.statSync(worktreeGitDir);
+    if (!worktreeGitDirStat.isDirectory()) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  // Use the worktree commondir when present.
+  let commonGitDir: string;
+  const commondirFilePath = path.join(worktreeGitDir, "commondir");
+  try {
+    if (!fs.statSync(commondirFilePath).isFile()) return null;
+    const rawCommonDir = fs.readFileSync(commondirFilePath, "utf-8").trim();
+    if (!rawCommonDir) return null;
+    commonGitDir = path.resolve(worktreeGitDir, rawCommonDir);
+  } catch {
+    return null;
+  }
+
+  let realCommonGitDir: string;
+  try {
+    realCommonGitDir = fs.realpathSync(commonGitDir);
+    const commonStat = fs.statSync(realCommonGitDir);
+    if (!commonStat.isDirectory()) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  let candidateRoot: string;
+  if (path.basename(realCommonGitDir) === ".git") {
+    candidateRoot = path.dirname(realCommonGitDir);
+  } else if (fs.existsSync(path.join(realCommonGitDir, ".git"))) {
+    candidateRoot = realCommonGitDir;
+  } else {
+    return null;
+  }
+
+  try {
+    const realRoot = fs.realpathSync(candidateRoot);
+    const rootStat = fs.statSync(realRoot);
+    if (!rootStat.isDirectory()) {
+      return null;
+    }
+    return realRoot;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveCfMemScope(workspaceRoot: string): CfMemScope | null {
+  if (typeof workspaceRoot !== "string") {
+    return null;
+  }
+
+  const trimmedRoot = workspaceRoot.trim();
+  if (!trimmedRoot) {
+    return null;
+  }
+
+  let realWorkspaceRoot: string;
+  try {
+    realWorkspaceRoot = fs.realpathSync(trimmedRoot);
+    const rootStat = fs.statSync(realWorkspaceRoot);
+    if (!rootStat.isDirectory()) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  const gitMarkerPath = path.join(realWorkspaceRoot, ".git");
+  let gitMarkerStat: fs.Stats;
+  try {
+    gitMarkerStat = fs.statSync(gitMarkerPath);
+  } catch {
+    // Non-git root or unreadable path
+    return null;
+  }
+
+  let repositoryRoot: string | null = null;
+  if (gitMarkerStat.isDirectory()) {
+    // Normal git repository with a .git directory
+    repositoryRoot = realWorkspaceRoot;
+  } else if (gitMarkerStat.isFile()) {
+    // Git worktree whose .git is a file containing gitdir:
+    repositoryRoot = resolveWorktreeRepositoryRoot(realWorkspaceRoot, gitMarkerPath);
+  }
+
+  if (!repositoryRoot) {
+    return null;
+  }
+
+  const projectId = path.basename(repositoryRoot);
+  if (!projectId || !PROJECT_ID_PATTERN.test(projectId) || projectId.toLowerCase() === "personal") {
+    return null;
+  }
+
+  const workspaceName = path.basename(realWorkspaceRoot);
+  if (!workspaceName) {
+    return null;
+  }
+
+  const hash = crypto.createHash("sha256").update(realWorkspaceRoot).digest("hex").slice(0, 16);
+  const workspaceId = "ws_" + projectId + "_" + hash;
+
+  return {
+    projectId,
+    workspaceId,
+    workspaceName,
+    repositoryRoot,
+  };
+}

--- a/server/middleware/index.ts
+++ b/server/middleware/index.ts
@@ -3,16 +3,63 @@ export * from "./pipeline.js";
 export * from "./builtin/globalRulesMiddleware.js";
 export * from "./builtin/contextArtifactMiddleware.js";
 export * from "./builtin/cfMemMiddleware.js";
+export * from "./builtin/cfMemClient.js";
+export * from "./builtin/cfMemScope.js";
 
 import { createMiddlewarePipeline, type MiddlewarePipeline } from "./pipeline.js";
 import { createGlobalRulesMiddleware } from "./builtin/globalRulesMiddleware.js";
 import { createContextArtifactMiddleware } from "./builtin/contextArtifactMiddleware.js";
 import { createCfMemMiddleware, type CfMemMiddlewareOptions } from "./builtin/cfMemMiddleware.js";
+import { createCfMemClient } from "./builtin/cfMemClient.js";
+import { createLogger } from "../utils/logger.js";
+
+const logger = createLogger("Middleware");
+let partialConfigWarningLogged = false;
+let invalidConfigWarningLogged = false;
 
 export interface CoreMiddlewarePipelineOptions {
   cfMemOptions?: CfMemMiddlewareOptions;
   includeGlobalRules?: boolean;
   includeContextArtifact?: boolean;
+}
+
+function parsePositiveEnvironmentNumber(name: string): number | undefined {
+  const raw = process.env[name]?.trim();
+  if (!raw) return undefined;
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function createEnvironmentCfMemOptions(): CfMemMiddlewareOptions | undefined {
+  const apiBase = process.env.CFMEM_URL?.trim();
+  const apiKey = process.env.CFMEM_API_KEY?.trim();
+  if (!apiBase && !apiKey) return undefined;
+  if (!apiBase || !apiKey) {
+    if (!partialConfigWarningLogged) {
+      logger.warn("[CfMem] disabled reason=partial_configuration");
+      partialConfigWarningLogged = true;
+    }
+    return undefined;
+  }
+
+  try {
+    const client = createCfMemClient({
+      apiBase,
+      apiKey,
+      recallTopK: parsePositiveEnvironmentNumber("CFMEM_RECALL_TOP_K"),
+      timeoutMs: parsePositiveEnvironmentNumber("CFMEM_TIMEOUT_MS"),
+    });
+    return {
+      fetchSemanticContext: (ctx) => client.recall(ctx),
+      ingestConversationTurn: (ctx, assistantReply) => client.ingest(ctx, assistantReply),
+    };
+  } catch {
+    if (!invalidConfigWarningLogged) {
+      logger.warn("[CfMem] disabled reason=invalid_configuration");
+      invalidConfigWarningLogged = true;
+    }
+    return undefined;
+  }
 }
 
 export function createCoreMiddlewarePipeline(
@@ -25,8 +72,9 @@ export function createCoreMiddlewarePipeline(
   if (options.includeContextArtifact !== false) {
     pipeline.use(createContextArtifactMiddleware());
   }
-  if (options.cfMemOptions) {
-    pipeline.use(createCfMemMiddleware(options.cfMemOptions));
+  const cfMemOptions = options.cfMemOptions ?? createEnvironmentCfMemOptions();
+  if (cfMemOptions) {
+    pipeline.use(createCfMemMiddleware(cfMemOptions));
   }
   return pipeline;
 }

--- a/server/middleware/types.ts
+++ b/server/middleware/types.ts
@@ -8,6 +8,8 @@ export interface TurnContext {
   workspaceRoot: string;
   channel: MiddlewareChannel;
   prompt: string;
+  /** Original user-authored prompt before middleware enrichment. */
+  originalPrompt?: string;
   metadata?: Record<string, unknown>;
 }
 

--- a/server/web/server/ws/handlePrompt.ts
+++ b/server/web/server/ws/handlePrompt.ts
@@ -156,10 +156,26 @@ export async function handlePromptMessage(deps: WsPromptHandlerDeps): Promise<{
       typeof rawPayload === "object" && rawPayload !== null && "channel" in rawPayload && typeof (rawPayload as { channel?: unknown }).channel === "string"
         ? (rawPayload as { channel: MiddlewareChannel }).channel
         : "web";
-    const turnMetadata =
+    const clientTurnMetadata =
       typeof rawPayload === "object" && rawPayload !== null && "metadata" in rawPayload && typeof (rawPayload as { metadata?: unknown }).metadata === "object"
-        ? ((rawPayload as { metadata?: Record<string, unknown> }).metadata ?? undefined)
-        : undefined;
+        && !Array.isArray((rawPayload as { metadata?: unknown }).metadata)
+        ? ((rawPayload as { metadata?: Record<string, unknown> }).metadata ?? {})
+        : {};
+    const turnMetadata: Record<string, unknown> = {
+      ...clientTurnMetadata,
+      // These reserved fields are owned by the authenticated WebSocket context.
+      // Client metadata may add channel-specific values but cannot replace them.
+      authUserId: deps.context.authUserId,
+      userId: deps.context.authUserId,
+      sessionId: deps.context.sessionId,
+      chatSessionId: deps.context.chatSessionId,
+    };
+    const originalTurnPrompt = typeof inputToSend === "string"
+      ? inputToSend
+      : inputToSend
+        .filter((part): part is { type: "text"; text: string } => part.type === "text")
+        .map((part) => part.text)
+        .join("\n");
 
     const { unsubscribe, handleExploredEntry } = attachWorkerPromptHandler({
       orchestrator,
@@ -259,6 +275,7 @@ export async function handlePromptMessage(deps: WsPromptHandlerDeps): Promise<{
           turnId: deps.request.clientMessageId ?? `turn-${Date.now()}`,
           sessionId: deps.context.historyKey,
           channel: turnChannel,
+          originalPrompt: originalTurnPrompt,
           metadata: turnMetadata,
         },
       });

--- a/tests/middleware/cfMemClient.test.ts
+++ b/tests/middleware/cfMemClient.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  createCfMemClient,
+  normalizeCfMemUrl,
+} from "../../server/middleware/builtin/cfMemClient.js";
+import { createCoreMiddlewarePipeline } from "../../server/middleware/index.js";
+import type { TurnContext } from "../../server/middleware/types.js";
+
+async function withGitWorkspace<T>(fn: (workspaceRoot: string) => T | Promise<T>): Promise<T> {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ads-cfmem-client-test-"));
+  const workspaceRoot = path.join(root, "ads");
+  fs.mkdirSync(path.join(workspaceRoot, ".git"), { recursive: true });
+  try {
+    return await fn(workspaceRoot);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function createContext(workspaceRoot: string): TurnContext {
+  return {
+    turnId: "turn-1",
+    sessionId: "session-1",
+    workspaceRoot,
+    channel: "web",
+    prompt: "<recalled_memory>synthetic context</recalled_memory>\n\noriginal prompt",
+    originalPrompt: "original prompt",
+    metadata: {
+      authUserId: "server-user",
+      userId: "client-user",
+    },
+  };
+}
+
+describe("cf-mem client", () => {
+  it("normalizes memory API URLs without duplicating the memory path", () => {
+    assert.equal(normalizeCfMemUrl("https://memory.example.test"), "https://memory.example.test/memory");
+    assert.equal(normalizeCfMemUrl("https://memory.example.test/memory/"), "https://memory.example.test/memory");
+    assert.equal(normalizeCfMemUrl("https://memory.example.test/api/memory"), "https://memory.example.test/api/memory");
+    assert.equal(normalizeCfMemUrl("not a URL"), null);
+    assert.equal(normalizeCfMemUrl("https://user:secret@memory.example.test"), null);
+  });
+
+  it("sends bounded recall requests with server identity and project scope", async () => {
+    await withGitWorkspace(async (workspaceRoot) => {
+      const requests: Array<{ url: string; init: RequestInit }> = [];
+      const client = createCfMemClient({
+        apiBase: "https://memory.example.test/memory/",
+        apiKey: "test-secret",
+        fetchImpl: async (url, init) => {
+          requests.push({ url: String(url), init });
+          return new Response(JSON.stringify({
+            claims: [
+              { canonical_text: "Use the repository's stable migration pattern.", secret: "must not be copied" },
+              { value: { raw: "object data" } },
+            ],
+          }), { status: 200, headers: { "content-type": "application/json" } });
+        },
+      });
+
+      const recalled = await client.recall(createContext(workspaceRoot));
+      assert.equal(recalled, "- Use the repository's stable migration pattern.");
+      assert.equal(requests.length, 1);
+      assert.equal(requests[0]?.url, "https://memory.example.test/memory/context");
+      assert.equal(requests[0]?.init.headers && new Headers(requests[0].init.headers).get("Authorization"), "Bearer test-secret");
+      assert.equal(requests[0]?.init.headers && new Headers(requests[0].init.headers).get("X-Project-Id"), "ads");
+
+      const body = JSON.parse(String(requests[0]?.init.body)) as Record<string, unknown>;
+      assert.equal(body.user_id, "server-user");
+      assert.equal(body.query, "original prompt");
+      assert.equal(body.workspace_id && String(body.workspace_id).startsWith("ws_ads_"), true);
+      assert.equal(body.limit, 5);
+      assert.equal(JSON.stringify(body).includes("client-user"), false);
+    });
+  });
+
+  it("ingests only the original prompt and cleaned final response with deterministic event ids", async () => {
+    await withGitWorkspace(async (workspaceRoot) => {
+      const requests: Array<{ init: RequestInit }> = [];
+      const client = createCfMemClient({
+        apiBase: "https://memory.example.test/memory",
+        apiKey: "test-secret",
+        fetchImpl: async (_url, init) => {
+          requests.push({ init });
+          return new Response(JSON.stringify({ ok: true }), { status: 202 });
+        },
+      });
+      const ctx = createContext(workspaceRoot);
+
+      await client.ingest(ctx, "<recalled_memory source=\"cf-mem\">do not store</recalled_memory><thought id=\"hidden\">private reasoning</thought>Final answer\n<<<tool.memory.update>>>secret trace>>>");
+      const firstBodies = requests.map((request) => JSON.parse(String(request.init.body)) as Record<string, unknown>);
+      assert.deepEqual(firstBodies.map((body) => body.role), ["user", "assistant"]);
+      assert.equal(firstBodies[0]?.text, "original prompt");
+      assert.equal(firstBodies[1]?.text, "Final answer");
+      assert.equal(firstBodies[0]?.source_app, "codex");
+      assert.equal(firstBodies[0]?.external_session_id, "session-1");
+      assert.equal(firstBodies[0]?.workspace_name, "ads");
+      assert.equal(new Headers(requests[0]?.init.headers).get("X-Project-Id"), "ads");
+
+      await client.ingest(ctx, "Final answer");
+      const secondBodies = requests.slice(2).map((request) => JSON.parse(String(request.init.body)) as Record<string, unknown>);
+      assert.equal(firstBodies[0]?.event_id, secondBodies[0]?.event_id);
+      assert.equal(firstBodies[1]?.event_id, secondBodies[1]?.event_id);
+      assert.notEqual(firstBodies[0]?.event_id, firstBodies[1]?.event_id);
+    });
+  });
+
+  it("fails open for HTTP failures and missing server scope", async () => {
+    await withGitWorkspace(async (workspaceRoot) => {
+      const client = createCfMemClient({
+        apiBase: "https://memory.example.test",
+        apiKey: "test-secret",
+        fetchImpl: async () => new Response("unavailable", { status: 503 }),
+      });
+      assert.equal(await client.recall(createContext(workspaceRoot)), null);
+
+      const noIdentity = createContext(workspaceRoot);
+      noIdentity.metadata = { userId: "client-only" };
+      assert.equal(await client.recall(noIdentity), null);
+    });
+  });
+
+  it("automatically enables cf-mem only when both environment values are present", () => {
+    const savedUrl = process.env.CFMEM_URL;
+    const savedKey = process.env.CFMEM_API_KEY;
+    try {
+      process.env.CFMEM_URL = "https://memory.example.test";
+      process.env.CFMEM_API_KEY = "test-secret";
+      const enabled = createCoreMiddlewarePipeline({ includeGlobalRules: false, includeContextArtifact: false });
+      assert.deepEqual(enabled.getMiddlewares().map((middleware) => middleware.name), ["cfMem"]);
+
+      delete process.env.CFMEM_API_KEY;
+      const partial = createCoreMiddlewarePipeline({ includeGlobalRules: false, includeContextArtifact: false });
+      assert.deepEqual(partial.getMiddlewares().map((middleware) => middleware.name), []);
+    } finally {
+      if (savedUrl === undefined) delete process.env.CFMEM_URL;
+      else process.env.CFMEM_URL = savedUrl;
+      if (savedKey === undefined) delete process.env.CFMEM_API_KEY;
+      else process.env.CFMEM_API_KEY = savedKey;
+    }
+  });
+});

--- a/tests/middleware/cfMemScope.test.ts
+++ b/tests/middleware/cfMemScope.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { resolveCfMemScope } from "../../server/middleware/builtin/cfMemScope.js";
+
+function withTempDir<T>(fn: (tempDir: string) => T): T {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ads-cfmem-scope-test-"));
+  const realTempDir = fs.realpathSync(tempDir);
+  try {
+    return fn(realTempDir);
+  } finally {
+    try {
+      fs.rmSync(realTempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors in temporary test directories
+    }
+  }
+}
+
+describe("resolveCfMemScope", () => {
+  it("resolves scope for a normal git repository with a .git directory", () => {
+    withTempDir((tempDir) => {
+      const repoDir = path.join(tempDir, "sample-repo");
+      fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+
+      const scope = resolveCfMemScope(repoDir);
+      assert.ok(scope !== null);
+      assert.equal(scope.projectId, "sample-repo");
+      assert.equal(scope.workspaceName, "sample-repo");
+      assert.equal(scope.repositoryRoot, repoDir);
+
+      const expectedHash = crypto.createHash("sha256").update(repoDir).digest("hex").slice(0, 16);
+      assert.equal(scope.workspaceId, `ws_sample-repo_${expectedHash}`);
+      assert.ok(!scope.workspaceId.includes("/"));
+      assert.ok(!scope.workspaceId.includes("\\"));
+      assert.ok(!scope.workspaceId.includes(repoDir));
+    });
+  });
+
+  it("resolves scope for a git worktree with .git file and relative commondir", () => {
+    withTempDir((tempDir) => {
+      const mainRepoDir = path.join(tempDir, "main-app");
+      const worktreeAdminDir = path.join(mainRepoDir, ".git", "worktrees", "issue-42");
+      fs.mkdirSync(worktreeAdminDir, { recursive: true });
+      fs.writeFileSync(path.join(worktreeAdminDir, "commondir"), "../..\n", "utf-8");
+
+      const worktreeDir = path.join(tempDir, "worktrees", "issue-42");
+      fs.mkdirSync(worktreeDir, { recursive: true });
+      fs.writeFileSync(path.join(worktreeDir, ".git"), `gitdir: ${worktreeAdminDir}\n`, "utf-8");
+
+      const scope = resolveCfMemScope(worktreeDir);
+      assert.ok(scope !== null);
+      assert.equal(scope.projectId, "main-app");
+      assert.equal(scope.workspaceName, "issue-42");
+      assert.equal(scope.repositoryRoot, mainRepoDir);
+
+      const expectedHash = crypto.createHash("sha256").update(worktreeDir).digest("hex").slice(0, 16);
+      assert.equal(scope.workspaceId, `ws_main-app_${expectedHash}`);
+      assert.ok(!scope.workspaceId.includes("/"));
+      assert.ok(!scope.workspaceId.includes("\\"));
+      assert.ok(!scope.workspaceId.includes(worktreeDir));
+    });
+  });
+
+  it("resolves scope for a git worktree with relative gitdir and absolute commondir", () => {
+    withTempDir((tempDir) => {
+      const mainRepoDir = path.join(tempDir, "my-service");
+      const worktreeAdminDir = path.join(mainRepoDir, ".git", "worktrees", "wt-rel");
+      fs.mkdirSync(worktreeAdminDir, { recursive: true });
+      fs.writeFileSync(path.join(worktreeAdminDir, "commondir"), path.join(mainRepoDir, ".git"), "utf-8");
+
+      const worktreeDir = path.join(tempDir, "wt-rel");
+      fs.mkdirSync(worktreeDir, { recursive: true });
+      const relGitDir = path.relative(worktreeDir, worktreeAdminDir);
+      fs.writeFileSync(path.join(worktreeDir, ".git"), `gitdir: ${relGitDir}\n`, "utf-8");
+
+      const scope = resolveCfMemScope(worktreeDir);
+      assert.ok(scope !== null);
+      assert.equal(scope.projectId, "my-service");
+      assert.equal(scope.workspaceName, "wt-rel");
+      assert.equal(scope.repositoryRoot, mainRepoDir);
+      assert.ok(scope.workspaceId.startsWith("ws_my-service_"));
+    });
+  });
+
+  it("returns null for missing, empty, invalid-type, or non-directory roots", () => {
+    assert.equal(resolveCfMemScope(""), null);
+    assert.equal(resolveCfMemScope("   "), null);
+    assert.equal(resolveCfMemScope("/path/does/not/exist/at/all"), null);
+    assert.equal(resolveCfMemScope(null as unknown as string), null);
+    assert.equal(resolveCfMemScope(undefined as unknown as string), null);
+
+    withTempDir((tempDir) => {
+      const regularFile = path.join(tempDir, "not-a-dir.txt");
+      fs.writeFileSync(regularFile, "content", "utf-8");
+      assert.equal(resolveCfMemScope(regularFile), null);
+    });
+  });
+
+  it("returns null for non-git roots and corrupted .git files", () => {
+    withTempDir((tempDir) => {
+      const nonGitDir = path.join(tempDir, "plain-directory");
+      fs.mkdirSync(nonGitDir);
+      assert.equal(resolveCfMemScope(nonGitDir), null);
+
+      const emptyGitFileDir = path.join(tempDir, "empty-git-file");
+      fs.mkdirSync(emptyGitFileDir);
+      fs.writeFileSync(path.join(emptyGitFileDir, ".git"), "", "utf-8");
+      assert.equal(resolveCfMemScope(emptyGitFileDir), null);
+
+      const badGitFileDir = path.join(tempDir, "bad-git-file");
+      fs.mkdirSync(badGitFileDir);
+      fs.writeFileSync(path.join(badGitFileDir, ".git"), "some random string without gitdir\n", "utf-8");
+      assert.equal(resolveCfMemScope(badGitFileDir), null);
+
+      const nonExistentTargetDir = path.join(tempDir, "missing-target-gitdir");
+      fs.mkdirSync(nonExistentTargetDir);
+      fs.writeFileSync(path.join(nonExistentTargetDir, ".git"), "gitdir: /no/such/path/exists\n", "utf-8");
+      assert.equal(resolveCfMemScope(nonExistentTargetDir), null);
+    });
+  });
+
+  it("rejects invalid repository basenames and the personal project id", () => {
+    withTempDir((tempDir) => {
+      const createRepo = (name: string): string => {
+        const repoPath = path.join(tempDir, name);
+        fs.mkdirSync(path.join(repoPath, ".git"), { recursive: true });
+        return repoPath;
+      };
+
+      // Exact "personal" and case variations must return null
+      assert.equal(resolveCfMemScope(createRepo("personal")), null);
+      assert.equal(resolveCfMemScope(createRepo("Personal")), null);
+      assert.equal(resolveCfMemScope(createRepo("PERSONAL")), null);
+
+      // Invalid starting characters
+      assert.equal(resolveCfMemScope(createRepo("-leading-hyphen")), null);
+      assert.equal(resolveCfMemScope(createRepo("_leading-underscore")), null);
+      assert.equal(resolveCfMemScope(createRepo(".leading-dot")), null);
+
+      // Invalid characters
+      assert.equal(resolveCfMemScope(createRepo("repo with spaces")), null);
+      assert.equal(resolveCfMemScope(createRepo("repo$invalid")), null);
+
+      // Length > 32 characters (33 chars)
+      const tooLongName = "a".repeat(33);
+      assert.equal(resolveCfMemScope(createRepo(tooLongName)), null);
+
+      // Length == 32 characters (valid boundary)
+      const valid32Name = "a".repeat(32);
+      const valid32Scope = resolveCfMemScope(createRepo(valid32Name));
+      assert.ok(valid32Scope !== null);
+      assert.equal(valid32Scope.projectId, valid32Name);
+
+      // Valid special characters in project-id: alphanumeric, ., _, :, -
+      const validSpecialName = "proj.1-test_v2:alpha";
+      const validSpecialScope = resolveCfMemScope(createRepo(validSpecialName));
+      assert.ok(validSpecialScope !== null);
+      assert.equal(validSpecialScope.projectId, validSpecialName);
+
+      // Worktree pointing back to a repo named personal must also return null
+      const personalRepo = createRepo("personal-main");
+      const wtAdmin = path.join(personalRepo, ".git", "worktrees", "wt-child");
+      fs.mkdirSync(wtAdmin, { recursive: true });
+      fs.writeFileSync(path.join(wtAdmin, "commondir"), "../..\n", "utf-8");
+
+      const personalBaseRepo = createRepo("personal");
+      const wtAdminPersonal = path.join(personalBaseRepo, ".git", "worktrees", "wt-child");
+      fs.mkdirSync(wtAdminPersonal, { recursive: true });
+      fs.writeFileSync(path.join(wtAdminPersonal, "commondir"), "../..\n", "utf-8");
+
+      const wtDir = path.join(tempDir, "wt-child");
+      fs.mkdirSync(wtDir, { recursive: true });
+      fs.writeFileSync(path.join(wtDir, ".git"), `gitdir: ${wtAdminPersonal}\n`, "utf-8");
+      assert.equal(resolveCfMemScope(wtDir), null);
+    });
+  });
+
+  it("guarantees deterministic workspaceId without absolute paths", () => {
+    withTempDir((tempDir) => {
+      const repoDir = path.join(tempDir, "nested", "sub", "test-project");
+      fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+
+      const scope1 = resolveCfMemScope(repoDir);
+      const scope2 = resolveCfMemScope(repoDir);
+
+      assert.ok(scope1 !== null);
+      assert.ok(scope2 !== null);
+      assert.equal(scope1.workspaceId, scope2.workspaceId);
+      assert.match(scope1.workspaceId, /^ws_[A-Za-z0-9._:-]{1,32}_[0-9a-f]{16}$/);
+      assert.ok(!scope1.workspaceId.includes("/"));
+      assert.ok(!scope1.workspaceId.includes("\\"));
+      assert.ok(!scope1.workspaceId.includes(tempDir));
+      assert.ok(!scope1.workspaceId.includes(repoDir));
+    });
+  });
+
+  it("resolves the live ADS worktree environment correctly", () => {
+    const cwd = process.cwd();
+    const scope = resolveCfMemScope(cwd);
+    assert.ok(scope !== null);
+    assert.equal(scope.projectId, "ads");
+    assert.equal(scope.workspaceName, path.basename(fs.realpathSync(cwd)));
+    assert.ok(scope.repositoryRoot.endsWith("/ads"));
+    assert.ok(scope.workspaceId.startsWith("ws_ads_"));
+    assert.ok(!scope.workspaceId.includes("/"));
+  });
+});

--- a/tests/middleware/pipeline.test.ts
+++ b/tests/middleware/pipeline.test.ts
@@ -293,6 +293,49 @@ describe("MiddlewarePipeline & Core Middlewares", () => {
     ]);
   });
 
+  it("keeps the original prompt and excludes tool traces from after-output middleware", async () => {
+    let afterContext: TurnContext | undefined;
+    let afterReply = "";
+    let invokedInput: unknown;
+    const pipeline = createMiddlewarePipeline([{
+      name: "lifecycle-memory-test",
+      onBeforeInput: (ctx) => ({ modifiedPrompt: `${ctx.prompt} [recalled]` }),
+      onAfterOutput: (ctx, reply) => {
+        afterContext = ctx;
+        afterReply = reply;
+      },
+    }]);
+    const orchestrator = {
+      getActiveAgentId: () => "codex",
+      onEvent: () => () => {},
+      invokeAgent: async (_agentId: string, input: unknown) => {
+        invokedInput = input;
+        return {
+          response: "final response\n<<<tool.unknown>>>internal trace\n>>>",
+          usage: null,
+          agentId: "codex",
+        };
+      },
+    } as any;
+
+    const result = await runAgentTurn(orchestrator, "original prompt", {
+      middleware: pipeline,
+      middlewareContext: {
+        turnId: "turn-1",
+        sessionId: "session-1",
+        channel: "web",
+        originalPrompt: "original prompt",
+      },
+      workspaceRoot: os.tmpdir(),
+    });
+
+    assert.equal(invokedInput, "original prompt [recalled]");
+    assert.equal(result.response, "final response\n\ntool.unknown: rejected (unknown tool)");
+    assert.equal(afterReply, "final response");
+    assert.equal(afterContext?.originalPrompt, "original prompt");
+    assert.equal(afterContext?.prompt, "original prompt [recalled]");
+  });
+
   it("fails closed when an item-start middleware throws", async () => {
     const pipeline = createMiddlewarePipeline([{
       name: "broken-guard",


### PR DESCRIPTION
## Summary

- Enable cf-mem from CFMEM_URL and CFMEM_API_KEY.
- Derive repository project and workspace scope on the server.
- Preserve original prompts and ingest cleaned final responses asynchronously with stable event IDs.
- Keep recall bounded and fail open on unavailable memory services.

## Verification

- npm run lint
- npx tsc --noEmit
- npm run build
- npm test (772 passed)
- npm run test:web (440 passed)
- focused cf-mem middleware tests (23 passed)

Closes #162