### PR TITLE
fix(agents): retry stream disconnects

### DIFF
--- a/server/agents/adapters/transientModelRetry.ts
+++ b/server/agents/adapters/transientModelRetry.ts
@@ -138,6 +138,18 @@ export function isClaudeSafeguardError(message: string): boolean {
   );
 }
 
+export function isStreamDisconnectedUpstreamError(message: string): boolean {
+  const normalized = message.replace(/\s+/g, " ").trim().toLowerCase();
+  if (!normalized) return false;
+  return (
+    normalized.includes("stream disconnected before completion") ||
+    normalized.includes("stream closed before response.completed") ||
+    normalized.includes("connection closed") ||
+    normalized.includes("socket hang up") ||
+    normalized.includes("premature close")
+  );
+}
+
 export function isTransientUpstreamModelError(message: string): boolean {
   return (
     isHighDemandUpstreamError(message) ||
@@ -145,7 +157,8 @@ export function isTransientUpstreamModelError(message: string): boolean {
     isHttp503UpstreamError(message) ||
     isHttpGateway5xxUpstreamError(message) ||
     isBadResponseStatusCode400UpstreamError(message) ||
-    isClaudeSafeguardError(message)
+    isClaudeSafeguardError(message) ||
+    isStreamDisconnectedUpstreamError(message)
   );
 }
 

--- a/tests/agents/transientModelRetry.test.ts
+++ b/tests/agents/transientModelRetry.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   isTransientByokCapacityError,
+  isStreamDisconnectedUpstreamError,
   isTransientUpstreamModelError,
   resolveTransientRetryDelayMs,
   runWithTransientModelRetry,
@@ -11,6 +12,56 @@ import {
 } from "../../server/agents/adapters/transientModelRetry.js";
 
 describe("transient model retry classification", () => {
+  it("treats upstream stream disconnect messages as retryable", () => {
+    const messages = [
+      "stream disconnected before completion: stream closed before response.completed",
+      "Connection closed while reading the upstream response",
+      "socket hang up",
+      "premature close while receiving the response",
+    ];
+
+    for (const message of messages) {
+      assert.equal(isStreamDisconnectedUpstreamError(message), true, message);
+      assert.equal(isTransientUpstreamModelError(message), true, message);
+    }
+  });
+
+  it("retries an upstream stream disconnect", async () => {
+    const previous = process.env[TRANSIENT_MODEL_RETRY_COUNT_ENV];
+    process.env[TRANSIENT_MODEL_RETRY_COUNT_ENV] = "1";
+    let attempts = 0;
+    const retryCounts: number[] = [];
+
+    try {
+      const result = await runWithTransientModelRetry(
+        {
+          agentName: "test",
+          backoffMs: [0],
+          onRetry: (notice) => retryCounts.push(notice.retryCount),
+        },
+        async () => {
+          attempts += 1;
+          if (attempts === 1) {
+            throw new Error(
+              "stream disconnected before completion: stream closed before response.completed",
+            );
+          }
+          return "ok";
+        },
+      );
+
+      assert.equal(result, "ok");
+      assert.equal(attempts, 2);
+      assert.deepEqual(retryCounts, [1]);
+    } finally {
+      if (previous === undefined) {
+        delete process.env[TRANSIENT_MODEL_RETRY_COUNT_ENV];
+      } else {
+        process.env[TRANSIENT_MODEL_RETRY_COUNT_ENV] = previous;
+      }
+    }
+  });
+
   it("treats high-demand upstream messages as retryable", () => {
     assert.equal(
       isTransientUpstreamModelError(

--- a/tests/codex/appServer/codexAppServerAdapter.test.ts
+++ b/tests/codex/appServer/codexAppServerAdapter.test.ts
@@ -993,6 +993,82 @@ describe("CodexAppServerAdapter", () => {
     await registry.stopAll();
   });
 
+  it("retries a terminal stream disconnect before replaying the turn", async () => {
+    const previous = process.env.ADS_UPSTREAM_RETRY_COUNT;
+    process.env.ADS_UPSTREAM_RETRY_COUNT = "1";
+    let turnStarts = 0;
+    const fake = buildFakeServer({
+      autoReplies: {
+        "thread/start": () => ({ thread: { id: "t-retry-stream" } }),
+        "turn/start": () => {
+          turnStarts += 1;
+          return {};
+        },
+      },
+    });
+    const registry = new CodexAppServerDaemonRegistry({ factory: () => fake.client });
+    const adapter = new CodexAppServerAdapter({ projectId: "retry-stream", registry });
+    const events: Array<{ phase: string; title: string; detail?: string }> = [];
+    adapter.onEvent((event) => {
+      events.push({ phase: event.phase, title: event.title, detail: event.detail });
+    });
+
+    try {
+      const sendPromise = adapter.send("retry a disconnected stream");
+      await waitForRequestCount(fake, "turn/start", 1);
+      fake.notify("error", {
+        error: {
+          message:
+            "stream disconnected before completion: stream closed before response.completed",
+        },
+        willRetry: false,
+        threadId: "t-retry-stream",
+        turnId: "turn-1",
+      });
+
+      await waitForRequestCount(fake, "turn/start", 2, 3_000);
+      fake.notify("item/completed", {
+        item: { type: "agentMessage", id: "m-stream-recovered", text: "Recovered stream" },
+        threadId: "t-retry-stream",
+        turnId: "turn-2",
+      });
+      fake.notify("turn/completed", {
+        threadId: "t-retry-stream",
+        turn: { id: "turn-2" },
+      });
+
+      const result = await sendPromise;
+      assert.equal(result.response, "Recovered stream");
+      assert.equal(turnStarts, 2);
+      const turnStartRequests = fake.requests.filter((request) => request.method === "turn/start");
+      assert.equal(turnStartRequests.length, 2);
+      assert.deepEqual(
+        (turnStartRequests[0]!.params as any).input,
+        (turnStartRequests[1]!.params as any).input,
+      );
+      assert(
+        events.some(
+          (event) =>
+            event.phase === "connection" &&
+            event.title === "模型请求重试" &&
+            event.detail ===
+              "stream disconnected before completion: stream closed before response.completed",
+        ),
+      );
+      assert.equal(
+        events.some((event) => ["command", "file", "tool"].includes(event.phase)),
+        false,
+      );
+    } finally {
+      await registry.stopAll();
+      if (previous === undefined) {
+        delete process.env.ADS_UPSTREAM_RETRY_COUNT;
+      } else {
+        process.env.ADS_UPSTREAM_RETRY_COUNT = previous;
+      }
+    }
+  });
+
   it("does not retry BYOK 500 capacity errors", async () => {
     let turnStarts = 0;
     const fake = buildFakeServer({


### PR DESCRIPTION
## Summary
- align transient upstream retry classification with Codex stream disconnect errors
- retry terminal stream disconnects through the existing adapter retry loop
- add unit and app-server integration coverage for retry notices and replayed input

## Validation
- `npx tsc -p tsconfig.build.json --noEmit`
- `npm run lint -- --no-fix`
- `npm test` (720 tests)
- `npm run test:web` (81 files, 452 tests)
- `npm run build`

Closes #167
