### PR TITLE
feat(ui): unify settings and lane prompt history

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -104,9 +104,9 @@ const {
   confirmProjectSwitch,
 } = createAppController();
 
-const modelManagerOpen = ref(false);
+const settingsOpen = ref(false);
 
-type MobileDrawerSection = "projects" | "models";
+type MobileDrawerSection = "projects" | "settings";
 type MobileContextActionId =
   | "resume"
   | "new-session"
@@ -125,7 +125,7 @@ type MobileManagerHandle = {
 const mobileDrawerOpen = ref(false);
 const mobileDrawerSection = ref<MobileDrawerSection>("projects");
 const mobileContextMenuOpen = ref(false);
-const mobileModelManagerRef = ref<MobileManagerHandle | null>(null);
+const mobileSettingsRef = ref<MobileManagerHandle | null>(null);
 
 const chatLanes: Array<{ id: ChatLane; label: string }> = [
   { id: "planner", label: "Advisor" },
@@ -209,17 +209,17 @@ const newSessionDisabledReason = computed(() => {
 });
 
 const mobileContextTitle = computed(() => {
-  if (mobileDrawerSection.value === "models") return "模型管理";
+  if (mobileDrawerSection.value === "settings") return "系统设置";
   return activeProject.value?.name?.trim() || "项目";
 });
 
 const mobileContextMenuTitle = computed(() => {
-  if (mobileDrawerSection.value === "models") return "模型管理操作";
+  if (mobileDrawerSection.value === "settings") return "系统设置操作";
   return "项目操作";
 });
 
 const mobileContextActions = computed<MobileContextAction[]>(() => {
-  if (mobileDrawerSection.value === "models") {
+  if (mobileDrawerSection.value === "settings") {
     return [
       { id: "create-model", label: "新增模型" },
       { id: "refresh-models", label: "刷新模型列表" },
@@ -277,7 +277,7 @@ function restoreMobileWorkspaceTab(): void {
 function selectMobileDrawerSection(section: MobileDrawerSection): void {
   mobileDrawerSection.value = section;
   mobileContextMenuOpen.value = false;
-  if (section === "models") closeMobileDrawer();
+  if (section === "settings") closeMobileDrawer();
 }
 
 function toggleMobileContextMenu(): void {
@@ -298,11 +298,11 @@ function handleMobileContextAction(actionId: MobileContextActionId): void {
     return;
   }
   if (actionId === "create-model") {
-    mobileModelManagerRef.value?.create();
+    mobileSettingsRef.value?.create();
     return;
   }
   if (actionId === "refresh-models") {
-    void mobileModelManagerRef.value?.refresh();
+    void mobileSettingsRef.value?.refresh();
     return;
   }
 }
@@ -381,19 +381,19 @@ const {
   reorderProjects,
   removeProject,
 });
-function openModelManager(): void {
+function openSettings(): void {
   if (isMobile.value) {
-    openMobileDrawer("models");
+    openMobileDrawer("settings");
     return;
   }
-  modelManagerOpen.value = true;
+  settingsOpen.value = true;
 }
 
-function closeModelManager(): void {
-  modelManagerOpen.value = false;
+function closeSettings(): void {
+  settingsOpen.value = false;
 }
 
-async function onModelManagerChanged(): Promise<void> {
+async function onSettingsChanged(): Promise<void> {
   try {
     await loadModels();
   } catch (error) {
@@ -459,10 +459,10 @@ const plannerConnectionStatus = computed(() => {
           v-if="!isMobile"
           type="button"
           class="topbarIconBtn"
-          title="管理模型"
-          aria-label="管理模型"
-          data-testid="model-manager-open"
-          @click="openModelManager"
+          title="系统设置"
+          aria-label="系统设置"
+          data-testid="settings-open"
+          @click="openSettings"
         >
           <el-icon :size="16" aria-hidden="true"><Setting /></el-icon>
         </button>
@@ -538,13 +538,13 @@ const plannerConnectionStatus = computed(() => {
           <button
             type="button"
             class="mobileDrawerNavItem"
-            :class="{ active: mobileDrawerSection === 'models' }"
-            :aria-current="mobileDrawerSection === 'models' ? 'page' : undefined"
-            data-testid="mobile-drawer-section-models"
-            @click="selectMobileDrawerSection('models')"
+            :class="{ active: mobileDrawerSection === 'settings' }"
+            :aria-current="mobileDrawerSection === 'settings' ? 'page' : undefined"
+            data-testid="mobile-drawer-section-settings"
+            @click="selectMobileDrawerSection('settings')"
           >
             <el-icon :size="16" aria-hidden="true"><Setting /></el-icon>
-            <span>Provider</span>
+            <span>系统设置</span>
           </button>
         </nav>
 
@@ -615,12 +615,13 @@ const plannerConnectionStatus = computed(() => {
 
       <section v-if="isMobile && mobileDrawerSection !== 'projects'" class="mobileMainPanel">
         <ModelManager
-          v-if="mobileDrawerSection === 'models'"
-          ref="mobileModelManagerRef"
+          v-if="mobileDrawerSection === 'settings'"
+          ref="mobileSettingsRef"
           :api="api"
+          initial-tab="lane-prompts"
           :show-header="false"
           @close="closeMobileModule"
-          @changed="onModelManagerChanged"
+          @changed="onSettingsChanged"
         />
       </section>
 
@@ -772,8 +773,13 @@ const plannerConnectionStatus = computed(() => {
       <span class="noticeToastText">{{ apiNotice }}</span>
     </div>
 
-    <DraggableModal v-if="modelManagerOpen" card-variant="large" @close="closeModelManager">
-      <ModelManager :api="api" @close="closeModelManager" @changed="onModelManagerChanged" />
+    <DraggableModal v-if="settingsOpen" card-variant="large" @close="closeSettings">
+      <ModelManager
+        :api="api"
+        initial-tab="lane-prompts"
+        @close="closeSettings"
+        @changed="onSettingsChanged"
+      />
     </DraggableModal>
 
     <DraggableModal v-if="sessionPickerOpen" card-variant="large" @close="closeSessionPicker">

--- a/client/src/__tests__/mobile-navigation-behavior.test.ts
+++ b/client/src/__tests__/mobile-navigation-behavior.test.ts
@@ -78,9 +78,10 @@ const ModelManagerStub = defineComponent({
   props: {
     agent: { type: String, default: null },
     showHeader: { type: Boolean, default: true },
+    initialTab: { type: String, default: "models" },
   },
   template:
-    '<section data-testid="model-manager" :data-show-header="showHeader"><span class="selected-agent">{{ agent }}</span></section>',
+    '<section data-testid="settings-panel" :data-show-header="showHeader" :data-initial-tab="initialTab"><span class="selected-agent">{{ agent }}</span></section>',
   setup(_, { expose }) {
     expose({ create: vi.fn(), refresh: vi.fn() });
     return {};
@@ -165,15 +166,16 @@ describe("mobile navigation behavior", () => {
     await settleUi(wrapper);
     expect(wrapper.findAll(".mobileDrawerNavItem")).toHaveLength(2);
     expect(wrapper.findAll(".mobileDrawerNavItem")[0]?.text()).toContain("项目");
-    expect(wrapper.findAll(".mobileDrawerNavItem")[1]?.text()).toContain("Provider");
+    expect(wrapper.findAll(".mobileDrawerNavItem")[1]?.text()).toContain("系统设置");
 
-    await wrapper.find('[data-testid="mobile-drawer-section-models"]').trigger("click");
+    await wrapper.find('[data-testid="mobile-drawer-section-settings"]').trigger("click");
     await settleUi(wrapper);
     expect(wrapper.find(".mobileDrawer").exists()).toBe(false);
     expect(wrapper.find(".chatShell").exists()).toBe(false);
-    expect(wrapper.find('[data-testid="model-manager"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="settings-panel"]').exists()).toBe(true);
     expect(wrapper.find(".selected-agent").text()).toBe("");
-    expect(wrapper.find('[data-testid="model-manager"]').attributes("data-show-header")).toBe("false");
+    expect(wrapper.find('[data-testid="settings-panel"]').attributes("data-show-header")).toBe("false");
+    expect(wrapper.find('[data-testid="settings-panel"]').attributes("data-initial-tab")).toBe("lane-prompts");
 
     await wrapper.find('[data-testid="mobile-context-menu-toggle"]').trigger("click");
     expect(wrapper.find('[data-testid="mobile-context-action-choose-provider"]').exists()).toBe(false);

--- a/client/src/__tests__/mobile-pane-tabs.test.ts
+++ b/client/src/__tests__/mobile-pane-tabs.test.ts
@@ -22,19 +22,20 @@ describe("mobile navigation shell", () => {
     expect(sfc).toMatch(/:aria-selected="activeWorkspaceTab === tab.id"/);
   });
 
-  it("uses a unified model manager without provider subitems", async () => {
+  it("uses unified settings without provider subitems", async () => {
     const sfc = await readSfc("../App.vue", import.meta.url);
     expect(sfc).toContain('data-testid="mobile-drawer-toggle"');
     expect(sfc).toContain('data-testid="mobile-drawer-section-projects"');
-    expect(sfc).toContain('data-testid="mobile-drawer-section-models"');
-    expect(sfc).toContain("<span>Provider</span>");
+    expect(sfc).toContain('data-testid="mobile-drawer-section-settings"');
+    expect(sfc).toContain("<span>系统设置</span>");
     expect(sfc).not.toContain('class="mobileDrawerSubitems"');
     expect(sfc).not.toContain("MODEL_AGENT_GROUPS");
     expect(sfc).toContain('class="mobileMainPanel"');
     // projectTasks removed
     expect(sfc).not.toContain('class="lanePanel taskLanePanel"');
     expect(sfc).not.toContain('class="mobileTaskWorkspace"');
-    expect(sfc).toContain('v-if="mobileDrawerSection === \'models\'"');
+    expect(sfc).toContain('v-if="mobileDrawerSection === \'settings\'"');
+    expect(sfc).toContain('initial-tab="lane-prompts"');
     expect(sfc).toContain("flex-direction: column");
     expect(sfc).toContain('v-if="!isMobile && p.id === \'default\'"');
     // create button removed
@@ -59,7 +60,7 @@ describe("mobile navigation shell", () => {
     expect(sfc).not.toContain('label: "选择 Provider"');
     expect(sfc).not.toContain('label: "切换 Provider"');
     expect(sfc).toContain("disabled: activeLaneBusy.value || resumeThreadBlocked.value");
-    expect(sfc).toContain("mobileModelManagerRef.value?.create()");
+    expect(sfc).toContain("mobileSettingsRef.value?.create()");
     expect(sfc).not.toContain("打开项目");
   });
 

--- a/client/src/__tests__/model-manager.test.ts
+++ b/client/src/__tests__/model-manager.test.ts
@@ -29,7 +29,7 @@ async function settle(wrapper: { vm: { $nextTick: () => Promise<void> } }): Prom
 }
 
 describe("ModelManager", () => {
-  it("edits and resets versioned Advisor and Worker prompts", async () => {
+  it("edits versioned Advisor and Worker prompts", async () => {
     const advisorPrompt = "Advisor baseline prompt";
     const workerPrompt = "Worker baseline prompt";
     const snapshots: LanePromptSnapshot[] = [
@@ -67,12 +67,11 @@ describe("ModelManager", () => {
     };
 
     const wrapper = mount(ModelManager, {
-      props: { api: api as any },
+      props: { api: api as any, initialTab: "lane-prompts" },
       global: { stubs: { "el-icon": true } },
     });
     await settle(wrapper);
 
-    await wrapper.find('[data-testid="model-manager-tab-lane-prompts"]').trigger("click");
     expect((wrapper.find('[data-testid="lane-prompt-editor"]').element as HTMLTextAreaElement).value).toBe(advisorPrompt);
     expect(wrapper.find('[data-testid="lane-prompt-save"]').attributes("disabled")).toBeDefined();
 
@@ -80,11 +79,112 @@ describe("ModelManager", () => {
     await wrapper.find('[data-testid="lane-prompt-save"]').trigger("click");
     await settle(wrapper);
     expect(api.put).toHaveBeenCalledWith("/api/lane-prompts/advisor", { prompt: "Custom advisor prompt" });
-    expect(wrapper.find('[data-testid="lane-prompt-status"]').text()).toContain("next conversation turn");
-    expect(wrapper.text()).toContain("Current version: v2");
+    expect(wrapper.find('[data-testid="lane-prompt-status"]').text()).toContain("已保存");
+    expect(wrapper.find('[data-testid="lane-prompt-history"]').text()).toContain("当前生效：v2");
+    expect(wrapper.find('[data-testid="lane-prompt-history"] details').exists()).toBe(false);
 
     await wrapper.find('[data-testid="lane-prompt-lane-worker"]').trigger("click");
     expect((wrapper.find('[data-testid="lane-prompt-editor"]').element as HTMLTextAreaElement).value).toBe(workerPrompt);
+    wrapper.unmount();
+  });
+
+  it("selects a historical prompt version and restores it as a new active version", async () => {
+    const advisorBase = "Advisor baseline prompt";
+    const advisorCustom = "Advisor custom prompt";
+    const snapshots: LanePromptSnapshot[] = [
+      {
+        lane: "advisor",
+        current: { lane: "advisor", version: 2, prompt: advisorCustom, isBase: false, createdAt: 2 },
+        base: { lane: "advisor", version: 1, prompt: advisorBase, isBase: true, createdAt: 1 },
+        versions: [
+          { lane: "advisor", version: 2, prompt: advisorCustom, isBase: false, createdAt: 2 },
+          { lane: "advisor", version: 1, prompt: advisorBase, isBase: true, createdAt: 1 },
+        ],
+        updatedAt: 2,
+      },
+      {
+        lane: "worker",
+        current: { lane: "worker", version: 1, prompt: "Worker baseline prompt", isBase: true, createdAt: 1 },
+        base: { lane: "worker", version: 1, prompt: "Worker baseline prompt", isBase: true, createdAt: 1 },
+        versions: [{ lane: "worker", version: 1, prompt: "Worker baseline prompt", isBase: true, createdAt: 1 }],
+        updatedAt: 1,
+      },
+    ];
+    const restored = {
+      ...snapshots[0],
+      current: { lane: "advisor", version: 3, prompt: advisorBase, isBase: false, createdAt: 3 },
+      versions: [
+        { lane: "advisor", version: 3, prompt: advisorBase, isBase: false, createdAt: 3 },
+        ...snapshots[0].versions,
+      ],
+      updatedAt: 3,
+    } satisfies LanePromptSnapshot;
+    const api = {
+      get: vi.fn().mockImplementation((path: string) =>
+        Promise.resolve(path === "/api/lane-prompts" ? snapshots : []),
+      ),
+      post: vi.fn(),
+      patch: vi.fn(),
+      put: vi.fn().mockResolvedValue(restored),
+      delete: vi.fn(),
+    };
+
+    const wrapper = mount(ModelManager, {
+      props: { api: api as any, initialTab: "lane-prompts" },
+      global: { stubs: { "el-icon": true } },
+    });
+    await settle(wrapper);
+
+    const versionSelect = wrapper.find('[data-testid="lane-prompt-version-select"]');
+    expect(versionSelect.findAll("option").map((option) => option.text())).toEqual([
+      expect.stringContaining("当前生效"),
+      expect.stringContaining("初始默认"),
+    ]);
+
+    await versionSelect.setValue(1);
+    await settle(wrapper);
+    expect((wrapper.find('[data-testid="lane-prompt-editor"]').element as HTMLTextAreaElement).value).toBe(advisorBase);
+    expect(wrapper.find('[data-testid="lane-prompt-version-notice"]').text()).toContain("当前生效版本为 v2");
+    expect(wrapper.find('[data-testid="lane-prompt-restore"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="lane-prompt-save"]').attributes("disabled")).toBeDefined();
+
+    await wrapper.find('[data-testid="lane-prompt-restore"]').trigger("click");
+    await settle(wrapper);
+    expect(api.put).toHaveBeenCalledWith("/api/lane-prompts/advisor", { prompt: advisorBase });
+    expect((wrapper.find('[data-testid="lane-prompt-editor"]').element as HTMLTextAreaElement).value).toBe(advisorBase);
+    expect(wrapper.find('[data-testid="lane-prompt-history"]').text()).toContain("当前生效：v3");
+    expect(wrapper.find('[data-testid="lane-prompt-version-notice"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="lane-prompt-status"]').text()).toContain("已恢复 v1");
+
+    wrapper.unmount();
+  });
+
+  it("switches between the prompt and model configuration settings tabs", async () => {
+    const api = {
+      get: vi.fn().mockImplementation((path: string) =>
+        Promise.resolve(path === "/api/model-configs" ? [makeModel("gpt-5.2", "GPT 5.2", "openai")] : []),
+      ),
+      post: vi.fn(),
+      patch: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+    };
+
+    const wrapper = mount(ModelManager, {
+      props: { api: api as any, initialTab: "lane-prompts" },
+      global: { stubs: { "el-icon": true } },
+    });
+    await settle(wrapper);
+
+    expect(wrapper.find('[data-testid="settings-tab-prompts"]').attributes("aria-selected")).toBe("true");
+    expect(wrapper.find('[data-testid="lane-prompt-panel"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="settings-models-panel"]').exists()).toBe(false);
+
+    await wrapper.find('[data-testid="settings-tab-models"]').trigger("click");
+    expect(wrapper.find('[data-testid="settings-models-panel"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="lane-prompt-panel"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="settings-tab-models"]').attributes("aria-selected")).toBe("true");
+
     wrapper.unmount();
   });
 

--- a/client/src/__tests__/model-selector-persistence.test.ts
+++ b/client/src/__tests__/model-selector-persistence.test.ts
@@ -221,7 +221,7 @@ describe("Model selector persistence", () => {
       await settleUi(wrapper);
 
       expect(modelFetchCount).toBeGreaterThanOrEqual(1);
-      await wrapper.find('[data-testid="model-manager-open"]').trigger("click");
+      await wrapper.find('[data-testid="settings-open"]').trigger("click");
       await settleUi(wrapper);
 
       runtimeModels = [

--- a/client/src/components/ModelManager.vue
+++ b/client/src/components/ModelManager.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref } from "vue";
+import { computed, onMounted, reactive, ref, watch } from "vue";
 import { Close, EditPen, Plus, Refresh, StarFilled } from "@element-plus/icons-vue";
 
 import type { ApiClient } from "../api/client";
@@ -15,14 +15,18 @@ type ModelForm = {
   configJsonText: string;
 };
 
+type SettingsTab = "lane-prompts" | "models";
+
 const props = withDefaults(
   defineProps<{
     api: ApiClient;
     agent?: string | null;
     showHeader?: boolean;
+    initialTab?: SettingsTab;
   }>(),
   {
     showHeader: true,
+    initialTab: "models",
   },
 );
 
@@ -41,9 +45,10 @@ const editingId = ref<string | null>(null);
 const dialogOpen = ref(false);
 const pendingDeleteId = ref<string | null>(null);
 const selectedModelId = ref<string | null>(null);
-const activeTab = ref<"models" | "lane-prompts">("models");
+const activeTab = ref<SettingsTab>(props.initialTab);
 const lanePromptSnapshots = ref<LanePromptSnapshot[]>([]);
 const selectedLane = ref<LaneName>("advisor");
+const selectedVersion = ref<number | null>(null);
 const lanePromptText = ref("");
 const lanePromptLoading = ref(false);
 const lanePromptSaving = ref(false);
@@ -104,7 +109,10 @@ const sortedModels = computed(() => {
 const enabledCount = computed(() => modelConfigs.value.filter((m) => m.isEnabled).length);
 const busy = computed(() => saving.value || loading.value || busyRowId.value !== null);
 const isEditing = computed(() => Boolean(editingId.value));
-const managerTitle = computed(() => (props.agent ? "模型" : "模型管理"));
+const managerTitle = computed(() => (props.agent ? "模型" : "系统设置"));
+const managerSubtitle = computed(() =>
+  props.agent ? "统一 Codex 引擎；保存后输入框下拉会立即刷新。" : "管理角色指令与模型配置。",
+);
 const editingCurrentDefault = computed(
   () => Boolean(editingId.value) && modelConfigs.value.some((model) => model.id === editingId.value && model.isDefault),
 );
@@ -126,7 +134,49 @@ const selectedLaneSnapshot = computed(() =>
   lanePromptSnapshots.value.find((snapshot) => snapshot.lane === selectedLane.value) ?? null,
 );
 
-const lanePromptDirty = computed(() => lanePromptText.value !== (selectedLaneSnapshot.value?.current.prompt ?? ""));
+const lanePromptVersions = computed(() => {
+  const snapshot = selectedLaneSnapshot.value;
+  if (!snapshot) return [];
+  const historical = snapshot.versions
+    .filter((version) => version.version !== snapshot.current.version)
+    .sort((a, b) => b.version - a.version);
+  return [snapshot.current, ...historical];
+});
+
+const selectedLaneVersion = computed(() => {
+  const snapshot = selectedLaneSnapshot.value;
+  if (!snapshot) return null;
+  if (selectedVersion.value === null) return snapshot.current;
+  return snapshot.versions.find((version) => version.version === selectedVersion.value) ?? snapshot.current;
+});
+
+const isViewingHistoricalVersion = computed(() => {
+  const snapshot = selectedLaneSnapshot.value;
+  const version = selectedLaneVersion.value;
+  return Boolean(snapshot && version && version.version !== snapshot.current.version);
+});
+
+const lanePromptDirty = computed(() => lanePromptText.value !== (selectedLaneVersion.value?.prompt ?? ""));
+
+function formatVersionTimestamp(createdAt: number): string {
+  if (!Number.isFinite(createdAt) || createdAt <= 0) return "未知时间";
+  return new Intl.DateTimeFormat("zh-CN", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(createdAt));
+}
+
+function versionLabel(version: LanePromptSnapshot["current"]): string {
+  const snapshot = selectedLaneSnapshot.value;
+  const suffixes = [
+    snapshot?.current.version === version.version ? "（当前生效）" : null,
+    version.isBase ? "（初始默认）" : null,
+  ].filter((suffix): suffix is string => suffix !== null);
+  const suffix = suffixes.length > 0 ? ` ${suffixes.join(" ")}` : "";
+  return `v${version.version} · ${formatVersionTimestamp(version.createdAt)}${suffix}`;
+}
 
 async function loadModelConfigs(): Promise<void> {
   loading.value = true;
@@ -147,6 +197,7 @@ async function loadLanePrompts(): Promise<void> {
   lanePromptError.value = null;
   try {
     lanePromptSnapshots.value = await props.api.get<LanePromptSnapshot[]>("/api/lane-prompts");
+    selectedVersion.value = null;
     lanePromptText.value = selectedLaneSnapshot.value?.current.prompt ?? "";
   } catch (err) {
     lanePromptError.value = err instanceof Error ? err.message : String(err);
@@ -157,31 +208,43 @@ async function loadLanePrompts(): Promise<void> {
 
 function selectLane(lane: LaneName): void {
   selectedLane.value = lane;
+  selectedVersion.value = null;
   lanePromptText.value = lanePromptSnapshots.value.find((snapshot) => snapshot.lane === lane)?.current.prompt ?? "";
   lanePromptError.value = null;
   lanePromptStatus.value = null;
 }
 
-async function saveLanePrompt(): Promise<void> {
-  if (lanePromptSaving.value || !lanePromptText.value.trim()) return;
+async function persistLanePrompt(prompt: string, successMessage: string): Promise<void> {
+  if (lanePromptSaving.value || !prompt.trim()) return;
   lanePromptSaving.value = true;
   lanePromptError.value = null;
   lanePromptStatus.value = null;
   try {
     const snapshot = await props.api.put<LanePromptSnapshot>(
       `/api/lane-prompts/${encodeURIComponent(selectedLane.value)}`,
-      { prompt: lanePromptText.value },
+      { prompt },
     );
     lanePromptSnapshots.value = lanePromptSnapshots.value.map((item) =>
       item.lane === snapshot.lane ? snapshot : item,
     );
+    selectedVersion.value = null;
     lanePromptText.value = snapshot.current.prompt;
-    lanePromptStatus.value = "Saved. It applies to the next conversation turn.";
+    lanePromptStatus.value = successMessage;
   } catch (err) {
     lanePromptError.value = err instanceof Error ? err.message : String(err);
   } finally {
     lanePromptSaving.value = false;
   }
+}
+
+async function saveLanePrompt(): Promise<void> {
+  await persistLanePrompt(lanePromptText.value, "已保存，将从下一轮对话开始生效。");
+}
+
+async function restoreLanePrompt(): Promise<void> {
+  const version = selectedLaneVersion.value;
+  if (!isViewingHistoricalVersion.value || !version) return;
+  await persistLanePrompt(version.prompt, `已恢复 v${version.version}，并创建新的活动版本。`);
 }
 
 async function resetLanePrompt(): Promise<void> {
@@ -196,6 +259,7 @@ async function resetLanePrompt(): Promise<void> {
     lanePromptSnapshots.value = lanePromptSnapshots.value.map((item) =>
       item.lane === snapshot.lane ? snapshot : item,
     );
+    selectedVersion.value = null;
     lanePromptText.value = snapshot.current.prompt;
     lanePromptStatus.value = "Reset to the default prompt.";
   } catch (err) {
@@ -204,6 +268,18 @@ async function resetLanePrompt(): Promise<void> {
     lanePromptSaving.value = false;
   }
 }
+
+watch(selectedVersion, (version) => {
+  const snapshot = selectedLaneSnapshot.value;
+  if (!snapshot) return;
+  const selected = version === null
+    ? snapshot.current
+    : snapshot.versions.find((item) => item.version === version) ?? snapshot.current;
+  if (lanePromptText.value === selected.prompt) return;
+  lanePromptText.value = selected.prompt;
+  lanePromptError.value = null;
+  lanePromptStatus.value = null;
+});
 
 function closeDialog(): void {
   editingId.value = null;
@@ -367,14 +443,15 @@ defineExpose({
 </script>
 
 <template>
-  <section class="modelManager" data-testid="model-manager">
+  <section class="modelManager" data-testid="settings-panel" data-component="model-manager">
     <header v-if="showHeader" class="modelHeader" data-drag-handle>
       <div class="modelHeaderTitle">
         <div class="modelTitle">{{ managerTitle }}</div>
-        <div class="modelSubtitle">统一 Codex 引擎；保存后输入框下拉会立即刷新。</div>
+        <div class="modelSubtitle">{{ managerSubtitle }}</div>
       </div>
       <div class="modelHeaderActions">
         <button
+          v-if="activeTab === 'models'"
           type="button"
           class="addBtn"
           :disabled="busy"
@@ -384,7 +461,14 @@ defineExpose({
           <el-icon :size="13" aria-hidden="true"><Plus /></el-icon>
           <span>新增模型</span>
         </button>
-        <button class="modelIconBtn" type="button" title="刷新" :disabled="busy" @click="loadModelConfigs">
+        <button
+          v-if="activeTab === 'models'"
+          class="modelIconBtn"
+          type="button"
+          title="刷新模型配置"
+          :disabled="busy"
+          @click="loadModelConfigs"
+        >
           <el-icon :size="16" aria-hidden="true"><Refresh /></el-icon>
         </button>
         <button class="modelIconBtn" type="button" title="关闭" @click="emit('close')">
@@ -393,37 +477,52 @@ defineExpose({
       </div>
     </header>
 
-    <nav class="managerTabs" role="tablist" aria-label="Settings sections">
+    <nav class="settingsTabs" role="tablist" aria-label="系统设置分区" data-testid="settings-tabs">
       <button
         type="button"
         role="tab"
-        class="managerTab"
-        :class="{ active: activeTab === 'models' }"
-        :aria-selected="activeTab === 'models'"
-        data-testid="model-manager-tab-models"
-        @click="activeTab = 'models'"
+        id="settings-tab-lane-prompts"
+        class="settingsTab"
+        :class="{ active: activeTab === 'lane-prompts' }"
+        :aria-selected="activeTab === 'lane-prompts'"
+        aria-controls="settings-panel-lane-prompts"
+        data-testid="settings-tab-prompts"
+        @click="activeTab = 'lane-prompts'"
       >
-        Models
+        角色指令
       </button>
       <button
         type="button"
         role="tab"
-        class="managerTab"
-        :class="{ active: activeTab === 'lane-prompts' }"
-        :aria-selected="activeTab === 'lane-prompts'"
-        data-testid="model-manager-tab-lane-prompts"
-        @click="activeTab = 'lane-prompts'"
+        id="settings-tab-models"
+        class="settingsTab"
+        :class="{ active: activeTab === 'models' }"
+        :aria-selected="activeTab === 'models'"
+        aria-controls="settings-panel-models"
+        data-testid="settings-tab-models"
+        @click="activeTab = 'models'"
       >
-        Lane Prompts
+        模型配置
       </button>
     </nav>
 
-    <div v-if="error && !dialogOpen && activeTab === 'models'" class="modelBanner error" data-testid="model-manager-error">{{ error }}</div>
+    <div
+      v-if="error && !dialogOpen && activeTab === 'models'"
+      class="modelBanner error"
+      data-testid="model-manager-error"
+    >{{ error }}</div>
     <div v-else-if="statusMessage && !dialogOpen" class="modelBanner success" data-testid="model-manager-status">
       {{ statusMessage }}
     </div>
 
-    <div v-if="activeTab === 'models'" class="cliList">
+    <div
+      v-if="activeTab === 'models'"
+      id="settings-panel-models"
+      class="cliList"
+      role="tabpanel"
+      aria-labelledby="settings-tab-models"
+      data-testid="settings-models-panel"
+    >
       <div class="modelListHeader">
         <span class="modelListCount">共 {{ sortedModels.length }} 个模型 · {{ enabledCount }} 已启用</span>
         <button
@@ -538,7 +637,14 @@ defineExpose({
       <p class="listFoot">未设置默认模型时优先使用列表中的第一个已启用模型。</p>
     </div>
 
-    <div v-else class="lanePromptPanel" data-testid="lane-prompt-panel">
+    <div
+      v-else
+      id="settings-panel-lane-prompts"
+      class="lanePromptPanel"
+      role="tabpanel"
+      aria-labelledby="settings-tab-lane-prompts"
+      data-testid="lane-prompt-panel"
+    >
       <div class="lanePromptLaneSelector" role="tablist" aria-label="Agent lanes">
         <button
           type="button"
@@ -566,6 +672,47 @@ defineExpose({
       <div v-if="lanePromptStatus" class="modelBanner success" data-testid="lane-prompt-status">{{ lanePromptStatus }}</div>
       <div v-if="lanePromptLoading" class="lanePromptLoading">Loading lane prompts...</div>
       <template v-else>
+        <div class="lanePromptEditorHeader">
+          <div>
+            <div class="lanePromptEditorTitle">角色指令</div>
+            <div class="lanePromptEditorSubtitle">配置 Advisor 与 Worker 的系统边界和工作方式。</div>
+          </div>
+          <label class="lanePromptVersionField">
+            <span class="modelLabel">版本</span>
+            <select
+              v-model="selectedVersion"
+              class="lanePromptVersionSelect"
+              data-testid="lane-prompt-version-select"
+              :disabled="lanePromptSaving"
+            >
+              <option
+                v-for="version in lanePromptVersions"
+                :key="`${version.lane}-${version.version}`"
+                :value="version.version === selectedLaneSnapshot?.current.version ? null : version.version"
+              >
+                {{ versionLabel(version) }}
+              </option>
+            </select>
+          </label>
+        </div>
+        <div
+          v-if="isViewingHistoricalVersion && selectedLaneVersion"
+          class="lanePromptVersionNotice"
+          data-testid="lane-prompt-version-notice"
+        >
+          <div>
+            正在查看 v{{ selectedLaneVersion.version }}；当前生效版本为 v{{ selectedLaneSnapshot?.current.version }}。
+          </div>
+          <button
+            type="button"
+            class="btnSecondary"
+            :disabled="lanePromptSaving"
+            data-testid="lane-prompt-restore"
+            @click="restoreLanePrompt"
+          >
+            {{ lanePromptSaving ? "恢复中…" : "回滚到此版本（Restore）" }}
+          </button>
+        </div>
         <label class="modelField lanePromptField">
           <span class="modelLabel">{{ selectedLane === 'advisor' ? 'Advisor' : 'Worker' }} system prompt</span>
           <textarea
@@ -586,19 +733,9 @@ defineExpose({
           </button>
         </div>
         <div v-if="selectedLaneSnapshot" class="lanePromptHistory" data-testid="lane-prompt-history">
-          <div class="lanePromptMeta">
-            <span>Current version: v{{ selectedLaneSnapshot.current.version }}</span>
-            <span>Default version: v{{ selectedLaneSnapshot.base.version }}</span>
-            <span>{{ selectedLaneSnapshot.versions.length }} saved version(s)</span>
-          </div>
-          <details>
-            <summary>Version history</summary>
-            <ul>
-              <li v-for="version in selectedLaneSnapshot.versions" :key="`${version.lane}-${version.version}`">
-                v{{ version.version }}{{ version.isBase ? " (default)" : "" }} · {{ new Date(version.createdAt).toLocaleString() }}
-              </li>
-            </ul>
-          </details>
+          <span>{{ lanePromptText.length }} 个字符</span>
+          <span>当前生效：v{{ selectedLaneSnapshot.current.version }}</span>
+          <span v-if="isViewingHistoricalVersion">正在查看：v{{ selectedLaneVersion?.version }}</span>
         </div>
       </template>
     </div>
@@ -796,7 +933,7 @@ defineExpose({
   color: #047857;
 }
 
-.managerTabs {
+.settingsTabs {
   flex: 0 0 auto;
   display: flex;
   gap: 4px;
@@ -804,7 +941,7 @@ defineExpose({
   border-bottom: 1px solid var(--border);
 }
 
-.managerTab,
+.settingsTab,
 .lanePromptLane {
   border: none;
   background: transparent;
@@ -814,17 +951,17 @@ defineExpose({
   font-weight: 700;
 }
 
-.managerTab {
+.settingsTab {
   padding: 8px 12px 10px;
   border-bottom: 2px solid transparent;
 }
 
-.managerTab.active,
+.settingsTab.active,
 .lanePromptLane.active {
   color: var(--accent);
 }
 
-.managerTab.active {
+.settingsTab.active {
   border-bottom-color: var(--accent);
 }
 
@@ -833,6 +970,68 @@ defineExpose({
   min-height: 0;
   overflow-y: auto;
   padding: 14px 16px 18px;
+}
+
+.lanePromptEditorHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.lanePromptEditorTitle {
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.lanePromptEditorSubtitle {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.lanePromptVersionField {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.lanePromptVersionField .modelLabel {
+  margin-bottom: 7px;
+}
+
+.lanePromptVersionSelect {
+  min-width: 230px;
+  height: 30px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0 8px;
+}
+
+.lanePromptVersionSelect:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.lanePromptVersionNotice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  border-radius: 9px;
+  padding: 9px 11px;
+  background: rgba(37, 99, 235, 0.06);
+  color: var(--muted);
+  font-size: 11px;
 }
 
 .lanePromptLaneSelector {
@@ -883,6 +1082,9 @@ defineExpose({
 }
 
 .lanePromptHistory {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
   margin-top: 18px;
   border-top: 1px solid var(--border);
   padding-top: 12px;
@@ -890,25 +1092,35 @@ defineExpose({
   font-size: 11px;
 }
 
-.lanePromptMeta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 16px;
-}
+@media (max-width: 640px) {
+  .lanePromptEditorHeader {
+    flex-direction: column;
+    gap: 10px;
+  }
 
-.lanePromptHistory details {
-  margin-top: 10px;
-}
+  .lanePromptVersionField {
+    align-items: center;
+    width: 100%;
+  }
 
-.lanePromptHistory summary {
-  cursor: pointer;
-  color: var(--text);
-  font-weight: 700;
-}
+  .lanePromptVersionField .modelLabel {
+    margin-bottom: 0;
+  }
 
-.lanePromptHistory ul {
-  margin: 8px 0 0;
-  padding-left: 18px;
+  .lanePromptVersionSelect {
+    min-width: 0;
+    flex: 1 1 auto;
+    width: 100%;
+  }
+
+  .lanePromptVersionNotice {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .lanePromptVersionNotice .btnSecondary {
+    width: 100%;
+  }
 }
 
 /* ---------- list ---------- */


### PR DESCRIPTION
## Summary

- elevate the gear entry point into a unified Settings surface
- expose Lane Prompts and Model Configs as primary settings tabs on desktop and mobile
- add interactive lane prompt version selection and restore-as-new-version flow
- update focused frontend coverage for navigation, tabs, and rollback behavior

## Validation

- npm run lint
- tsc -p tsconfig.json --noEmit
- npm run build
- npm run test:web
- CODEX_HOME=/tmp/ads-issue-173-empty-codex-home npm test

Closes #173