### PR TITLE
fix(audio): prime whisper transcription

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,8 @@ ADS 会在启动时从当前工作目录向上查找 `.env` 文件，并自动�
 | `ADS_REINJECTION_TURNS` | `6` | 系统 Instructions 周期性重新注入的轮次间隔 |
 | `ADS_RULE_ENFORCEMENT_MODE` | `observe` | 兼容性日志模式；内置安全拦截始终执行，不由该变量放宽 |
 | `ADS_AUDIO_TRANSCRIPTION_TIMEOUT_MS`| `120000` | 语音转写处理的单次超时时限（毫秒） |
+| `ADS_AUDIO_TRANSCRIPTION_PROMPT` | `以下是普通话的句子，包含标点符号。` | Whisper 转写使用的前缀提示，可覆盖默认值 |
+| `ADS_AUDIO_TRANSCRIPTION_LANGUAGE` | `zh` | Whisper 转写的语言代码，可覆盖默认值 |
 
 ---
 

--- a/server/audio/transcription.ts
+++ b/server/audio/transcription.ts
@@ -13,6 +13,14 @@ export type AudioTranscriptionResult =
   | { ok: true; text: string; provider: string }
   | { ok: false; error: string; errors: string[]; timedOut: boolean };
 
+const DEFAULT_TRANSCRIPTION_PROMPT = "以下是普通话的句子，包含标点符号。";
+const DEFAULT_TRANSCRIPTION_LANGUAGE = "zh";
+
+type TranscriptionOptions = {
+  prompt: string;
+  language: string;
+};
+
 function normalizeContentType(raw: string | undefined): string {
   let contentType = String(raw ?? "").trim();
   if (contentType.includes(";")) {
@@ -36,8 +44,17 @@ function resolveTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
   return Number.isFinite(raw) ? Math.max(1000, raw) : 120_000;
 }
 
-function resolveTranscriptionSkillOrder(workspaceRoot: string): string[] {
-  const explicit = parseCsv(process.env.ADS_AUDIO_TRANSCRIPTION_SKILLS);
+function resolveTranscriptionOptions(env: NodeJS.ProcessEnv = process.env): TranscriptionOptions {
+  const prompt = String(env.ADS_AUDIO_TRANSCRIPTION_PROMPT ?? "").trim();
+  const language = String(env.ADS_AUDIO_TRANSCRIPTION_LANGUAGE ?? "").trim();
+  return {
+    prompt: prompt || DEFAULT_TRANSCRIPTION_PROMPT,
+    language: language || DEFAULT_TRANSCRIPTION_LANGUAGE,
+  };
+}
+
+function resolveTranscriptionSkillOrder(workspaceRoot: string, env: NodeJS.ProcessEnv = process.env): string[] {
+  const explicit = parseCsv(env.ADS_AUDIO_TRANSCRIPTION_SKILLS);
   if (explicit.length > 0) {
     return explicit;
   }
@@ -108,6 +125,7 @@ async function runTranscriptionSkill(args: {
   skill: SkillMetadata | null;
   audioPath: string;
   timeoutMs: number;
+  transcriptionOptions: TranscriptionOptions;
   signal?: AbortSignal;
   exec?: (req: {
     cmd: string;
@@ -135,7 +153,11 @@ async function runTranscriptionSkill(args: {
     args: [...script.args, "--input", args.audioPath],
     cwd: args.workspaceRoot,
     timeoutMs: args.timeoutMs,
-    env: process.env,
+    env: {
+      ...process.env,
+      ADS_WHISPER_PROMPT: args.transcriptionOptions.prompt,
+      ADS_WHISPER_LANGUAGE: args.transcriptionOptions.language,
+    },
     signal: args.signal,
     allowlist: null,
   });
@@ -181,8 +203,10 @@ export async function transcribeAudioBuffer(args: {
   const ext = resolveAudioExt(contentType);
   const audioPath = writeTempAudioFile(audio, ext);
 
-  const timeoutMs = resolveTimeoutMs();
-  const skills = resolveTranscriptionSkillOrder(workspaceRoot);
+  const env = process.env;
+  const timeoutMs = resolveTimeoutMs(env);
+  const transcriptionOptions = resolveTranscriptionOptions(env);
+  const skills = resolveTranscriptionSkillOrder(workspaceRoot, env);
   const discoveredSkills = discoverSkills(workspaceRoot);
   const skillLookup = indexSkillsByName(discoveredSkills);
   const errors: string[] = [];
@@ -197,6 +221,7 @@ export async function transcribeAudioBuffer(args: {
           skill: skillLookup.get(skillName.toLowerCase()) ?? null,
           audioPath,
           timeoutMs,
+          transcriptionOptions,
           signal: args.signal,
           exec: args.exec,
         });

--- a/tests/audio/transcription.test.ts
+++ b/tests/audio/transcription.test.ts
@@ -144,4 +144,61 @@ describe("audio/transcription (skill-based)", () => {
 
     assert.deepEqual(result, { ok: true, text: "ok", provider: "skill:skill-b" });
   });
+
+  it("passes default and configured Whisper options through the child environment", async () => {
+    writeSkill(codexHomeDir, "skill-a");
+    writeRegistry(codexHomeDir, [
+      "version: 1",
+      "mode: overlay",
+      "skills:",
+      "  skill-a:",
+      "    provides: [audio.transcribe]",
+      "    priority: 100",
+      "",
+    ].join("\n"));
+
+    const requests: Array<{ args: string[]; env?: NodeJS.ProcessEnv }> = [];
+    const exec = async ({ args, env }: { args: string[]; env?: NodeJS.ProcessEnv }) => {
+      requests.push({ args, env });
+      return {
+        commandLine: "python3 transcribe.py",
+        exitCode: 0,
+        signal: null,
+        elapsedMs: 1,
+        timedOut: false,
+        stdout: "default transcript",
+        stderr: "",
+        truncatedStdout: false,
+        truncatedStderr: false,
+      };
+    };
+
+    const defaultResult = await transcribeAudioBuffer({
+      workspaceRoot,
+      audio: Buffer.from("abc"),
+      contentType: "audio/ogg",
+      exec,
+    });
+
+    assert.deepEqual(defaultResult, { ok: true, text: "default transcript", provider: "skill:skill-a" });
+    assert.equal(requests[0]?.args.at(-2), "--input");
+    assert.equal(requests[0]?.env?.ADS_WHISPER_PROMPT, "以下是普通话的句子，包含标点符号。");
+    assert.equal(requests[0]?.env?.ADS_WHISPER_LANGUAGE, "zh");
+
+    process.env.ADS_AUDIO_TRANSCRIPTION_PROMPT = "Custom punctuation prompt.";
+    process.env.ADS_AUDIO_TRANSCRIPTION_LANGUAGE = "ja";
+
+    const configuredResult = await transcribeAudioBuffer({
+      workspaceRoot,
+      audio: Buffer.from("def"),
+      contentType: "audio/ogg",
+      exec,
+    });
+
+    assert.deepEqual(configuredResult, { ok: true, text: "default transcript", provider: "skill:skill-a" });
+    assert.equal(requests[1]?.env?.ADS_WHISPER_PROMPT, "Custom punctuation prompt.");
+    assert.equal(requests[1]?.env?.ADS_WHISPER_LANGUAGE, "ja");
+    assert.equal(process.env.ADS_WHISPER_PROMPT, originalEnv.ADS_WHISPER_PROMPT);
+    assert.equal(process.env.ADS_WHISPER_LANGUAGE, originalEnv.ADS_WHISPER_LANGUAGE);
+  });
 });


### PR DESCRIPTION
## Summary

- pass default and configurable Whisper prompt/language settings through the ADS transcription child process
- add prompt and language multipart fields to the Groq Whisper skill
- cover default and override propagation in audio transcription tests

## Validation

- TypeScript build check
- ESLint
- 721 backend tests with an isolated CODEX_HOME
- 452 Web tests
- production build
- Python syntax and local multipart request checks

Closes #169