### PR TITLE
feat(ui): improve mobile typography

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>ADS Tasks</title>
 
     <!-- PWA: iOS 独立 App 全屏支持 -->

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1093,3 +1093,13 @@
     white-space: nowrap;
   }
 }
+
+@media (max-width: 768px) {
+  .brandVersion,
+  .projectBranch,
+  .mobileContextMenuTitle,
+  .mobileContextActionHint,
+  .mobileDrawerSubitemText small {
+    font-size: 12px;
+  }
+}

--- a/client/src/__tests__/mobile-typography.test.ts
+++ b/client/src/__tests__/mobile-typography.test.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+function readUtf8(relFromThisFile: string): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return fs.readFileSync(path.resolve(here, relFromThisFile), "utf8");
+}
+
+describe("mobile typography", () => {
+  it("allows the browser to zoom the PWA viewport", () => {
+    const html = readUtf8("../../index.html");
+
+    expect(html).toContain(
+      '<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />',
+    );
+    expect(html).not.toMatch(/maximum-scale\s*=\s*1(?:\.0)?/);
+    expect(html).not.toMatch(/user-scalable\s*=\s*no/);
+  });
+
+  it("keeps compact desktop Markdown styles and adds readable mobile sizes", () => {
+    const sfc = readUtf8("../components/MarkdownContent.vue");
+
+    expect(sfc).toMatch(/\.md\s*\{[\s\S]*?font-size:\s*13px\s*;/);
+    expect(sfc).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.md\s*\{[\s\S]*?font-size:\s*16px\s*;/);
+    expect(sfc).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.md\s*:deep\(h1\)\s*\{[\s\S]*?font-size:\s*19px\s*;/);
+    expect(sfc).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.md\s*:deep\(h2\)\s*\{[\s\S]*?font-size:\s*17px\s*;/);
+    expect(sfc).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.md\s*:deep\(h3\)[\s\S]*?font-size:\s*16px\s*;/);
+    expect(sfc).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.md\s*:deep\(\.md-codeblock pre > code\)[\s\S]*?font-size:\s*14px\s*;/);
+  });
+
+  it("enlarges mobile command output and metadata", () => {
+    const sfc = readUtf8("../components/MainChatMessageList.vue");
+
+    expect(sfc).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.execute-output[\s\S]*?font-size:\s*14px\s*;/);
+    expect(sfc).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.patchCardDiff[\s\S]*?font-size:\s*14px\s*;/);
+    expect(sfc).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.msgTime[\s\S]*?font-size:\s*12px\s*;/);
+    expect(sfc).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.retryBadge[\s\S]*?font-size:\s*12px\s*;/);
+  });
+
+  it("raises mobile App chrome microcopy to the minimum readable size", () => {
+    const css = readUtf8("../App.css");
+
+    expect(css).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.brandVersion,[\s\S]*?font-size:\s*12px\s*;/);
+    expect(css).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.projectBranch,[\s\S]*?font-size:\s*12px\s*;/);
+    expect(css).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.mobileContextActionHint[\s\S]*?font-size:\s*12px\s*;/);
+  });
+});

--- a/client/src/components/MainChatMessageList.vue
+++ b/client/src/components/MainChatMessageList.vue
@@ -1466,6 +1466,27 @@ function closeFilePreview(): void {
   vertical-align: middle;
 }
 
+@media (max-width: 768px) {
+  .execute-cmd,
+  .execute-output,
+  .command-tree-branch,
+  .command-cmd,
+  .patchCardDiff {
+    font-size: 14px;
+  }
+
+  .prompt-tag,
+  .patchCardToggle,
+  .retryBadge,
+  .msgTime,
+  .thoughtCardToggleText,
+  .liveStepToggleBtn,
+  .sessionBoundaryTag,
+  .sessionBoundaryNotice {
+    font-size: 12px;
+  }
+}
+
 @keyframes actionSpin {
   to {
     transform: rotate(360deg);

--- a/client/src/components/MarkdownContent.vue
+++ b/client/src/components/MarkdownContent.vue
@@ -587,6 +587,45 @@ const html = computed(() => renderMarkdownToHtml(props.content));
   color: var(--github-text);
 }
 
+@media (max-width: 768px) {
+  .md {
+    font-size: 16px;
+    line-height: 1.6;
+  }
+
+  .md :deep(h1) {
+    font-size: 19px;
+  }
+
+  .md :deep(h2) {
+    font-size: 17px;
+  }
+
+  .md :deep(h3),
+  .md :deep(h4),
+  .md :deep(h5),
+  .md :deep(h6) {
+    font-size: 16px;
+  }
+
+  .md :deep(code),
+  .md :deep(.md-diffstat),
+  .md :deep(.md-codeblock pre),
+  .md :deep(.md-codeblock pre > code),
+  .md :deep(details.md-codeblock > summary) {
+    font-size: 14px;
+  }
+
+  .md :deep(.md-codeblock pre),
+  .md :deep(.md-codeblock pre > code) {
+    line-height: 1.5;
+  }
+
+  .md :deep(.md-code-toggle) {
+    font-size: 12px;
+  }
+}
+
 @media (max-width: 480px) {
   .md :deep(img) {
     max-width: 50%;


### PR DESCRIPTION
## Summary

- Allow mobile browsers to pinch-zoom by removing restrictive viewport scaling flags.
- Add readable mobile typography for Markdown content, command output, diffs, metadata, and app chrome while preserving desktop sizing.
- Add regression coverage for the viewport and responsive typography rules.

Closes #176

## Validation

- npm run lint
- ./node_modules/.bin/tsc -p tsconfig.json --noEmit
- npm run build
- Full Web test suite: 83 files, 464 tests passed
- Server test suite: 721 tests passed
- git diff --cached --check