### PR TITLE
feat(ui): show advisor and worker activity

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -411,6 +411,7 @@
   color: rgba(255, 255, 255, 0.9);
 }
 .projectStatus {
+  --project-status-center: #ffffff;
   width: 14px;
   height: 14px;
   border-radius: 999px;
@@ -440,6 +441,7 @@
   background: transparent;
 }
 .projectNode.active .projectStatus {
+  --project-status-center: #2f80ff;
   border-color: rgba(255, 255, 255, 0.8);
 }
 .projectNode.active .projectStatus.spinning {
@@ -448,6 +450,29 @@
 }
 .projectNode.active .projectStatus.spinning::after {
   background: transparent;
+}
+.projectStatus.spinning--advisor,
+.projectNode.active .projectStatus.spinning--advisor {
+  border-color: #a855f7;
+  border-top-color: transparent;
+}
+.projectStatus.spinning--worker,
+.projectNode.active .projectStatus.spinning--worker {
+  border-color: #10b981;
+  border-top-color: transparent;
+}
+.projectStatus.spinning--both,
+.projectNode.active .projectStatus.spinning--both {
+  border-color: transparent;
+  background: conic-gradient(#a855f7 0deg 180deg, #10b981 180deg 360deg);
+}
+.projectStatus.spinning--both::after,
+.projectNode.active .projectStatus.spinning--both::after {
+  inset: 2px;
+  width: auto;
+  height: auto;
+  margin: 0;
+  background: var(--project-status-center);
 }
 .projectText {
   display: flex;
@@ -637,6 +662,24 @@
 
 .laneTabStatusDot--disconnected {
   background: #94a3b8;
+}
+
+.laneTabBusySpinner {
+  width: 10px;
+  height: 10px;
+  flex: 0 0 10px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.laneTabBusySpinner--advisor {
+  color: #a855f7;
+}
+
+.laneTabBusySpinner--worker {
+  color: #10b981;
 }
 
 .laneTab.active {

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -46,6 +46,7 @@ const {
   reorderProjects,
   removeProject,
   getRuntime,
+  getPlannerRuntime,
   connectWs,
   runtimeProjectInProgress,
   formatProjectBranch,
@@ -191,6 +192,30 @@ const {
   resumeTaskThread,
   listResumableSessions,
 });
+
+type ProjectBusyState = "idle" | "advisor" | "worker" | "both";
+
+function projectBusyState(projectId: string): ProjectBusyState {
+  const advisorBusy = runtimeProjectInProgress(getPlannerRuntime(projectId));
+  const workerBusy = runtimeProjectInProgress(getRuntime(projectId));
+  if (advisorBusy && workerBusy) return "both";
+  if (advisorBusy) return "advisor";
+  if (workerBusy) return "worker";
+  return "idle";
+}
+
+function projectStatusClass(projectId: string): string {
+  const state = projectBusyState(projectId);
+  return state === "idle" ? "" : `spinning spinning--${state}`;
+}
+
+function projectStatusTitle(projectId: string): string | undefined {
+  const state = projectBusyState(projectId);
+  if (state === "advisor") return "Advisor 正在规划…";
+  if (state === "worker") return "Worker 正在执行…";
+  if (state === "both") return "Advisor 与 Worker 均在运行中…";
+  return undefined;
+}
 
 /**
  * Browsing the list is read-only and always allowed; only the resume action is
@@ -376,6 +401,7 @@ const {
 } = useProjectSidebar({
   projects,
   getRuntime,
+  getPlannerRuntime,
   runtimeProjectInProgress,
   requestProjectSwitch: requestProjectSwitchFromMobile,
   reorderProjects,
@@ -573,7 +599,12 @@ const plannerConnectionStatus = computed(() => {
               @dragover="(ev) => onProjectDragOver(ev, p.id)"
               @drop="(ev) => onProjectDrop(ev, p.id)"
             >
-              <span class="projectStatus" :class="{ spinning: runtimeProjectInProgress(getRuntime(p.id)) }" />
+              <span
+                class="projectStatus"
+                :class="projectStatusClass(p.id)"
+                :title="projectStatusTitle(p.id)"
+                :data-testid="`project-status-${p.id}`"
+              />
               <span class="projectText">
                 <span class="projectName">{{ p.name }}</span>
                 <span class="projectBranch">{{ formatProjectBranch(p.branch) }}</span>
@@ -649,6 +680,13 @@ const plannerConnectionStatus = computed(() => {
               aria-hidden="true"
             />
             <span class="laneTabLabel">{{ tab.label }}</span>
+            <span
+              v-if="tab.id === 'planner' ? plannerBusy : agentBusy"
+              class="laneTabBusySpinner"
+              :class="tab.id === 'planner' ? 'laneTabBusySpinner--advisor' : 'laneTabBusySpinner--worker'"
+              :data-testid="`lane-tab-busy-${tab.id}`"
+              aria-hidden="true"
+            />
           </button>
           <span v-if="!isMobile" class="laneTabSpacer" />
           <button

--- a/client/src/__tests__/app-remove-project.test.ts
+++ b/client/src/__tests__/app-remove-project.test.ts
@@ -256,4 +256,28 @@ describe("App.removeProject", () => {
     expect(idsFromVm(wrapper as any)).toEqual(["default", "p1", "p2"]);
     wrapper.unmount();
   });
+
+  it("blocks removal while the Advisor runtime is busy", async () => {
+    projectsFromApi = [
+      { id: "p1", workspaceRoot: "/w/p1", name: "P1", chatSessionId: "main", createdAt: 1, updatedAt: 1 },
+      { id: "p2", workspaceRoot: "/w/p2", name: "P2", chatSessionId: "main", createdAt: 2, updatedAt: 2 },
+    ];
+    activeProjectIdFromApi = "p2";
+
+    const App = (await import("../App.vue")).default;
+    const wrapper = shallowMount(App, { global: { stubs: { LoginGate: false } } });
+    await waitForProjectIds(wrapper as any, ["default", "p1", "p2"]);
+
+    const plannerRuntime = (wrapper.vm as any).getPlannerRuntime("p2") as { busy: { value: boolean } };
+    plannerRuntime.busy.value = true;
+    await settleUi(wrapper);
+
+    const removeButton = wrapper.find('[data-testid="project-remove"]');
+    expect(removeButton.classes()).toContain("disabled");
+    await removeButton.trigger("click");
+    expect((wrapper.vm as any).projectRemoveConfirmOpen).toBe(false);
+    expect(deleteCalls).toEqual([]);
+
+    wrapper.unmount();
+  });
 });

--- a/client/src/__tests__/project-status-spinner.test.ts
+++ b/client/src/__tests__/project-status-spinner.test.ts
@@ -87,7 +87,7 @@ describe("project status spinner", () => {
     vi.clearAllMocks();
   });
 
-  it("shows spinner while a conversation is in progress", async () => {
+  it("shows lane-specific and combined project activity states", async () => {
     const App = (await import("../App.vue")).default;
     const wrapper = shallowMount(App, { global: { stubs: { LoginGate: false } } });
     await settleUi(wrapper);
@@ -95,19 +95,43 @@ describe("project status spinner", () => {
     const pid = String((wrapper.vm as any).activeProjectId ?? "").trim();
     expect(pid).not.toBe("");
 
-    const rt = (wrapper.vm as any).getRuntime(pid) as { busy: { value: boolean } };
-    rt.busy.value = false;
+    const workerRuntime = (wrapper.vm as any).getRuntime(pid) as { busy: { value: boolean } };
+    const plannerRuntime = (wrapper.vm as any).getPlannerRuntime(pid) as { busy: { value: boolean } };
+    workerRuntime.busy.value = false;
+    plannerRuntime.busy.value = false;
     await settleUi(wrapper);
 
     expect(wrapper.find(".projectStatus").classes("spinning")).toBe(false);
+    expect(wrapper.find(".laneTabBusySpinner").exists()).toBe(false);
 
-    rt.busy.value = true;
+    plannerRuntime.busy.value = true;
     await settleUi(wrapper);
-    expect(wrapper.find(".projectStatus").classes("spinning")).toBe(true);
+    const projectStatus = wrapper.find(".projectStatus");
+    expect(projectStatus.classes()).toEqual(expect.arrayContaining(["spinning", "spinning--advisor"]));
+    expect(projectStatus.attributes("title")).toBe("Advisor 正在规划…");
+    expect(wrapper.find('[data-testid="lane-tab-busy-planner"]').classes()).toEqual(
+      expect.arrayContaining(["laneTabBusySpinner", "laneTabBusySpinner--advisor"]),
+    );
+    expect(wrapper.find('[data-testid="lane-tab-busy-worker"]').exists()).toBe(false);
 
-    rt.busy.value = false;
+    workerRuntime.busy.value = true;
     await settleUi(wrapper);
-    expect(wrapper.find(".projectStatus").classes("spinning")).toBe(false);
+    expect(projectStatus.classes()).toEqual(expect.arrayContaining(["spinning", "spinning--both"]));
+    expect(projectStatus.attributes("title")).toBe("Advisor 与 Worker 均在运行中…");
+    expect(wrapper.find('[data-testid="lane-tab-busy-worker"]').classes()).toEqual(
+      expect.arrayContaining(["laneTabBusySpinner", "laneTabBusySpinner--worker"]),
+    );
+
+    plannerRuntime.busy.value = false;
+    await settleUi(wrapper);
+    expect(projectStatus.classes()).toEqual(expect.arrayContaining(["spinning", "spinning--worker"]));
+    expect(projectStatus.classes("spinning--advisor")).toBe(false);
+    expect(projectStatus.attributes("title")).toBe("Worker 正在执行…");
+
+    workerRuntime.busy.value = false;
+    await settleUi(wrapper);
+    expect(projectStatus.classes("spinning")).toBe(false);
+    expect(projectStatus.attributes("title")).toBeUndefined();
 
     wrapper.unmount();
   });

--- a/client/src/app/projectsWs/projectActions.ts
+++ b/client/src/app/projectsWs/projectActions.ts
@@ -28,6 +28,7 @@ export function createProjectActions(ctx: AppContext & ChatActions, deps: Projec
     activeProject,
     activeRuntime,
     getRuntime,
+    getPlannerRuntime,
     normalizeProjectId,
     runtimeProjectInProgress,
     busy,
@@ -287,7 +288,8 @@ export function createProjectActions(ctx: AppContext & ChatActions, deps: Projec
 
     const pid = normalizeProjectId(targetId);
     const rt = getRuntime(pid);
-    if (runtimeProjectInProgress(rt)) {
+    const plannerRt = getPlannerRuntime(pid);
+    if (runtimeProjectInProgress(rt) || runtimeProjectInProgress(plannerRt)) {
       apiError.value = "Project is busy; cannot remove right now.";
       return;
     }

--- a/client/src/composables/app/useProjectSidebar.ts
+++ b/client/src/composables/app/useProjectSidebar.ts
@@ -8,6 +8,7 @@ type ProjectLike = {
 export function useProjectSidebar(params: {
   projects: Ref<ProjectLike[]>;
   getRuntime: (projectId: string) => unknown;
+  getPlannerRuntime: (projectId: string) => unknown;
   runtimeProjectInProgress: (runtime: unknown) => boolean;
   requestProjectSwitch: (projectId: string) => void;
   reorderProjects: (ids: string[]) => Promise<void>;
@@ -114,7 +115,10 @@ export function useProjectSidebar(params: {
   function canRemoveProject(id: string): boolean {
     const projectId = String(id ?? "").trim();
     if (!projectId || projectId === "default") return false;
-    return !params.runtimeProjectInProgress(params.getRuntime(projectId));
+    return (
+      !params.runtimeProjectInProgress(params.getRuntime(projectId)) &&
+      !params.runtimeProjectInProgress(params.getPlannerRuntime(projectId))
+    );
   }
 
   function requestRemoveProject(id: string): void {
@@ -134,6 +138,7 @@ export function useProjectSidebar(params: {
     projectRemoveConfirmOpen.value = false;
     pendingRemoveProjectId.value = null;
     if (!projectId) return;
+    if (!canRemoveProject(projectId)) return;
     await params.removeProject(projectId);
   }
 


### PR DESCRIPTION
## Summary

- distinguish Advisor, Worker, and combined busy states in the project sidebar
- show lane-specific busy spinners on the Advisor and Worker tabs
- prevent project removal while either lane is active

## Validation

- npm run lint
- ./node_modules/.bin/tsc -p tsconfig.json --noEmit
- npm run build
- npm run test:web (460 tests)
- npm test (721 tests)

Closes #174