### PR TITLE
perf(web): optimize long chat rendering

### DIFF
--- a/client/src/__tests__/issue-168-chat-rendering.test.ts
+++ b/client/src/__tests__/issue-168-chat-rendering.test.ts
@@ -1,0 +1,173 @@
+import { mount } from "@vue/test-utils";
+import { nextTick, ref } from "vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createAppContext } from "../app/controller";
+import type { ChatItem, ProjectRuntime } from "../app/controller";
+import { createChatActions } from "../app/chat";
+import { createStreamingActions } from "../app/chatStreaming";
+import MarkdownContent from "../components/MarkdownContent.vue";
+import MainChatMessageList from "../components/MainChatMessageList.vue";
+import type { ChatMessage } from "../components/mainChat/types";
+import { readSfc } from "./readSfc";
+
+function message(id: string, content = `message ${id}`): ChatMessage {
+  return {
+    id,
+    role: "assistant",
+    kind: "text",
+    content,
+  };
+}
+
+function messageListProps(messages: ChatMessage[]) {
+  return {
+    messages,
+    copiedMessageId: null,
+    formatMessageTs: () => "",
+    liveStepExpanded: false,
+    liveStepHasOverflow: false,
+    liveStepCanToggleExpanded: false,
+    liveStepOutlineItems: [],
+    liveStepOutlineHiddenCount: 0,
+    liveStepCollapsedTrivialOutline: false,
+  };
+}
+
+describe("Issue #168 chat rendering", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("mounts a recent message window and preserves the scroll anchor when loading earlier messages", async () => {
+    const messages = Array.from({ length: 65 }, (_, index) => message(`m-${index}`));
+    const host = document.createElement("div");
+    host.className = "chat";
+    document.body.appendChild(host);
+
+    const wrapper = mount(MainChatMessageList, {
+      props: messageListProps(messages),
+      attachTo: host,
+    });
+
+    let height = 10;
+    Object.defineProperty(host, "clientHeight", { configurable: true, get: () => 100 });
+    Object.defineProperty(host, "scrollHeight", {
+      configurable: true,
+      get: () => wrapper.findAll(".msg").length * height + 1,
+    });
+    host.scrollTop = 40;
+
+    expect(wrapper.findAll(".msg")).toHaveLength(30);
+    expect(wrapper.find('.msg[data-id="m-35"]').exists()).toBe(true);
+    expect(wrapper.find('.msg[data-id="m-34"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="load-earlier-messages"]').exists()).toBe(true);
+
+    height = 10;
+    await wrapper.find('[data-testid="load-earlier-messages"]').trigger("click");
+    await vi.waitFor(() => {
+      expect(wrapper.findAll(".msg")).toHaveLength(50);
+    });
+
+    expect(wrapper.find('.msg[data-id="m-15"]').exists()).toBe(true);
+    expect(wrapper.find('.msg[data-id="m-14"]').exists()).toBe(false);
+    expect(host.scrollTop).toBe(240);
+
+    wrapper.unmount();
+  });
+
+  it("keeps the complete message history in the application state while the list owns only a window", async () => {
+    const chat = createChatActions(createAppContext());
+    const stateItems = Array.from({ length: 240 }, (_, index) => ({
+      id: `m-${index}`,
+      role: "assistant" as const,
+      kind: "text" as const,
+      content: `message ${index}`,
+    }));
+    expect(chat.trimChatItems(stateItems)).toHaveLength(240);
+
+    const messages = Array.from({ length: 100 }, (_, index) => message(`m-${index}`));
+    const wrapper = mount(MainChatMessageList, {
+      props: messageListProps(messages),
+    });
+
+    await nextTick();
+    expect(messages).toHaveLength(100);
+    expect(wrapper.find('[data-total-messages="100"]').exists()).toBe(true);
+    expect(wrapper.findAll(".msg")).toHaveLength(30);
+
+    wrapper.unmount();
+  });
+
+  it("clamps long ordinary code blocks and toggles their full content", async () => {
+    const code = Array.from({ length: 31 }, (_, index) => `const value${index} = ${index};`).join("\n");
+    const wrapper = mount(MarkdownContent, {
+      props: { content: `\`\`\`ts\n${code}\n\`\`\`` },
+    });
+
+    const block = wrapper.find(".md-codeblock");
+    expect(block.classes()).toContain("md-codeblock--clamped");
+    expect(block.attributes("data-expanded")).toBe("false");
+    expect(block.find(".md-code-toggle").text()).toBe("Show full code");
+
+    await block.find(".md-code-toggle").trigger("click");
+
+    expect(block.classes()).toContain("md-codeblock--expanded");
+    expect(block.classes()).not.toContain("md-codeblock--clamped");
+    expect(block.attributes("data-expanded")).toBe("true");
+    expect(block.find(".md-code-toggle").text()).toBe("Collapse");
+
+    wrapper.unmount();
+  });
+
+  it("batches streaming deltas into one animation-frame commit", () => {
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    let callback: FrameRequestCallback | null = null;
+    let commitCount = 0;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      callback = cb;
+      return 1;
+    }) as typeof globalThis.requestAnimationFrame;
+
+    try {
+      const messages = ref<ChatItem[]>([]);
+      const runtime = {
+        messages,
+        liveActivity: { head: 0, tail: 0, size: 0, capacity: 10, totalRecorded: 0, buffer: [] },
+        liveActivityTtlTimer: null,
+      } as unknown as ProjectRuntime;
+      const streaming = createStreamingActions({
+        liveStepId: "live-step",
+        liveActivityId: "live-activity",
+        runtimeOrActive: () => runtime,
+        setMessages: (items) => {
+          commitCount += 1;
+          messages.value = items;
+        },
+        dropEmptyAssistantPlaceholder: () => {},
+        isLiveMessageId: (id) => id === "live-step" || id === "live-activity",
+        randomId: (prefix) => `${prefix}-1`,
+      });
+
+      streaming.upsertStreamingDelta("first ", runtime);
+      streaming.upsertStreamingDelta("second", runtime);
+
+      expect(messages.value[0]?.content).toBe("first second");
+      expect(commitCount).toBe(0);
+      expect(callback).not.toBeNull();
+
+      callback?.(0);
+
+      expect(commitCount).toBe(1);
+      expect(messages.value[0]?.content).toBe("first second");
+    } finally {
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    }
+  });
+
+  it("uses browser-native containment for mounted message subtrees", async () => {
+    const source = await readSfc("../components/MainChatMessageList.vue", import.meta.url);
+    expect(source).toMatch(/content-visibility:\s*auto\s*;/);
+    expect(source).toMatch(/contain-intrinsic-size:\s*auto\s+150px\s*;/);
+  });
+});

--- a/client/src/app/chat.ts
+++ b/client/src/app/chat.ts
@@ -30,7 +30,6 @@ export function createChatActions(ctx: AppContext) {
   const {
     runtimeOrActive,
     runtimeAgentBusy,
-    maxChatMessages,
     maxExecutePreviewLines,
     maxRecentCommands,
     maxTurnCommands,
@@ -302,8 +301,9 @@ export function createChatActions(ctx: AppContext) {
       if (msg) liveById.set(liveId, msg);
     }
 
-    const nonLive = existing.filter((m) => !isLiveMessageId(m.id));
-    const trimmed = nonLive.length <= maxChatMessages ? nonLive : nonLive.slice(nonLive.length - maxChatMessages);
+    // Keep the complete conversation in memory. The message list owns the DOM
+    // window, so retaining history here does not require mounting every item.
+    const trimmed = existing.filter((m) => !isLiveMessageId(m.id));
     const liveBlock = LIVE_MESSAGE_IDS.map((id) => liveById.get(id)).filter(Boolean) as ChatItem[];
     if (liveBlock.length === 0) {
       return trimmed;

--- a/client/src/app/chatStreaming.ts
+++ b/client/src/app/chatStreaming.ts
@@ -1,3 +1,5 @@
+import { toRaw } from "vue";
+
 import { clearLiveActivityWindow, renderLiveActivityMarkdown } from "../lib/live_activity";
 import {
   findAssistantInsertIndex,
@@ -67,6 +69,37 @@ export function createStreamingActions(params: {
   const { liveStepId, liveActivityId, runtimeOrActive, setMessages, dropEmptyAssistantPlaceholder, isLiveMessageId, randomId } =
     params;
 
+  const pendingFrameStates = new Set<ProjectRuntime>();
+  let pendingFrame: number | null = null;
+
+  const flushStreamingFrame = (): void => {
+    pendingFrame = null;
+    const states = [...pendingFrameStates];
+    pendingFrameStates.clear();
+    for (const state of states) {
+      setMessages(state.messages.value.slice(), state);
+    }
+  };
+
+  const scheduleStreamingFrame = (state: ProjectRuntime): void => {
+    pendingFrameStates.add(state);
+    if (pendingFrame !== null) return;
+
+    const requestFrame = globalThis.requestAnimationFrame;
+    if (typeof requestFrame !== "function") {
+      // Non-visual environments (SSR and jsdom) do not provide a frame clock.
+      // Flush synchronously there so state consumers keep the same contract.
+      flushStreamingFrame();
+      return;
+    }
+
+    // Use a sentinel while invoking requestAnimationFrame because test clocks
+    // are allowed to invoke the callback synchronously.
+    pendingFrame = -1;
+    const frame = requestFrame(() => flushStreamingFrame());
+    if (pendingFrame === -1) pendingFrame = frame;
+  };
+
   const findActiveStreamingAssistantIndex = (items: ChatItem[]): number => {
     for (let i = items.length - 1; i >= 0; i--) {
       const msg = items[i]!;
@@ -123,11 +156,11 @@ export function createStreamingActions(params: {
       const current = String(existing[streamIndex]!.content ?? "");
       const nextChunk = options?.preserveRepeatedText ? chunk : stripStreamingOverlap(current, chunk);
       if (!nextChunk) return;
-      existing[streamIndex] = {
-        ...existing[streamIndex]!,
-        content: current + nextChunk,
-      };
-      setMessages(existing.slice(), state);
+      const rawMessages = toRaw(state.messages.value) as ChatItem[];
+      const rawMessage = toRaw(rawMessages[streamIndex]) as ChatItem | undefined;
+      if (!rawMessage) return;
+      rawMessage.content = current + nextChunk;
+      scheduleStreamingFrame(state);
       return;
     }
 
@@ -148,7 +181,12 @@ export function createStreamingActions(params: {
       ts: (Number.isFinite(ts) && (ts as number) > 0) ? Math.floor(ts as number) : Date.now(),
     };
     const insertAt = findAssistantInsertIndex(sealedExisting);
-    setMessages([...sealedExisting.slice(0, insertAt), nextItem, ...sealedExisting.slice(insertAt)], state);
+    const rawMessages = toRaw(state.messages.value) as ChatItem[];
+    const nextMessages = [...sealedExisting.slice(0, insertAt), nextItem, ...sealedExisting.slice(insertAt)].map(
+      (message) => toRaw(message) as ChatItem,
+    );
+    rawMessages.splice(0, rawMessages.length, ...nextMessages);
+    scheduleStreamingFrame(state);
   };
 
   const sealActiveStreamingAssistant = (rt?: ProjectRuntime): void => {
@@ -343,5 +381,6 @@ export function createStreamingActions(params: {
     upsertLiveActivity,
     clearStepLive,
     sealActiveStreamingAssistant,
+    flushStreamingFrame,
   };
 }

--- a/client/src/app/controller.ts
+++ b/client/src/app/controller.ts
@@ -28,7 +28,6 @@ export function createAppContext() {
   const maxLiveActivitySteps = 5;
   const maxTurnCommands = 64;
   const maxExecutePreviewLines = 3;
-  const maxChatMessages = 200;
 
   const fixtureMode = computed(() => {
     try {
@@ -182,7 +181,6 @@ export function createAppContext() {
     maxLiveActivitySteps,
     maxTurnCommands,
     maxExecutePreviewLines,
-    maxChatMessages,
     fixtureMode,
     isExecuteBlockFixture,
     loggedIn,

--- a/client/src/components/MainChat.vue
+++ b/client/src/components/MainChat.vue
@@ -52,6 +52,7 @@ const emit = defineEmits<{
 }>();
 
 const listRef = ref<HTMLElement | null>(null);
+const messageListRef = ref<{ showLatestMessages?: () => void } | null>(null);
 const autoScroll = ref(true);
 const showScrollToBottom = ref(false);
 
@@ -99,6 +100,9 @@ function onLiveStepScroll(): void {
 
 async function scrollChatToBottom(): Promise<void> {
   if (!listRef.value) return;
+  await nextTick();
+  if (!listRef.value) return;
+  messageListRef.value?.showLatestMessages?.();
   await nextTick();
   if (!listRef.value) return;
   listRef.value.scrollTop = listRef.value.scrollHeight;
@@ -350,6 +354,7 @@ onBeforeUnmount(() => {
     />
     <div ref="listRef" class="chat" @scroll="handleScroll">
       <MainChatMessageList
+        ref="messageListRef"
         :messages="messages"
         :copied-message-id="copiedMessageId"
         :format-message-ts="formatMessageTs"

--- a/client/src/components/MainChatMessageList.vue
+++ b/client/src/components/MainChatMessageList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
 import MarkdownContent from "./MarkdownContent.vue";
 import ChatFilePreviewModal from "./ChatFilePreviewModal.vue";
@@ -33,6 +33,18 @@ const openCommandTrees = ref<Set<string>>(new Set());
 const expandedExecuteIds = ref<Set<string>>(new Set());
 const expandedPatchKeys = ref<Set<string>>(new Set());
 const filePreviewTarget = ref<MarkdownFilePreviewLink | null>(null);
+const messageListEl = ref<HTMLElement | null>(null);
+const earlierMessagesSentinel = ref<HTMLElement | null>(null);
+const windowStart = ref(0);
+const windowEnd = ref(0);
+const loadingEarlierMessages = ref(false);
+
+const INITIAL_MESSAGE_WINDOW = 30;
+const EARLIER_MESSAGE_PAGE_SIZE = 20;
+const CHAT_BOTTOM_THRESHOLD_PX = 80;
+
+let messageScrollRoot: HTMLElement | null = null;
+let earlierMessagesObserver: IntersectionObserver | null = null;
 
 type PatchRenderRow = {
   key: string;
@@ -244,6 +256,145 @@ const renderMessages = computed<RenderMessage[]>(() => {
   return processed;
 });
 
+const hasEarlierMessages = computed(() => windowStart.value > 0);
+
+const windowedMessages = computed<RenderMessage[]>(() => {
+  const end = Math.min(windowEnd.value || renderMessages.value.length, renderMessages.value.length);
+  const start = Math.min(windowStart.value, end);
+  return renderMessages.value.slice(start, end);
+});
+
+function sameMessageIds(left: RenderMessage[] | undefined, right: RenderMessage[]): boolean {
+  if (!left || left.length !== right.length) return false;
+  return left.every((message, index) => message.id === right[index]?.id);
+}
+
+function resolveMessageScrollRoot(): HTMLElement | null {
+  const list = messageListEl.value;
+  if (!list) return null;
+  return (list.closest(".chat") as HTMLElement | null) ?? list.parentElement;
+}
+
+function isMessageScrollRootNearBottom(): boolean {
+  const root = messageScrollRoot ?? resolveMessageScrollRoot();
+  if (!root) return true;
+  const distance = root.scrollHeight - root.scrollTop - root.clientHeight;
+  return root.scrollHeight <= root.clientHeight || distance <= CHAT_BOTTOM_THRESHOLD_PX;
+}
+
+function showLatestMessages(): void {
+  const total = renderMessages.value.length;
+  const nextStart = Math.max(0, total - INITIAL_MESSAGE_WINDOW);
+  if (windowEnd.value === total && windowStart.value === nextStart) return;
+  windowStart.value = nextStart;
+  windowEnd.value = total;
+}
+
+defineExpose({ showLatestMessages });
+
+function handleMessageScroll(): void {
+  if (isMessageScrollRootNearBottom()) showLatestMessages();
+}
+
+async function loadEarlierMessages(): Promise<void> {
+  if (loadingEarlierMessages.value || !hasEarlierMessages.value) return;
+
+  const root = messageScrollRoot ?? resolveMessageScrollRoot();
+  const previousScrollTop = root?.scrollTop ?? 0;
+  const previousScrollHeight = root?.scrollHeight ?? 0;
+  const nextStart = Math.max(0, windowStart.value - EARLIER_MESSAGE_PAGE_SIZE);
+
+  loadingEarlierMessages.value = true;
+  windowStart.value = nextStart;
+  try {
+    await nextTick();
+    if (root) {
+      root.scrollTop = previousScrollTop + (root.scrollHeight - previousScrollHeight);
+    }
+  } finally {
+    loadingEarlierMessages.value = false;
+  }
+}
+
+function observeEarlierMessagesSentinel(): void {
+  earlierMessagesObserver?.disconnect();
+  earlierMessagesObserver = null;
+
+  const sentinel = earlierMessagesSentinel.value;
+  if (!sentinel || typeof IntersectionObserver === "undefined") return;
+
+  earlierMessagesObserver = new IntersectionObserver(
+    (entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) void loadEarlierMessages();
+    },
+    {
+      root: messageScrollRoot,
+      rootMargin: "240px 0px 0px 0px",
+    },
+  );
+  earlierMessagesObserver.observe(sentinel);
+}
+
+watch(
+  renderMessages,
+  (next, previous) => {
+    if (!previous || previous.length === 0 || next.length === 0) {
+      windowStart.value = Math.max(0, next.length - INITIAL_MESSAGE_WINDOW);
+      windowEnd.value = next.length;
+      return;
+    }
+
+    if (sameMessageIds(previous, next)) return;
+
+    const isTailAppend =
+      next.length >= previous.length &&
+      previous.every((message, index) => message.id === next[index]?.id);
+    if (isTailAppend) {
+      if (isMessageScrollRootNearBottom()) {
+        showLatestMessages();
+      } else {
+        windowEnd.value = Math.min(windowEnd.value || previous.length, previous.length);
+      }
+      return;
+    }
+
+    if (isMessageScrollRootNearBottom()) {
+      showLatestMessages();
+      return;
+    }
+
+    const currentStartId = previous[windowStart.value]?.id;
+    const preservedStart = currentStartId ? next.findIndex((message) => message.id === currentStartId) : -1;
+    if (preservedStart >= 0) {
+      const visibleCount = Math.max(0, (windowEnd.value || previous.length) - windowStart.value);
+      windowStart.value = preservedStart;
+      windowEnd.value = Math.min(next.length, preservedStart + visibleCount);
+      return;
+    }
+
+    windowStart.value = Math.max(0, next.length - INITIAL_MESSAGE_WINDOW);
+    windowEnd.value = next.length;
+  },
+  { immediate: true },
+);
+
+watch(windowStart, () => {
+  void nextTick().then(observeEarlierMessagesSentinel);
+});
+
+onMounted(() => {
+  messageScrollRoot = resolveMessageScrollRoot();
+  messageScrollRoot?.addEventListener("scroll", handleMessageScroll, { passive: true });
+  observeEarlierMessagesSentinel();
+});
+
+onBeforeUnmount(() => {
+  earlierMessagesObserver?.disconnect();
+  earlierMessagesObserver = null;
+  messageScrollRoot?.removeEventListener("scroll", handleMessageScroll);
+  messageScrollRoot = null;
+});
+
 watch(
   () =>
     renderMessages.value
@@ -361,11 +512,34 @@ function closeFilePreview(): void {
 </script>
 
 <template>
-  <div class="messageList">
+  <div
+    ref="messageListEl"
+    class="messageList"
+    :data-total-messages="renderMessages.length"
+    :data-window-start="windowStart"
+    :data-window-end="windowEnd"
+  >
     <div v-if="messages.length === 0" class="chat-empty">
       <span>直接开始对话…</span>
     </div>
-    <div v-for="m in renderMessages" :key="m.id" class="msg" :data-id="m.id" :data-role="m.role" :data-kind="m.kind">
+    <div
+      v-if="hasEarlierMessages"
+      ref="earlierMessagesSentinel"
+      class="messageHistorySentinel"
+      data-testid="load-earlier-sentinel"
+      aria-hidden="true"
+    ></div>
+    <button
+      v-if="hasEarlierMessages"
+      class="loadEarlierMessages"
+      type="button"
+      data-testid="load-earlier-messages"
+      :disabled="loadingEarlierMessages"
+      @click="loadEarlierMessages"
+    >
+      {{ loadingEarlierMessages ? "正在加载…" : "加载更早消息" }}
+    </button>
+    <div v-for="m in windowedMessages" :key="m.id" class="msg" :data-id="m.id" :data-role="m.role" :data-kind="m.kind">
       <div v-if="m.kind === 'command'" class="command-block">
         <button
           class="command-tree-header"
@@ -583,6 +757,36 @@ function closeFilePreview(): void {
   max-width: 100%;
   overflow: visible;
   justify-content: flex-start;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 150px;
+}
+
+.messageHistorySentinel {
+  width: 100%;
+  height: 1px;
+  pointer-events: none;
+}
+
+.loadEarlierMessages {
+  display: block;
+  margin: 0 auto 10px;
+  padding: 5px 12px;
+  border: 1px solid var(--github-border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--github-muted);
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.loadEarlierMessages:hover:not(:disabled) {
+  color: var(--github-text);
+  background: #ffffff;
+}
+
+.loadEarlierMessages:disabled {
+  cursor: wait;
+  opacity: 0.7;
 }
 
 .command-block {

--- a/client/src/components/MarkdownContent.vue
+++ b/client/src/components/MarkdownContent.vue
@@ -35,6 +35,21 @@ async function onClick(ev: MouseEvent): Promise<void> {
   const target = ev.target as HTMLElement | null;
   if (!target) return;
 
+  const toggle = target.closest("button.md-code-toggle") as HTMLButtonElement | null;
+  if (toggle) {
+    const wrapper = toggle.closest(".md-codeblock");
+    if (!wrapper) return;
+    const expanded = wrapper.getAttribute("data-expanded") === "true";
+    const nextExpanded = !expanded;
+    wrapper.setAttribute("data-expanded", String(nextExpanded));
+    wrapper.classList.toggle("md-codeblock--clamped", !nextExpanded);
+    wrapper.classList.toggle("md-codeblock--expanded", nextExpanded);
+    toggle.setAttribute("aria-expanded", String(nextExpanded));
+    toggle.setAttribute("aria-label", nextExpanded ? "Collapse code" : "Show full code");
+    toggle.textContent = nextExpanded ? "Collapse" : "Show full code";
+    return;
+  }
+
   const btn = target.closest("button.md-codecopy") as HTMLButtonElement | null;
   if (btn) {
     const wrapper = btn.closest(".md-codeblock");
@@ -279,10 +294,56 @@ const html = computed(() => renderMarkdownToHtml(props.content));
   background: transparent;
   overflow-x: auto;
   overflow-y: auto;
-  max-height: min(40vh, 360px);
+  max-height: 400px;
   scrollbar-gutter: stable;
   scrollbar-width: thin;
   scrollbar-color: rgba(148, 163, 184, 0.45) transparent;
+}
+
+.md :deep(.md-codeblock--clamped .md-codeblock-body) {
+  position: relative;
+}
+
+.md :deep(.md-codeblock--clamped .md-codeblock-body::after) {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 56px;
+  content: "";
+  background: linear-gradient(to bottom, transparent, var(--github-code-bg));
+  pointer-events: none;
+}
+
+.md :deep(.md-codeblock--clamped .md-codeblock-body pre) {
+  overflow-y: hidden;
+}
+
+.md :deep(.md-codeblock--expanded .md-codeblock-body pre) {
+  max-height: none;
+}
+
+.md :deep(.md-code-toggle) {
+  display: block;
+  width: 100%;
+  padding: 7px 12px;
+  border: 0;
+  border-top: 1px solid var(--github-border);
+  background: var(--github-code-header);
+  color: var(--github-muted);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.md :deep(.md-code-toggle:hover) {
+  color: var(--github-text);
+}
+
+.md :deep(.md-code-toggle:focus-visible) {
+  outline: 2px solid rgba(9, 105, 218, 0.28);
+  outline-offset: -2px;
 }
 
 .md :deep(.md-codeblock pre)::-webkit-scrollbar {

--- a/client/src/lib/markdown/renderer.ts
+++ b/client/src/lib/markdown/renderer.ts
@@ -141,6 +141,7 @@ md.renderer.rules.fence = (tokens, idx, options, _env, _self) => {
   const patchPaths = isLikelyPatch ? extractPatchFilePaths(token.content) : [];
   const canCollapse = isLikelyPatch;
   const lineCount = token.content.split("\n").length;
+  const shouldClamp = !canCollapse && lineCount > 30;
 
   const bodyHtml = [
     `<div class="md-codeblock-body">`,
@@ -174,6 +175,15 @@ md.renderer.rules.fence = (tokens, idx, options, _env, _self) => {
       `</summary>`,
       bodyHtml,
       `</details>`,
+    ].join("");
+  }
+
+  if (shouldClamp) {
+    return [
+      `<div class="md-codeblock md-codeblock--clamped"${langAttr} data-expanded="false" data-line-count="${lineCount}">`,
+      bodyHtml,
+      `<button class="md-code-toggle" type="button" aria-expanded="false" aria-label="Show full code">Show full code</button>`,
+      `</div>`,
     ].join("");
   }
 


### PR DESCRIPTION
## Summary

- Keep the full chat history in application state while mounting a bounded recent-message window.
- Add scroll-anchor-preserving earlier-message pagination and browser-native content containment.
- Batch streaming assistant deltas per animation frame and clamp long ordinary code blocks with an accessible toggle.

## Validation

- npm run lint
- npx tsc -p tsconfig.json --noEmit
- npm run build
- npm run test:web (82 files, 457 tests)

Closes #168