### PR TITLE
feat(ui): modernize chat interface

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -279,11 +279,9 @@
   flex: 1;
   display: grid;
   grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
-  gap: 12px;
-  padding: 12px 12px 8px 12px;
-  max-width: 1480px;
+  gap: 0;
   width: 100%;
-  margin: 0 auto;
+  margin: 0;
   min-height: 0;
   overflow: hidden;
 }
@@ -295,6 +293,8 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  padding: 12px 12px 8px;
+  border-right: 1px solid var(--border);
   min-width: 0;
   min-height: 0;
   overflow: hidden;
@@ -591,15 +591,23 @@
 }
 
 .laneTabs {
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 10px;
-  border-radius: 16px 16px 0 0;
-  border: 1px solid rgba(208, 215, 222, 0.85);
-  border-bottom: none;
-  background: rgba(248, 250, 252, 0.95);
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+  gap: 8px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.laneTabGroup {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 999px;
+  background: rgba(241, 245, 249, 0.92);
 }
 
 .laneTabSpacer {
@@ -637,8 +645,8 @@
   color: #64748b;
   font-size: 13px;
   font-weight: 800;
-  padding: 8px 14px;
-  border-radius: 12px;
+  padding: 6px 14px;
+  border-radius: 999px;
   cursor: pointer;
   white-space: nowrap;
   flex-shrink: 0;
@@ -686,7 +694,7 @@
   background: white;
   color: #0f172a;
   font-weight: 800;
-  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.1), 0 1px 2px rgba(15, 23, 42, 0.06);
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.12);
 }
 
 .laneTab:not(.active) {
@@ -755,9 +763,9 @@
 @media (max-width: 900px) {
   .layout {
     grid-template-columns: 1fr;
-    padding: 8px;
-    gap: 8px;
-    max-width: 100%;
+    padding: 0;
+    gap: 0;
+    max-width: none;
     position: relative;
   }
   :deep(input),
@@ -1085,7 +1093,13 @@
   }
   .laneTabs {
     width: 100%;
-    justify-content: stretch;
+    padding: 8px 12px;
+    justify-content: space-between;
+  }
+
+  .laneTabGroup {
+    flex: 1 1 auto;
+    min-width: 0;
   }
   .laneTab {
     flex: 1 1 0;

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -658,36 +658,38 @@ const plannerConnectionStatus = computed(() => {
 
       <section v-if="!isMobile || mobileDrawerSection === 'projects'" class="chatShell">
         <div class="laneTabs" role="tablist" aria-label="切换工作区">
-          <button
-            v-for="tab in workspaceTabs"
-            :id="`lane-tab-${tab.id}`"
-            :key="tab.id"
-            type="button"
-            class="laneTab"
-            :class="{ active: activeWorkspaceTab === tab.id }"
-            role="tab"
-            :aria-selected="activeWorkspaceTab === tab.id"
-            :aria-controls="`lane-panel-${tab.id}`"
-            :data-testid="`lane-tab-${tab.id}`"
-            @click="selectWorkspaceTab(tab.id)"
-          >
-            <span
-              class="laneTabStatusDot"
-              :class="isLaneConnected(tab.id, { planner: plannerConnected, worker: connected })
-                ? 'laneTabStatusDot--connected'
-                : 'laneTabStatusDot--disconnected'"
-              :data-testid="`lane-tab-status-${tab.id}`"
-              aria-hidden="true"
-            />
-            <span class="laneTabLabel">{{ tab.label }}</span>
-            <span
-              v-if="tab.id === 'planner' ? plannerBusy : agentBusy"
-              class="laneTabBusySpinner"
-              :class="tab.id === 'planner' ? 'laneTabBusySpinner--advisor' : 'laneTabBusySpinner--worker'"
-              :data-testid="`lane-tab-busy-${tab.id}`"
-              aria-hidden="true"
-            />
-          </button>
+          <div class="laneTabGroup">
+            <button
+              v-for="tab in workspaceTabs"
+              :id="`lane-tab-${tab.id}`"
+              :key="tab.id"
+              type="button"
+              class="laneTab"
+              :class="{ active: activeWorkspaceTab === tab.id }"
+              role="tab"
+              :aria-selected="activeWorkspaceTab === tab.id"
+              :aria-controls="`lane-panel-${tab.id}`"
+              :data-testid="`lane-tab-${tab.id}`"
+              @click="selectWorkspaceTab(tab.id)"
+            >
+              <span
+                class="laneTabStatusDot"
+                :class="isLaneConnected(tab.id, { planner: plannerConnected, worker: connected })
+                  ? 'laneTabStatusDot--connected'
+                  : 'laneTabStatusDot--disconnected'"
+                :data-testid="`lane-tab-status-${tab.id}`"
+                aria-hidden="true"
+              />
+              <span class="laneTabLabel">{{ tab.label }}</span>
+              <span
+                v-if="tab.id === 'planner' ? plannerBusy : agentBusy"
+                class="laneTabBusySpinner"
+                :class="tab.id === 'planner' ? 'laneTabBusySpinner--advisor' : 'laneTabBusySpinner--worker'"
+                :data-testid="`lane-tab-busy-${tab.id}`"
+                aria-hidden="true"
+              />
+            </button>
+          </div>
           <span v-if="!isMobile" class="laneTabSpacer" />
           <button
             v-if="!isMobile && activeLaneHasResume"
@@ -735,6 +737,7 @@ const plannerConnectionStatus = computed(() => {
             <MainChatView
               :key="plannerChatKey"
               class="chatHost chatHost--planner"
+              title="Advisor"
               :messages="plannerMessages"
               :draft="plannerComposerDraft"
               :latest-prompt-key="plannerChatKey"
@@ -774,6 +777,7 @@ const plannerConnectionStatus = computed(() => {
             <MainChatView
               :key="workerChatKey"
               class="chatHost"
+              title="Worker"
               :messages="messages"
               :draft="workerComposerDraft"
               :latest-prompt-key="workerLatestPromptKey"

--- a/client/src/__tests__/mainchat-header-ui.test.ts
+++ b/client/src/__tests__/mainchat-header-ui.test.ts
@@ -53,10 +53,12 @@ describe("MainChat header UI", () => {
     wrapper.unmount();
   });
 
-  it("only toggles the active chat class without restoring the legacy transparent top border", () => {
+  it("keeps the chat detail container flat while busy state remains in the composer", () => {
     const css = readUtf8("../components/MainChat.css");
-    expect(css).toMatch(/\.detail\s*\{[\s\S]*?border-top:\s*none\s*;[\s\S]*?\}/);
-    expect(css).toMatch(/\.detail--active\s*\{[\s\S]*?border-top-color:\s*#22c55e\s*;[\s\S]*?\}/);
+    expect(css).toMatch(/\.detail\s*\{[\s\S]*?position:\s*relative\s*;[\s\S]*?\}/);
+    expect(css).not.toContain("detail--active");
+    expect(css).not.toMatch(/\.detail\s*\{[\s\S]*?box-shadow\s*:/);
+    expect(css).not.toMatch(/\.detail\s*\{[\s\S]*?linear-gradient/);
 
     const baseProps = {
       queuedPrompts: [],
@@ -83,7 +85,7 @@ describe("MainChat header UI", () => {
       },
       global: { stubs: { MarkdownContent: true } },
     });
-    expect(busy.classes()).toContain("detail--active");
+    expect(busy.classes()).not.toContain("detail--active");
     busy.unmount();
 
     const withHistory = mount(MainChat, {
@@ -98,9 +100,9 @@ describe("MainChat header UI", () => {
     withHistory.unmount();
   });
 
-  it("renders a green top border on the chat detail container", () => {
+  it("reserves room for the floating composer in the chat stream", () => {
     const css = readUtf8("../components/MainChat.css");
-    expect(css).toMatch(/\.detail--active\s*\{[\s\S]*?border-top-color:\s*#22c55e\s*;[\s\S]*?\}/);
+    expect(css).toMatch(/\.chat\s*\{[\s\S]*?padding:[\s\S]*?220px/);
   });
 
   it("renders an optional header action button and emits newSession", async () => {

--- a/client/src/__tests__/mainchat-model-selector.test.ts
+++ b/client/src/__tests__/mainchat-model-selector.test.ts
@@ -39,12 +39,12 @@ describe("MainChat model selector", () => {
     const agentSelect = wrapper.find('select[aria-label="Select agent"]');
     expect(agentSelect.exists()).toBe(false);
 
-    const modelSelect = wrapper.find('[data-testid="chat-model-select"]');
+    const modelSelect = wrapper.find('[data-testid="chat-model-popover-toggle"]');
     expect(modelSelect.exists()).toBe(true);
     expect(modelSelect.text()).toContain("GPT-4.1");
     expect(modelSelect.text()).not.toContain("(gpt-4.1)");
 
-    const modelOptions = modelSelect.findAll("option").map((opt) => opt.attributes("value"));
+    const modelOptions = wrapper.findAll('[data-testid="chat-model-option"]').map((option) => option.attributes("data-model-id"));
     expect(modelOptions).not.toContain("auto");
 
     wrapper.unmount();
@@ -69,8 +69,37 @@ describe("MainChat model selector", () => {
 
     const effortSelect = wrapper.find('[data-testid="chat-reasoning-effort"]');
     expect(effortSelect.exists()).toBe(true);
-    expect(effortSelect.findAll("option").map((option) => option.attributes("value"))).toEqual(["minimal", "high"]);
+    expect(effortSelect.findAll("[data-reasoning-effort]").map((option) => option.attributes("data-reasoning-effort"))).toEqual(["minimal", "high"]);
 
+    wrapper.unmount();
+  });
+
+  it("opens one header popover for model and reasoning changes", async () => {
+    const model = makeModel("gpt-5.6", "GPT-5.6", "openai");
+    model.configJson = { reasoningEfforts: ["low", "high"] };
+    const wrapper = mount(MainChat, {
+      props: {
+        ...baseProps,
+        title: "Worker",
+        agents: [{ id: "codex", name: "Codex", ready: true }],
+        activeAgentId: "codex",
+        models: [model, makeModel("gpt-4.1", "GPT-4.1", "openai")],
+        modelId: "gpt-5.6",
+        modelReasoningEffort: "low",
+      },
+      global: { stubs: { MarkdownContent: true, DraggableModal: true } },
+    });
+
+    const toggle = wrapper.get('[data-testid="chat-model-popover-toggle"]');
+    expect(wrapper.find('[data-testid="chat-model-popover-menu"]').attributes("aria-hidden")).toBe("true");
+    await toggle.trigger("click");
+    expect(wrapper.find('[data-testid="chat-model-popover-menu"]').attributes("aria-hidden")).toBe("false");
+
+    await wrapper.find('[data-testid="chat-model-option"][data-model-id="gpt-4.1"]').trigger("click");
+    expect(wrapper.emitted("setModel")?.at(-1)?.[0]).toBe("gpt-4.1");
+
+    await wrapper.find('[data-testid="chat-reasoning-effort"] [data-reasoning-effort="high"]').trigger("click");
+    expect(wrapper.emitted("setReasoningEffort")?.at(-1)?.[0]).toBe("high");
     wrapper.unmount();
   });
 
@@ -86,7 +115,7 @@ describe("MainChat model selector", () => {
       global: { stubs: { MarkdownContent: true, DraggableModal: true } },
     });
 
-    expect(wrapper.find('[data-testid="chat-reasoning-effort"]').findAll("option").map((option) => option.attributes("value"))).toEqual([
+    expect(wrapper.find('[data-testid="chat-reasoning-effort"]').findAll("[data-reasoning-effort]").map((option) => option.attributes("data-reasoning-effort"))).toEqual([
       "medium",
       "high",
       "xhigh",
@@ -114,8 +143,8 @@ describe("MainChat model selector", () => {
     });
 
     const effortSelect = wrapper.find('[data-testid="chat-reasoning-effort"]');
-    expect(effortSelect.attributes("value")).toBe("ultra");
-    expect(effortSelect.findAll("option").map((option) => option.attributes("value"))).toEqual([
+    expect(effortSelect.find('[aria-pressed="true"]').attributes("data-reasoning-effort")).toBe("ultra");
+    expect(effortSelect.findAll("[data-reasoning-effort]").map((option) => option.attributes("data-reasoning-effort"))).toEqual([
       "medium",
       "high",
       "xhigh",
@@ -143,8 +172,8 @@ describe("MainChat model selector", () => {
     });
 
     const effortSelect = wrapper.find('[data-testid="chat-reasoning-effort"]');
-    expect((effortSelect.element as HTMLSelectElement).value).toBe("max");
-    expect(effortSelect.findAll("option").map((option) => option.attributes("value"))).toEqual([
+    expect(effortSelect.find('[aria-pressed="true"]').attributes("data-reasoning-effort")).toBe("max");
+    expect(effortSelect.findAll("[data-reasoning-effort]").map((option) => option.attributes("data-reasoning-effort"))).toEqual([
       "low",
       "medium",
       "high",
@@ -246,11 +275,11 @@ describe("MainChat model selector", () => {
       global: { stubs: { MarkdownContent: true, DraggableModal: true } },
     });
 
-    const modelSelect = wrapper.find('[data-testid="chat-model-select"]');
-    expect(modelSelect.findAll("option").map((option) => option.attributes("value"))).toEqual(["gpt-4.1"]);
+    const modelSelect = wrapper.find('[data-testid="chat-model-popover-toggle"]');
+    expect(wrapper.findAll('[data-testid="chat-model-option"]').map((option) => option.attributes("data-model-id"))).toEqual(["gpt-4.1"]);
     expect(modelSelect.text()).not.toContain("Claude Opus 5");
 
-    await modelSelect.setValue("gpt-4.1");
+    await wrapper.find('[data-testid="chat-model-option"]').trigger("click");
 
     expect(wrapper.emitted("switchAgent")).toBeUndefined();
     expect(wrapper.emitted("setModel")?.[0]?.[0]).toBe("gpt-4.1");
@@ -275,12 +304,12 @@ describe("MainChat model selector", () => {
       global: { stubs: { MarkdownContent: true, DraggableModal: true } },
     });
 
-    const modelSelect = wrapper.find('[data-testid="chat-model-select"]');
-    expect(modelSelect.attributes("disabled")).toBeDefined();
-    expect(modelSelect.findAll("option").map((option) => option.attributes("value"))).toEqual([""]);
-    expect(modelSelect.text()).toContain("No models");
-    expect(modelSelect.text()).not.toContain("GPT-4.1");
-    expect(modelSelect.text()).not.toContain("Claude Opus 5");
+    const modelSelect = wrapper.find('[data-testid="chat-model-popover-toggle"]');
+    expect(modelSelect.attributes("disabled")).toBeUndefined();
+    expect(wrapper.findAll('[data-testid="chat-model-option"]')).toHaveLength(0);
+    expect(wrapper.find('[data-testid="chat-model-popover-menu"]').text()).toContain("No compatible models");
+    expect(wrapper.find('[data-testid="chat-model-popover-menu"]').text()).not.toContain("GPT-4.1");
+    expect(wrapper.find('[data-testid="chat-model-popover-menu"]').text()).not.toContain("Claude Opus 5");
 
     wrapper.unmount();
   });
@@ -320,10 +349,10 @@ describe("MainChat model selector", () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.emitted("setModel")).toBeUndefined();
 
-    const modelSelect = wrapper.find('[data-testid="chat-model-select"]');
+    const modelSelect = wrapper.find('[data-testid="chat-model-popover-toggle"]');
     expect(modelSelect.exists()).toBe(true);
-    expect(modelSelect.attributes("disabled")).toBeDefined();
-    expect(modelSelect.text()).toContain("No models");
+    expect(modelSelect.attributes("disabled")).toBeUndefined();
+    expect(wrapper.find('[data-testid="chat-model-popover-menu"]').text()).toContain("No compatible models");
 
     wrapper.unmount();
   });

--- a/client/src/__tests__/mainchat-prompt-tools.test.ts
+++ b/client/src/__tests__/mainchat-prompt-tools.test.ts
@@ -31,6 +31,11 @@ function mountPromptTools(options?: { inputLocked?: boolean; latestPromptKey?: s
   return mount(Host, { global: { stubs: { MainChatPendingImageViewer: true } } });
 }
 
+async function openActionSheet(wrapper: ReturnType<typeof mount>): Promise<void> {
+  await wrapper.get('[data-testid="composer-actions-toggle"]').trigger("click");
+  await nextTick();
+}
+
 describe("MainChat prompt tools", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -48,6 +53,7 @@ describe("MainChat prompt tools", () => {
     expect((wrapper.vm as { sent: string[] }).sent).toEqual(["Retry this prompt"]);
     expect((textarea.element as HTMLTextAreaElement).value).toBe("");
 
+    await openActionSheet(wrapper);
     const restore = wrapper.get("[data-testid='restore-latest-prompt']");
     expect(restore.attributes("disabled")).toBeUndefined();
     await restore.trigger("click");
@@ -64,8 +70,9 @@ describe("MainChat prompt tools", () => {
 
     const wrapper = mountPromptTools({ latestPromptKey: "project-1:planner" });
     const textarea = wrapper.get("textarea.composer-input");
-    const restore = wrapper.get("[data-testid='restore-latest-prompt']");
     await textarea.setValue("Current draft");
+    await openActionSheet(wrapper);
+    const restore = wrapper.get("[data-testid='restore-latest-prompt']");
 
     expect(restore.attributes("disabled")).toBeDefined();
     await textarea.setValue("");
@@ -86,6 +93,7 @@ describe("MainChat prompt tools", () => {
     element.setSelectionRange(6, 10);
     await textarea.trigger("select");
 
+    await openActionSheet(wrapper);
     const quote = wrapper.get("[data-testid='wrap-triple-quotes']");
     expect(quote.attributes("disabled")).toBeUndefined();
     await quote.trigger("click");
@@ -97,18 +105,12 @@ describe("MainChat prompt tools", () => {
     wrapper.unmount();
   });
 
-  it("places both tools in the bottom toolbar and disables them while input is locked", () => {
+  it("keeps secondary actions behind the plus button and disables the trigger while input is locked", () => {
     localStorage.setItem(STORAGE_KEY, "Stored prompt");
     const wrapper = mountPromptTools({ inputLocked: true });
-    const toolbarRight = wrapper.get(".inputToolbarRight").element;
-    const restoreBtn = wrapper.get("[data-testid='restore-latest-prompt']").element;
-    const quoteBtn = wrapper.get("[data-testid='wrap-triple-quotes']").element;
-    const toolbarChildren = Array.from(toolbarRight.children);
-
-    expect(toolbarChildren).toContain(restoreBtn);
-    expect(toolbarChildren).toContain(quoteBtn);
-    expect(wrapper.get("[data-testid='restore-latest-prompt']").attributes("disabled")).toBeDefined();
-    expect(wrapper.get("[data-testid='wrap-triple-quotes']").attributes("disabled")).toBeDefined();
+    expect(wrapper.find(".inputToolbarRight").exists()).toBe(false);
+    expect(wrapper.get('[data-testid="composer-actions-toggle"]').attributes("disabled")).toBeDefined();
+    expect(wrapper.find('[data-testid="composer-action-sheet"]').exists()).toBe(false);
     wrapper.unmount();
   });
 });

--- a/client/src/components/MainChat.css
+++ b/client/src/components/MainChat.css
@@ -2,18 +2,10 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  position: relative;
   min-height: 0;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(246, 248, 250, 0.98) 100%);
-  border-top: none;
-  border-radius: 0 0 var(--radius) var(--radius);
-  border: 1px solid rgba(208, 215, 222, 0.85);
-  border-top: none;
-  box-shadow: 0 10px 30px rgba(31, 35, 40, 0.06);
+  background: var(--app-bg, #ffffff);
   overflow: hidden;
-}
-
-.detail--active {
-  border-top-color: #22c55e;
 }
 
 .chat {
@@ -21,14 +13,17 @@
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior: contain;
-  padding: 10px;
-  background:
-    radial-gradient(circle at top right, rgba(9, 105, 218, 0.06), transparent 26%),
-    linear-gradient(180deg, #fbfcfe 0%, var(--github-canvas) 100%);
+  padding: 18px clamp(16px, 4vw, 40px) 220px;
+  background: var(--app-bg, #ffffff);
   min-height: 0;
   position: relative;
   scrollbar-width: thin;
   scrollbar-color: rgba(148, 163, 184, 0.55) transparent;
+}
+
+.chat :deep(.messageList) {
+  width: min(920px, 100%);
+  margin: 0 auto;
 }
 
 .chat::-webkit-scrollbar {

--- a/client/src/components/MainChat.vue
+++ b/client/src/components/MainChat.vue
@@ -234,8 +234,6 @@ const liveStepCanToggleExpanded = computed(() => {
   if (liveStepCollapsedTrivialOutline.value) return false;
   return liveStepHasMeaningfulBody.value || liveStepOutlineHiddenCount.value > 0 || liveStepHasOverflow.value;
 });
-const showActiveBorder = computed(() => props.busy);
-
 const { copiedMessageId, onCopyMessage, formatMessageTs } = useCopyMessage();
 
 function handleScroll() {
@@ -339,11 +337,18 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="detail" :class="{ 'detail--active': showActiveBorder }">
+  <div class="detail">
     <MainChatHeader
-      v-if="title"
-      :title="title"
+      v-if="title || agents !== undefined || models !== undefined"
+      :title="title || 'Chat'"
       :busy="busy"
+      :connected="connected"
+      :input-locked="inputLocked"
+      :agents="agents"
+      :active-agent-id="activeAgentId"
+      :models="models"
+      :model-id="modelId"
+      :model-reasoning-effort="modelReasoningEffort"
       :header-action="headerAction"
       :header-clear-action="headerClearAction"
       :header-resume-action="headerResumeAction"
@@ -351,6 +356,9 @@ onBeforeUnmount(() => {
       @new-session="emit('newSession')"
       @clear="emit('clear')"
       @resume-thread="emit('resumeThread')"
+      @switch-agent="emit('switchAgent', $event)"
+      @set-model="emit('setModel', $event)"
+      @set-reasoning-effort="emit('setReasoningEffort', $event)"
     />
     <div ref="listRef" class="chat" @scroll="handleScroll">
       <MainChatMessageList
@@ -386,11 +394,6 @@ onBeforeUnmount(() => {
       :connected="connected"
       :busy="busy"
       :input-locked="inputLocked"
-      :agents="agents"
-      :active-agent-id="activeAgentId"
-      :models="models"
-      :model-id="modelId"
-      :model-reasoning-effort="modelReasoningEffort"
       :api-token="apiToken"
       :running-task-count="runningTaskCount"
       :connection-status-kind="connectionStatusKind"
@@ -401,9 +404,6 @@ onBeforeUnmount(() => {
       @add-images="emit('addImages', $event)"
       @clear-images="emit('clearImages')"
       @remove-queued="emit('removeQueued', $event)"
-      @switch-agent="emit('switchAgent', $event)"
-      @set-model="emit('setModel', $event)"
-      @set-reasoning-effort="emit('setReasoningEffort', $event)"
     />
   </div>
 </template>

--- a/client/src/components/MainChatComposerPanel.vue
+++ b/client/src/components/MainChatComposerPanel.vue
@@ -1,34 +1,15 @@
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
-import type { ModelConfig } from "../api/types";
-import { normalizeReasoningEffort } from "../lib/chatPreferences";
-import { supportsAgentModel } from "../lib/model_agent";
 import MainChatPendingImageViewer from "./MainChatPendingImageViewer.vue";
 import { resolveComposerImagePreview } from "./mainChat/attachmentPreview";
 import type { IncomingImage, QueuedPrompt } from "./mainChat/types";
 import { useMainChatComposer } from "./mainChat/useComposer";
 
-type AgentOption = { id: string; name: string; ready: boolean; error?: string };
-
 type PendingImagePreview = {
   key: string;
   src: string;
   href: string;
-};
-
-const DEFAULT_CODEX_REASONING_EFFORTS = ["medium", "high", "xhigh", "max", "ultra"] as const;
-const DEFAULT_CLAUDE_REASONING_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
-const REASONING_EFFORT_LABELS: Record<string, string> = {
-  off: "Off",
-  none: "None",
-  minimal: "Minimal",
-  low: "Low",
-  medium: "Medium",
-  high: "High",
-  xhigh: "Extra High",
-  max: "Max",
-  ultra: "Ultra",
 };
 
 const props = defineProps<{
@@ -39,11 +20,6 @@ const props = defineProps<{
   connected: boolean;
   busy: boolean;
   inputLocked?: boolean;
-  agents?: AgentOption[];
-  activeAgentId?: string;
-  models?: ModelConfig[];
-  modelId?: string;
-  modelReasoningEffort?: string;
   apiToken?: string;
   runningTaskCount?: number;
   connectionStatusKind?: "info" | "progress" | "disconnected" | "error" | null;
@@ -57,205 +33,9 @@ const emit = defineEmits<{
   (e: "addImages", images: IncomingImage[]): void;
   (e: "clearImages"): void;
   (e: "removeQueued", id: string): void;
-  (e: "switchAgent", agentId: string): void;
-  (e: "setModel", modelId: string): void;
-  (e: "setReasoningEffort", effort: string): void;
 }>();
 
 const canInterrupt = computed(() => props.busy);
-
-const agentOptions = computed(() => (Array.isArray(props.agents) ? props.agents : []));
-const readyAgentIds = computed(() =>
-  agentOptions.value
-    .filter((agent) => Boolean(agent?.ready))
-    .map((agent) => String(agent?.id ?? "").trim())
-    .filter(Boolean),
-);
-const modelOptions = computed(() =>
-  (Array.isArray(props.models) ? props.models : []).filter((model) => model?.isEnabled !== false),
-);
-
-const selectedAgentId = computed(() => {
-  const active = String(props.activeAgentId ?? "").trim();
-  if (active && readyAgentIds.value.includes(active)) {
-    return active;
-  }
-  return readyAgentIds.value[0] ?? "";
-});
-
-const lastAutoSwitchedAgentId = ref<string | null>(null);
-
-watch(
-  () => [
-    Boolean(props.connected),
-    Boolean(props.busy),
-    Boolean(props.inputLocked),
-    String(props.activeAgentId ?? "").trim(),
-    readyAgentIds.value.join("\n"),
-  ],
-  () => {
-    if (!props.connected || props.busy || props.inputLocked) {
-      lastAutoSwitchedAgentId.value = null;
-      return;
-    }
-
-    if (readyAgentIds.value.length === 0) {
-      lastAutoSwitchedAgentId.value = null;
-      return;
-    }
-
-    const active = String(props.activeAgentId ?? "").trim();
-    if (active && readyAgentIds.value.includes(active)) {
-      lastAutoSwitchedAgentId.value = null;
-      return;
-    }
-
-    const next = selectedAgentId.value;
-    if (!next || next === active) return;
-    if (lastAutoSwitchedAgentId.value === next) return;
-
-    lastAutoSwitchedAgentId.value = next;
-    emit("switchAgent", next);
-  },
-  { immediate: true },
-);
-
-function normalizeModelId(value: unknown): string {
-  return typeof value === "string" ? value.trim() : String(value ?? "").trim();
-}
-
-function isUnsetModelId(modelId: string): boolean {
-  const id = String(modelId ?? "").trim().toLowerCase();
-  return !id || id === "auto";
-}
-
-const compatibleModelOptions = computed(() => {
-  const agentId = selectedAgentId.value;
-  if (!agentId) return [];
-  return modelOptions.value.filter((model) => supportsAgentModel({ agentId, model }));
-});
-
-function preferredModel(options: readonly ModelConfig[]): ModelConfig | null {
-  return options.find((model) => model.isDefault) ?? options[0] ?? null;
-}
-
-const effectiveModelId = computed(() => {
-  const options = compatibleModelOptions.value;
-  if (options.length === 0) return "";
-  const current = normalizeModelId(props.modelId);
-  const known = modelOptions.value.some((m) => String(m.modelId ?? m.id ?? "").trim() === current);
-  if (!isUnsetModelId(current) && (!known || options.some((m) => String(m.modelId ?? m.id ?? "").trim() === current))) {
-    return current;
-  }
-  const fallback = preferredModel(options);
-  return String(fallback?.modelId ?? fallback?.id ?? "").trim();
-});
-
-watch(
-  () => [
-    Boolean(props.inputLocked),
-    selectedAgentId.value,
-    props.modelId,
-    compatibleModelOptions.value
-      .map((m) => `${String(m.modelId ?? m.id ?? "").trim()}:${m.isDefault ? "default" : "standard"}`)
-      .join("\n"),
-  ],
-  () => {
-    if (props.inputLocked) return;
-    const options = compatibleModelOptions.value;
-    if (options.length === 0) return;
-    const fallback = preferredModel(options);
-    const desired = String(fallback?.modelId ?? fallback?.id ?? "").trim();
-    if (!desired) return;
-
-    const current = normalizeModelId(props.modelId);
-    const known = modelOptions.value.some((m) => String(m.modelId ?? m.id ?? "").trim() === current);
-    if (!isUnsetModelId(current) && (!known || options.some((m) => String(m.modelId ?? m.id ?? "").trim() === current))) {
-      return;
-    }
-
-    if (desired !== current) {
-      emit("setModel", desired);
-    }
-  },
-  { immediate: true },
-);
-
-function formatModelLabel(model: ModelConfig): string {
-  const id = String(model.modelId ?? model.id ?? "").trim();
-  const name = String(model.displayName ?? "").trim() || id;
-  return name || "model";
-}
-
-function onModelChange(ev: Event): void {
-  if (props.inputLocked) return;
-  const value = (ev.target as HTMLSelectElement | null)?.value ?? "";
-  const next = normalizeModelId(value);
-  if (!next || isUnsetModelId(next)) return;
-  const model = compatibleModelOptions.value.find(
-    (option) => String(option.modelId ?? option.id ?? "").trim() === next,
-  );
-  if (!model) return;
-  emit("setModel", next);
-}
-
-const selectedModel = computed(() => {
-  const modelId = effectiveModelId.value;
-  return compatibleModelOptions.value.find((model) => String(model.modelId ?? model.id ?? "").trim() === modelId) ?? null;
-});
-
-const reasoningEffortOptions = computed(() => {
-  if (!selectedModel.value) return [];
-
-  const fallback = selectedAgentId.value === "codex"
-    ? DEFAULT_CODEX_REASONING_EFFORTS
-    : DEFAULT_CLAUDE_REASONING_EFFORTS;
-  const config = selectedModel.value?.configJson;
-  const raw = config && typeof config === "object" && !Array.isArray(config)
-    ? (config as Record<string, unknown>).reasoningEfforts
-    : null;
-  if (!Array.isArray(raw)) return [...fallback];
-
-  const values = raw
-    .map((entry) => String(entry ?? "").trim().toLowerCase())
-    .filter((entry) => Boolean(REASONING_EFFORT_LABELS[entry]));
-  return values.length > 0 ? [...new Set(values)] : [...fallback];
-});
-
-const reasoningEffortValue = computed(() => {
-  const normalized = normalizeReasoningEffort(props.modelReasoningEffort);
-  if (reasoningEffortOptions.value.includes(normalized)) return normalized;
-  if (reasoningEffortOptions.value.includes("high")) return "high";
-  return reasoningEffortOptions.value[0] ?? "high";
-});
-
-watch(
-  () => [
-    Boolean(props.inputLocked),
-    selectedAgentId.value,
-    effectiveModelId.value,
-    String(props.modelReasoningEffort ?? "").trim().toLowerCase(),
-    reasoningEffortOptions.value.join("\n"),
-  ],
-  () => {
-    if (props.inputLocked) return;
-    if (reasoningEffortOptions.value.length === 0) return;
-    const current = String(props.modelReasoningEffort ?? "").trim().toLowerCase();
-    if (!current || current === reasoningEffortValue.value) return;
-    emit("setReasoningEffort", reasoningEffortValue.value);
-  },
-  { immediate: true },
-);
-
-function formatReasoningEffortLabel(effort: string): string {
-  return REASONING_EFFORT_LABELS[effort] ?? effort;
-}
-
-function onReasoningEffortChange(ev: Event): void {
-  if (props.inputLocked) return;
-  const value = (ev.target as HTMLSelectElement | null)?.value ?? "";
-  emit("setReasoningEffort", String(value ?? "").trim());
-}
 
 const normalizedConnectionStatusKind = computed(() => props.connectionStatusKind ?? "info");
 const latestPrompt = ref("");
@@ -365,9 +145,65 @@ const {
   onAddImages: (images) => emit("addImages", images),
 });
 
+const composerRoot = ref<HTMLElement | null>(null);
+const actionMenuOpen = ref(false);
+
+function closeActionMenu(): void {
+  actionMenuOpen.value = false;
+}
+
+function toggleActionMenu(): void {
+  if (props.inputLocked) return;
+  actionMenuOpen.value = !actionMenuOpen.value;
+}
+
+function onActionMenuPointerDown(event: Event): void {
+  const target = event.target;
+  if (target instanceof Node && composerRoot.value?.contains(target)) return;
+  closeActionMenu();
+}
+
+function onActionMenuKeydown(event: KeyboardEvent): void {
+  if (event.key === "Escape") closeActionMenu();
+}
+
+function attachFromActionMenu(): void {
+  closeActionMenu();
+  triggerFileInput();
+}
+
+async function restoreFromActionMenu(): Promise<void> {
+  closeActionMenu();
+  await restoreLatestPrompt();
+}
+
+async function quoteFromActionMenu(): Promise<void> {
+  closeActionMenu();
+  await wrapSelectedTextWithTripleQuotes();
+}
+
+onMounted(() => {
+  document.addEventListener("pointerdown", onActionMenuPointerDown);
+  document.addEventListener("keydown", onActionMenuKeydown);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener("pointerdown", onActionMenuPointerDown);
+  document.removeEventListener("keydown", onActionMenuKeydown);
+});
+
 const hasTextSelection = ref(false);
 const canRestoreLatestPrompt = computed(
   () => !props.inputLocked && !input.value.trim() && Boolean(latestPrompt.value.trim()),
+);
+
+watch(
+  () => Boolean(props.inputLocked),
+  (locked) => {
+    if (!locked) return;
+    closeActionMenu();
+    hasTextSelection.value = false;
+  },
 );
 
 function updateTextSelection(): void {
@@ -412,7 +248,7 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
 </script>
 
 <template>
-  <div class="composer">
+  <div ref="composerRoot" class="composer">
     <div
       v-if="connectionStatusMessage"
       class="laneStatusBar"
@@ -485,7 +321,7 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
         :disabled="inputLocked"
         rows="5"
         class="composer-input"
-        placeholder="输入…（Enter 发送，Alt+Enter 换行，粘贴图片）"
+        placeholder="输入…（Enter 发送，Shift+Enter 换行，粘贴图片）"
         @keydown="onInputKeydown"
         @paste="onPaste"
         @select="updateTextSelection"
@@ -494,74 +330,26 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
         @focus="updateTextSelection"
         @blur="clearTextSelectionState"
       />
-      <div class="inputToolbar">
-        <div class="inputToolbarLeft">
-          <button class="attachIcon" type="button" title="添加图片附件" :disabled="inputLocked" @click="triggerFileInput">
+      <div class="composerMainRow">
+        <div class="composerMainRowLeft">
+          <button
+            class="attachIcon composerActionToggle"
+            type="button"
+            title="更多输入操作"
+            aria-label="更多输入操作"
+            :aria-expanded="actionMenuOpen"
+            aria-haspopup="menu"
+            data-testid="composer-actions-toggle"
+            :disabled="inputLocked"
+            @mousedown.prevent
+            @click.stop="toggleActionMenu"
+          >
             <svg width="18" height="18" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-              <path
-                fill-rule="evenodd"
-                d="M15.621 4.379a3.5 3.5 0 0 0-4.95 0l-7.07 7.07a5 5 0 0 0 7.07 7.072l4.95-4.95a.75.75 0 0 0-1.06-1.061l-4.95 4.95a3.5 3.5 0 1 1-4.95-4.95l7.07-7.07a2 2 0 1 1 2.83 2.828l-7.07 7.071a.5.5 0 0 1-.707-.707l4.95-4.95a.75.75 0 1 0-1.06-1.06l-4.95 4.95a2 2 0 0 0 2.828 2.828l7.07-7.071a3.5 3.5 0 0 0 0-4.95Z"
-                clip-rule="evenodd"
-              />
+              <path fill-rule="evenodd" d="M10 3a.75.75 0 0 1 .75.75v5.5h5.5a.75.75 0 0 1 0 1.5h-5.5v5.5a.75.75 0 0 1-1.5 0v-5.5h-5.5a.75.75 0 0 1 0-1.5h5.5v-5.5A.75.75 0 0 1 10 3Z" clip-rule="evenodd" />
             </svg>
           </button>
-          <div v-if="agentOptions.length" class="agentSelect">
-            <select
-              class="agentSelectInput"
-              :value="effectiveModelId"
-              :disabled="!connected || busy || inputLocked || compatibleModelOptions.length === 0"
-              aria-label="Select model"
-              data-testid="chat-model-select"
-              @change="onModelChange"
-            >
-              <option v-if="compatibleModelOptions.length === 0" value="" disabled>No models</option>
-              <option v-for="m in compatibleModelOptions" :key="m.id" :value="m.modelId || m.id">
-                {{ formatModelLabel(m) }}
-              </option>
-            </select>
-          </div>
-          <div v-if="reasoningEffortOptions.length > 0" class="agentSelect">
-            <select
-              class="agentSelectInput"
-              :value="reasoningEffortValue"
-              :disabled="!connected || busy || inputLocked"
-              aria-label="Select reasoning effort"
-              data-testid="chat-reasoning-effort"
-              @change="onReasoningEffortChange"
-            >
-              <option v-for="effort in reasoningEffortOptions" :key="effort" :value="effort">
-                {{ formatReasoningEffortLabel(effort) }}
-              </option>
-            </select>
-          </div>
         </div>
-        <div class="inputToolbarRight">
-          <button
-            class="composerToolIcon"
-            type="button"
-            title="恢复最新 Prompt"
-            aria-label="恢复最新 Prompt"
-            data-testid="restore-latest-prompt"
-            :disabled="!canRestoreLatestPrompt"
-            @mousedown.prevent
-            @click="restoreLatestPrompt"
-          >
-            <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-              <path d="M5 3.75A1.75 1.75 0 0 1 6.75 2h6.5A1.75 1.75 0 0 1 15 3.75v13.1a.65.65 0 0 1-1.02.54L10 14.74l-3.98 2.65A.65.65 0 0 1 5 16.85V3.75Z" />
-            </svg>
-          </button>
-          <button
-            class="composerToolIcon composerToolIcon--quote"
-            type="button"
-            title="用三引号包裹选中文本"
-            aria-label="用三引号包裹选中文本"
-            data-testid="wrap-triple-quotes"
-            :disabled="inputLocked || !hasTextSelection"
-            @mousedown.prevent
-            @click="wrapSelectedTextWithTripleQuotes"
-          >
-            <span aria-hidden="true">&quot;&quot;&quot;</span>
-          </button>
+        <div class="composerMainRowRight">
           <div v-if="recording" class="voiceIndicator recording" aria-hidden="true">
             <div class="voiceBars">
               <span class="bar" />
@@ -612,6 +400,51 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
         </div>
       </div>
       <div
+        v-if="actionMenuOpen"
+        class="actionSheet"
+        role="menu"
+        aria-label="输入操作"
+        data-testid="composer-action-sheet"
+        @click.stop
+      >
+        <button
+          class="actionSheetItem"
+          type="button"
+          role="menuitem"
+          data-testid="action-attach-image"
+          :disabled="inputLocked"
+          @mousedown.prevent
+          @click="attachFromActionMenu"
+        >
+          <span class="actionSheetIcon" aria-hidden="true">📎</span>
+          <span>添加图片附件</span>
+        </button>
+        <button
+          class="actionSheetItem"
+          type="button"
+          role="menuitem"
+          data-testid="wrap-triple-quotes"
+          :disabled="inputLocked || !hasTextSelection"
+          @mousedown.prevent
+          @click="quoteFromActionMenu"
+        >
+          <span class="actionSheetIcon actionSheetIcon--mono" aria-hidden="true">&quot;&quot;&quot;</span>
+          <span>快速引用选中文本</span>
+        </button>
+        <button
+          class="actionSheetItem"
+          type="button"
+          role="menuitem"
+          data-testid="restore-latest-prompt"
+          :disabled="!canRestoreLatestPrompt"
+          @mousedown.prevent
+          @click="restoreFromActionMenu"
+        >
+          <span class="actionSheetIcon" aria-hidden="true">↺</span>
+          <span>恢复上一条输入</span>
+        </button>
+      </div>
+      <div
         v-if="(voiceStatusKind === 'ok' || voiceStatusKind === 'error') && voiceStatusMessage"
         class="voiceToast"
         :class="voiceStatusKind"
@@ -645,13 +478,38 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 10px;
-  padding: 12px 12px calc(8px + env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1)) 12px;
-  border-top: 1px solid #e2e8f0;
-  background: white;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 20;
+  padding: 0 16px calc(16px + env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1));
+  pointer-events: none;
+}
+
+.composer::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 190px;
+  z-index: 0;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.96) 68%, #ffffff 100%);
+  pointer-events: none;
+}
+
+.composer > :not(.draggableOverlay) {
+  position: relative;
+  z-index: 1;
+  pointer-events: auto;
 }
 
 .laneStatusBar {
+  width: min(800px, 100%);
+  box-sizing: border-box;
   display: flex;
   align-items: flex-start;
   gap: 8px;
@@ -703,6 +561,7 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
 }
 
 .queue {
+  width: min(800px, 100%);
   display: grid;
   gap: 6px;
   max-height: 140px;
@@ -757,18 +616,21 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
 }
 
 .inputWrap {
+  width: min(800px, 100%);
+  box-sizing: border-box;
   position: relative;
-  border-radius: 10px;
-  border: 1px solid #e2e8f0;
-  background: transparent;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.38);
+  background: rgba(255, 255, 255, 0.97);
+  box-shadow: 0 4px 24px rgba(15, 23, 42, 0.08);
   display: flex;
   flex-direction: column;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 
 .inputWrap:focus-within {
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+  border-color: rgba(37, 99, 235, 0.52);
+  box-shadow: 0 4px 24px rgba(15, 23, 42, 0.1), 0 0 0 3px rgba(37, 99, 235, 0.1);
 }
 
 .hiddenFileInput {
@@ -780,77 +642,38 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
   pointer-events: none;
 }
 
-.composerToolIcon {
-  width: 26px;
-  height: 26px;
-  border: none;
-  border-radius: 7px;
-  background: transparent;
-  color: #64748b;
-  display: grid;
-  place-items: center;
-  cursor: pointer;
-  transition: color 0.15s, background-color 0.15s, opacity 0.15s;
-}
-
-.composerToolIcon--quote {
-  margin-right: 2px;
-}
-
-.composerToolIcon:hover:not(:disabled) {
-  color: #0f172a;
-  background: rgba(15, 23, 42, 0.06);
-}
-
-.composerToolIcon:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.14);
-}
-
-.composerToolIcon:disabled {
-  cursor: not-allowed;
-  opacity: 0.3;
-}
-
-.composerToolIcon--quote span {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 12px;
-  font-weight: 800;
-  line-height: 1;
-  letter-spacing: -1px;
-}
-
-.inputToolbar {
+.composerMainRow {
   display: flex;
   align-items: center;
-  padding: 4px 6px;
+  min-height: 40px;
+  padding: 2px 8px 8px;
   flex-shrink: 0;
   gap: 6px;
 }
 
-.inputToolbarLeft {
+.composerMainRowLeft,
+.composerMainRowRight {
   display: flex;
   gap: 6px;
   align-items: center;
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
 }
 
-.inputToolbarRight {
-  display: flex;
-  gap: 6px;
-  align-items: center;
+.composerMainRowLeft {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.composerMainRowRight {
   flex: 0 0 auto;
   margin-left: auto;
 }
 
 .attachIcon {
-  width: 28px;
-  height: 28px;
-  border-radius: 8px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
   border: none;
-  background: transparent;
+  background: rgba(15, 23, 42, 0.06);
   color: #64748b;
   display: grid;
   place-items: center;
@@ -858,39 +681,80 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
   transition: color 0.15s;
 }
 
-.attachIcon:hover {
+.attachIcon:hover:not(:disabled) {
   color: #0f172a;
+  background: rgba(15, 23, 42, 0.1);
 }
 
-.agentSelect {
+.attachIcon:disabled {
+  cursor: not-allowed;
+  opacity: 0.35;
+}
+
+.composerActionToggle:focus-visible,
+.micIcon:focus-visible,
+.sendIcon:focus-visible,
+.stopIcon:focus-visible,
+.actionSheetItem:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+}
+
+.actionSheet {
+  position: absolute;
+  left: 8px;
+  bottom: calc(100% + 8px);
+  width: min(270px, calc(100% - 16px));
+  padding: 6px;
+  display: grid;
+  gap: 2px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 15px;
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.16);
+}
+
+.actionSheetItem {
   display: flex;
   align-items: center;
-  min-width: 0;
-}
-
-.agentSelectInput {
-  height: 28px;
-  max-width: 150px;
-  min-width: 0;
-  border-radius: 8px;
-  border: 1px solid rgba(226, 232, 240, 0.95);
-  background: white;
-  color: #0f172a;
+  gap: 10px;
+  width: 100%;
+  min-height: 36px;
+  padding: 7px 9px;
+  border: none;
+  border-radius: 9px;
+  background: transparent;
+  color: #334155;
+  text-align: left;
   font-size: 12px;
-  font-weight: 600;
-  padding: 0 8px;
+  font-weight: 700;
   cursor: pointer;
 }
 
-.agentSelectInput:disabled {
-  cursor: not-allowed;
-  opacity: 0.65;
+.actionSheetItem:hover:not(:disabled) {
+  background: rgba(37, 99, 235, 0.08);
+  color: #1d4ed8;
 }
 
-.agentSelectInput:focus {
-  outline: none;
-  border-color: rgba(37, 99, 235, 0.65);
-  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.12);
+.actionSheetItem:disabled {
+  color: #94a3b8;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.actionSheetIcon {
+  width: 22px;
+  flex: 0 0 22px;
+  text-align: center;
+  font-size: 15px;
+  line-height: 1;
+}
+
+.actionSheetIcon--mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: -1px;
 }
 
 .voiceIndicator {
@@ -984,6 +848,8 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
 }
 
 .attachmentsBar {
+  width: min(800px, 100%);
+  box-sizing: border-box;
   display: flex;
   align-items: center;
   gap: 4px;
@@ -1067,10 +933,12 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
   width: 100%;
   resize: none;
   overflow-y: hidden;
-  border-radius: 10px 10px 0 0;
+  min-height: 30px;
+  border-radius: 23px 23px 0 0;
   border: none;
-  padding: 10px 12px;
+  padding: 13px 16px 8px;
   font-size: 16px;
+  line-height: 1.45;
   background: transparent;
   color: #0f172a;
   box-sizing: border-box;
@@ -1083,9 +951,9 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
 }
 
 .micIcon {
-  width: 28px;
-  height: 28px;
-  border-radius: 8px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
   border: none;
   background: transparent;
   color: #64748b;
@@ -1121,34 +989,34 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
 }
 
 .sendIcon {
-  width: 28px;
-  height: 28px;
-  border-radius: 8px;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
   border: none;
-  background: transparent;
-  color: #2563eb;
+  background: #2563eb;
+  color: #ffffff;
   display: grid;
   place-items: center;
   cursor: pointer;
 }
 
 .sendIcon:disabled {
-  opacity: 0.35;
+  opacity: 0.4;
   cursor: not-allowed;
 }
 
 .sendIcon:hover:not(:disabled) {
-  color: #1d4ed8;
+  background: #1d4ed8;
 }
 
 .stopIcon {
   position: relative;
-  width: 28px;
-  height: 28px;
-  border-radius: 8px;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
   border: none;
-  background: transparent;
-  color: #dc2626;
+  background: #dc2626;
+  color: #ffffff;
   display: grid;
   place-items: center;
   cursor: pointer;
@@ -1171,7 +1039,23 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
 }
 
 .stopIcon:hover {
-  color: #b91c1c;
+  background: #b91c1c;
+}
+
+@media (max-width: 768px) {
+  .composer {
+    padding-left: 12px;
+    padding-right: 12px;
+    padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1));
+  }
+
+  .composer::before {
+    height: 160px;
+  }
+
+  .actionSheet {
+    width: min(270px, calc(100vw - 40px));
+  }
 }
 
 @keyframes voiceBars {

--- a/client/src/components/MainChatHeader.vue
+++ b/client/src/components/MainChatHeader.vue
@@ -1,12 +1,24 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { ChatDotRound, Delete, Refresh } from "@element-plus/icons-vue";
+
+import type { ModelConfig } from "../api/types";
+import MainChatModelPopover from "./MainChatModelPopover.vue";
 
 type HeaderAction = { title: string; ariaLabel?: string; testId?: string };
 type HeaderResumeAction = { title: string; ariaLabel?: string; testId?: string; disabled?: boolean };
+type AgentOption = { id: string; name: string; ready: boolean; error?: string };
 
 const props = defineProps<{
   title: string;
   busy: boolean;
+  connected: boolean;
+  inputLocked?: boolean;
+  agents?: AgentOption[];
+  activeAgentId?: string;
+  models?: ModelConfig[];
+  modelId?: string;
+  modelReasoningEffort?: string;
   headerAction?: HeaderAction;
   headerClearAction?: HeaderAction;
   headerResumeAction?: HeaderResumeAction;
@@ -17,7 +29,12 @@ const emit = defineEmits<{
   (e: "newSession"): void;
   (e: "clear"): void;
   (e: "resumeThread"): void;
+  (e: "switchAgent", agentId: string): void;
+  (e: "setModel", modelId: string): void;
+  (e: "setReasoningEffort", effort: string): void;
 }>();
+
+const hasModelSettings = computed(() => props.agents !== undefined || props.models !== undefined);
 </script>
 
 <template>
@@ -29,6 +46,20 @@ const emit = defineEmits<{
       </div>
     </div>
     <div class="paneHeaderActions">
+      <MainChatModelPopover
+        v-if="hasModelSettings"
+        :connected="props.connected"
+        :busy="props.busy"
+        :input-locked="props.inputLocked"
+        :agents="props.agents"
+        :active-agent-id="props.activeAgentId"
+        :models="props.models"
+        :model-id="props.modelId"
+        :model-reasoning-effort="props.modelReasoningEffort"
+        @switch-agent="emit('switchAgent', $event)"
+        @set-model="emit('setModel', $event)"
+        @set-reasoning-effort="emit('setReasoningEffort', $event)"
+      />
       <button
         v-if="props.headerResumeAction"
         class="paneHeaderIconBtn"
@@ -114,6 +145,7 @@ const emit = defineEmits<{
 .paneHeaderActions {
   display: flex;
   align-items: center;
+  min-width: 0;
   gap: 6px;
   flex: 0 0 auto;
 }

--- a/client/src/components/MainChatMessageList.vue
+++ b/client/src/components/MainChatMessageList.vue
@@ -753,12 +753,16 @@ function closeFilePreview(): void {
 
 .msg {
   display: flex;
-  margin-bottom: 10px;
+  margin-bottom: 18px;
   max-width: 100%;
   overflow: visible;
   justify-content: flex-start;
   content-visibility: auto;
   contain-intrinsic-size: auto 150px;
+}
+
+.msg[data-role="user"] {
+  justify-content: flex-end;
 }
 
 .messageHistorySentinel {
@@ -1109,17 +1113,17 @@ function closeFilePreview(): void {
 .bubble {
   width: 100%;
   max-width: 100%;
-  border-radius: 12px;
-  padding: 12px 14px 22px 14px;
-  border: 1px solid var(--github-border);
-  background: rgba(255, 255, 255, 0.94);
-  box-shadow: 0 1px 0 rgba(27, 31, 36, 0.04);
+  border-radius: 0;
+  padding: 4px 0 22px;
+  border: none;
+  background: transparent;
+  box-shadow: none;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .bubble--compact {
-  padding: 12px 14px;
+  padding: 0;
 }
 
 .bubble--retryNotice {
@@ -1188,19 +1192,44 @@ function closeFilePreview(): void {
 }
 
 .msg[data-role="user"] .bubble {
+  width: auto;
+  max-width: min(80%, 720px);
+  padding: 10px 14px;
+  border: 1px solid rgba(9, 105, 218, 0.18);
+  border-radius: 18px 18px 5px 18px;
   background: rgba(221, 244, 255, 0.82);
-  border-color: rgba(9, 105, 218, 0.18);
+  overflow: visible;
 }
 
 .msg[data-role="system"] .bubble {
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(208, 215, 222, 0.95);
   background: rgba(246, 248, 250, 0.96);
-  border-color: rgba(208, 215, 222, 0.95);
 }
 
 .msg[data-kind="error"] .bubble {
-  background: rgba(255, 247, 237, 0.96);
+  padding: 10px 14px 22px;
+  border: 1px solid rgba(251, 146, 60, 0.55);
   border-color: rgba(251, 146, 60, 0.55);
+  border-radius: 12px;
+  background: rgba(255, 247, 237, 0.96);
   color: #7c2d12;
+}
+
+.msg[data-kind="execute"] .bubble {
+  width: 100%;
+  max-width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--github-border);
+  border-radius: 12px;
+  background: rgba(248, 250, 252, 0.88);
+  overflow: hidden;
+}
+
+.msg[data-role="user"] .msgActions {
+  left: auto;
+  right: 10px;
 }
 
 .thoughtCard {

--- a/client/src/components/MainChatModelPopover.vue
+++ b/client/src/components/MainChatModelPopover.vue
@@ -1,0 +1,545 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+
+import type { ModelConfig } from "../api/types";
+import { normalizeReasoningEffort } from "../lib/chatPreferences";
+import { supportsAgentModel } from "../lib/model_agent";
+
+type AgentOption = { id: string; name: string; ready: boolean; error?: string };
+
+const DEFAULT_CODEX_REASONING_EFFORTS = ["medium", "high", "xhigh", "max", "ultra"] as const;
+const DEFAULT_CLAUDE_REASONING_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
+const REASONING_EFFORT_LABELS: Record<string, string> = {
+  off: "Off",
+  none: "None",
+  minimal: "Minimal",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "Extra High",
+  max: "Max",
+  ultra: "Ultra",
+};
+
+const REASONING_EFFORT_SHORT_LABELS: Record<string, string> = {
+  off: "Off",
+  none: "None",
+  minimal: "Minimal",
+  low: "低 (low)",
+  medium: "中 (medium)",
+  high: "高 (high)",
+  xhigh: "极高 (xhigh)",
+  max: "Max",
+  ultra: "Ultra",
+};
+
+const props = defineProps<{
+  connected: boolean;
+  busy: boolean;
+  inputLocked?: boolean;
+  agents?: AgentOption[];
+  activeAgentId?: string;
+  models?: ModelConfig[];
+  modelId?: string;
+  modelReasoningEffort?: string;
+}>();
+
+const emit = defineEmits<{
+  (e: "switchAgent", agentId: string): void;
+  (e: "setModel", modelId: string): void;
+  (e: "setReasoningEffort", effort: string): void;
+}>();
+
+const popoverRoot = ref<HTMLElement | null>(null);
+const open = ref(false);
+const lastAutoSwitchedAgentId = ref<string | null>(null);
+
+const agentOptions = computed(() => (Array.isArray(props.agents) ? props.agents : []));
+const readyAgentIds = computed(() =>
+  agentOptions.value
+    .filter((agent) => Boolean(agent?.ready))
+    .map((agent) => String(agent?.id ?? "").trim())
+    .filter(Boolean),
+);
+
+const selectedAgentId = computed(() => {
+  const active = String(props.activeAgentId ?? "").trim();
+  if (active && readyAgentIds.value.includes(active)) return active;
+  return readyAgentIds.value[0] ?? "";
+});
+
+watch(
+  () => [
+    Boolean(props.connected),
+    Boolean(props.busy),
+    Boolean(props.inputLocked),
+    String(props.activeAgentId ?? "").trim(),
+    readyAgentIds.value.join("\n"),
+  ],
+  () => {
+    if (!props.connected || props.busy || props.inputLocked) {
+      lastAutoSwitchedAgentId.value = null;
+      return;
+    }
+
+    if (readyAgentIds.value.length === 0) {
+      lastAutoSwitchedAgentId.value = null;
+      return;
+    }
+
+    const active = String(props.activeAgentId ?? "").trim();
+    if (active && readyAgentIds.value.includes(active)) {
+      lastAutoSwitchedAgentId.value = null;
+      return;
+    }
+
+    const next = selectedAgentId.value;
+    if (!next || next === active || lastAutoSwitchedAgentId.value === next) return;
+    lastAutoSwitchedAgentId.value = next;
+    emit("switchAgent", next);
+  },
+  { immediate: true },
+);
+
+const modelOptions = computed(() =>
+  (Array.isArray(props.models) ? props.models : []).filter((model) => model?.isEnabled !== false),
+);
+
+function normalizeModelId(value: unknown): string {
+  return typeof value === "string" ? value.trim() : String(value ?? "").trim();
+}
+
+function isUnsetModelId(modelId: string): boolean {
+  const id = String(modelId ?? "").trim().toLowerCase();
+  return !id || id === "auto";
+}
+
+function modelKey(model: ModelConfig): string {
+  return normalizeModelId(model.modelId ?? model.id);
+}
+
+function modelKeyOrEmpty(model: ModelConfig | null): string {
+  return model ? modelKey(model) : "";
+}
+
+function formatModelLabel(model: ModelConfig): string {
+  return String(model.displayName ?? "").trim() || modelKey(model) || "model";
+}
+
+function preferredModel(options: readonly ModelConfig[]): ModelConfig | null {
+  return options.find((model) => model.isDefault) ?? options[0] ?? null;
+}
+
+const compatibleModelOptions = computed(() => {
+  const agentId = selectedAgentId.value;
+  if (!agentId) return [];
+  return modelOptions.value.filter((model) => supportsAgentModel({ agentId, model }));
+});
+
+const effectiveModelId = computed(() => {
+  const options = compatibleModelOptions.value;
+  if (options.length === 0) return "";
+  const current = normalizeModelId(props.modelId);
+  const known = modelOptions.value.some((model) => modelKey(model) === current);
+  if (!isUnsetModelId(current) && (!known || options.some((model) => modelKey(model) === current))) {
+    return current;
+  }
+  return modelKeyOrEmpty(preferredModel(options));
+});
+
+watch(
+  () => [
+    Boolean(props.inputLocked),
+    selectedAgentId.value,
+    props.modelId,
+    compatibleModelOptions.value
+      .map((model) => `${modelKey(model)}:${model.isDefault ? "default" : "standard"}`)
+      .join("\n"),
+  ],
+  () => {
+    if (props.inputLocked) return;
+    const options = compatibleModelOptions.value;
+    if (options.length === 0) return;
+    const desired = modelKeyOrEmpty(preferredModel(options));
+    if (!desired) return;
+
+    const current = normalizeModelId(props.modelId);
+    const known = modelOptions.value.some((model) => modelKey(model) === current);
+    if (!isUnsetModelId(current) && (!known || options.some((model) => modelKey(model) === current))) return;
+    if (desired !== current) emit("setModel", desired);
+  },
+  { immediate: true },
+);
+
+const selectedModel = computed(() => {
+  const modelId = effectiveModelId.value;
+  return compatibleModelOptions.value.find((model) => modelKey(model) === modelId) ?? null;
+});
+
+const reasoningEffortOptions = computed(() => {
+  if (!selectedModel.value) return [];
+
+  const fallback = selectedAgentId.value === "codex"
+    ? DEFAULT_CODEX_REASONING_EFFORTS
+    : DEFAULT_CLAUDE_REASONING_EFFORTS;
+  const config = selectedModel.value.configJson;
+  const raw = config && typeof config === "object" && !Array.isArray(config)
+    ? (config as Record<string, unknown>).reasoningEfforts
+    : null;
+  if (!Array.isArray(raw)) return [...fallback];
+
+  const values = raw
+    .map((entry) => String(entry ?? "").trim().toLowerCase())
+    .filter((entry) => Boolean(REASONING_EFFORT_LABELS[entry]));
+  return values.length > 0 ? [...new Set(values)] : [...fallback];
+});
+
+const reasoningEffortValue = computed(() => {
+  const normalized = normalizeReasoningEffort(props.modelReasoningEffort);
+  if (reasoningEffortOptions.value.includes(normalized)) return normalized;
+  if (reasoningEffortOptions.value.includes("high")) return "high";
+  return reasoningEffortOptions.value[0] ?? "";
+});
+
+watch(
+  () => [
+    Boolean(props.inputLocked),
+    selectedAgentId.value,
+    effectiveModelId.value,
+    String(props.modelReasoningEffort ?? "").trim().toLowerCase(),
+    reasoningEffortOptions.value.join("\n"),
+  ],
+  () => {
+    if (props.inputLocked || reasoningEffortOptions.value.length === 0) return;
+    const current = String(props.modelReasoningEffort ?? "").trim().toLowerCase();
+    if (!current || current === reasoningEffortValue.value) return;
+    emit("setReasoningEffort", reasoningEffortValue.value);
+  },
+  { immediate: true },
+);
+
+const selectedModelLabel = computed(() => selectedModel.value ? formatModelLabel(selectedModel.value) : "选择模型");
+const selectedReasoningLabel = computed(() => {
+  const effort = reasoningEffortValue.value;
+  return effort ? REASONING_EFFORT_SHORT_LABELS[effort] ?? effort : "";
+});
+const canChange = computed(() => props.connected && !props.busy && !props.inputLocked);
+
+function selectModel(modelId: string): void {
+  if (!canChange.value || !compatibleModelOptions.value.some((model) => modelKey(model) === modelId)) return;
+  emit("setModel", modelId);
+}
+
+function selectReasoningEffort(effort: string): void {
+  if (!canChange.value || !reasoningEffortOptions.value.includes(effort)) return;
+  emit("setReasoningEffort", effort);
+}
+
+function onDocumentPointerDown(event: Event): void {
+  const target = event.target;
+  if (target instanceof Node && popoverRoot.value?.contains(target)) return;
+  open.value = false;
+}
+
+function onDocumentKeydown(event: KeyboardEvent): void {
+  if (event.key === "Escape") open.value = false;
+}
+
+onMounted(() => {
+  document.addEventListener("pointerdown", onDocumentPointerDown);
+  document.addEventListener("keydown", onDocumentKeydown);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener("pointerdown", onDocumentPointerDown);
+  document.removeEventListener("keydown", onDocumentKeydown);
+});
+</script>
+
+<template>
+  <div ref="popoverRoot" class="modelPopover">
+    <button
+      class="modelPopoverToggle"
+      type="button"
+      :disabled="busy || inputLocked"
+      :aria-expanded="open"
+      aria-haspopup="dialog"
+      aria-label="模型与推理强度"
+      data-testid="chat-model-popover-toggle"
+      @click.stop="open = !open"
+    >
+      <span class="modelPopoverIcon" aria-hidden="true">🧠</span>
+      <span class="modelPopoverSummary" data-testid="chat-model-summary">
+        <span class="modelPopoverModel">{{ selectedModelLabel }}</span>
+        <span v-if="selectedReasoningLabel" class="modelPopoverEffort">⚡ {{ selectedReasoningLabel }}</span>
+      </span>
+      <svg class="modelPopoverChevron" width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="m5 7 5 5 5-5" />
+      </svg>
+    </button>
+
+    <div
+      v-show="open"
+      class="modelPopoverMenu"
+      role="dialog"
+      aria-label="模型与推理强度设置"
+      :aria-hidden="!open"
+      data-testid="chat-model-popover-menu"
+    >
+      <section class="modelPopoverSection" aria-labelledby="model-popover-models-title">
+        <div id="model-popover-models-title" class="modelPopoverSectionTitle">Models</div>
+        <div v-if="compatibleModelOptions.length" class="modelPopoverOptions" role="radiogroup" aria-label="Models">
+          <button
+            v-for="model in compatibleModelOptions"
+            :key="modelKey(model)"
+            class="modelPopoverOption"
+            :class="{ active: modelKey(model) === effectiveModelId }"
+            type="button"
+            role="radio"
+            :aria-checked="modelKey(model) === effectiveModelId"
+            :disabled="!canChange"
+            data-testid="chat-model-option"
+            :data-model-id="modelKey(model)"
+            @click="selectModel(modelKey(model))"
+          >
+            <span class="modelPopoverOptionLabel">{{ formatModelLabel(model) }}</span>
+            <span v-if="modelKey(model) === effectiveModelId" class="modelPopoverCheck" aria-hidden="true">✓</span>
+          </button>
+        </div>
+        <div v-else class="modelPopoverEmpty">No compatible models</div>
+      </section>
+
+      <section v-if="reasoningEffortOptions.length" class="modelPopoverSection" aria-labelledby="model-popover-reasoning-title">
+        <div id="model-popover-reasoning-title" class="modelPopoverSectionTitle">Reasoning effort</div>
+        <div class="modelPopoverReasoning" role="group" aria-label="Reasoning effort" data-testid="chat-reasoning-effort">
+          <button
+            v-for="effort in reasoningEffortOptions"
+            :key="effort"
+            class="modelPopoverReasoningOption"
+            :class="{ active: effort === reasoningEffortValue }"
+            type="button"
+            :aria-pressed="effort === reasoningEffortValue"
+            :disabled="!canChange"
+            :data-reasoning-effort="effort"
+            @click="selectReasoningEffort(effort)"
+          >
+            {{ REASONING_EFFORT_SHORT_LABELS[effort] ?? REASONING_EFFORT_LABELS[effort] ?? effort }}
+          </button>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.modelPopover {
+  position: relative;
+  min-width: 0;
+}
+
+.modelPopoverToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  max-width: min(280px, 42vw);
+  min-height: 32px;
+  padding: 5px 9px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 999px;
+  background: rgba(248, 250, 252, 0.92);
+  color: #334155;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.modelPopoverToggle:hover:not(:disabled),
+.modelPopoverToggle[aria-expanded="true"] {
+  border-color: rgba(37, 99, 235, 0.32);
+  background: #ffffff;
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.08);
+}
+
+.modelPopoverToggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.14);
+}
+
+.modelPopoverToggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
+.modelPopoverIcon {
+  flex: 0 0 auto;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.modelPopoverSummary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.modelPopoverModel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.modelPopoverEffort {
+  flex: 0 0 auto;
+  color: #64748b;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.modelPopoverChevron {
+  flex: 0 0 auto;
+  color: #64748b;
+  transition: transform 0.15s ease;
+}
+
+.modelPopoverToggle[aria-expanded="true"] .modelPopoverChevron {
+  transform: rotate(180deg);
+}
+
+.modelPopoverMenu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 220;
+  display: flex;
+  flex-direction: column;
+  width: min(340px, calc(100vw - 24px));
+  max-height: min(70vh, 480px);
+  overflow: auto;
+  padding: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.16);
+}
+
+.modelPopoverSection + .modelPopoverSection {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(226, 232, 240, 0.9);
+}
+
+.modelPopoverSectionTitle {
+  padding: 3px 7px 6px;
+  color: #64748b;
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.modelPopoverOptions {
+  display: grid;
+  gap: 2px;
+}
+
+.modelPopoverOption {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  min-height: 34px;
+  padding: 7px 9px;
+  border: none;
+  border-radius: 9px;
+  background: transparent;
+  color: #334155;
+  text-align: left;
+  cursor: pointer;
+}
+
+.modelPopoverOption:hover:not(:disabled),
+.modelPopoverOption.active {
+  background: rgba(37, 99, 235, 0.08);
+  color: #1d4ed8;
+}
+
+.modelPopoverOption:focus-visible,
+.modelPopoverReasoningOption:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.5);
+  outline-offset: -2px;
+}
+
+.modelPopoverOption:disabled,
+.modelPopoverReasoningOption:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.modelPopoverOptionLabel {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.modelPopoverCheck {
+  flex: 0 0 auto;
+  color: #2563eb;
+  font-size: 15px;
+  font-weight: 900;
+}
+
+.modelPopoverEmpty {
+  padding: 8px 9px;
+  color: #94a3b8;
+  font-size: 12px;
+}
+
+.modelPopoverReasoning {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 2px;
+  border-radius: 11px;
+  background: #f1f5f9;
+}
+
+.modelPopoverReasoningOption {
+  flex: 1 1 auto;
+  min-width: 68px;
+  min-height: 30px;
+  padding: 5px 7px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: #64748b;
+  font-size: 11px;
+  font-weight: 800;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.modelPopoverReasoningOption:hover:not(:disabled),
+.modelPopoverReasoningOption.active {
+  background: #ffffff;
+  color: #1d4ed8;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.1);
+}
+
+@media (max-width: 768px) {
+  .modelPopoverToggle {
+    max-width: min(230px, 60vw);
+  }
+
+  .modelPopoverMenu {
+    right: -4px;
+  }
+}
+</style>

--- a/client/src/components/mainChat/useComposer.ts
+++ b/client/src/components/mainChat/useComposer.ts
@@ -95,7 +95,7 @@ export function useMainChatComposer(params: {
   const resizeComposer = (): void => {
     const el = inputEl.value;
     if (!el) return;
-    autosizeTextarea(el, { minRows: 5, maxRows: 8 });
+    autosizeTextarea(el, { minRows: 1, maxRows: 8 });
   };
 
   // Resize after Vue commits DOM updates (v-model, conditional UI that affects wrapping, etc).


### PR DESCRIPTION
## Summary
- flatten the chat workspace into an edge-to-edge canvas with a compact lane switcher
- move model and reasoning controls into a unified header popover
- add a centered floating composer capsule with a plus action sheet
- render assistant messages without card framing and user messages as right-aligned capsules

## Verification
- `npm run test:web` (83 files, 466 tests passed)
- targeted UI regression tests after final modal-layering fix (5 files, 31 tests passed)
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`
- `npm test` currently reports 720 passed and 1 failure in the existing `SystemPromptManager` no-lane test; the same failure reproduces on clean `dev` because globally discovered skill descriptions contain `Advisor lane` / `Worker lane`.

Closes #180
