### PR TITLE
fix(web): compact chat controls and composer

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,5 +1,5 @@
 .app {
-  --topbar-height: 48px;
+  --topbar-height: 40px;
   position: fixed;
   top: var(--app-top, 0px);
   left: 0;
@@ -596,8 +596,8 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  min-height: 40px;
-  padding: 4px 16px;
+  min-height: 36px;
+  padding: 2px 12px;
   border-bottom: 1px solid var(--border);
   background: var(--surface);
   box-sizing: border-box;
@@ -648,7 +648,7 @@
   color: #64748b;
   font-size: 13px;
   font-weight: 800;
-  padding: 6px 14px;
+  padding: 4px 12px;
   border-radius: 999px;
   cursor: pointer;
   white-space: nowrap;
@@ -765,7 +765,7 @@
 }
 @media (max-width: 900px) {
   .app {
-    --topbar-height: 40px;
+    --topbar-height: 36px;
   }
   .topbar,
   .laneTabs {
@@ -1105,8 +1105,8 @@
   }
   .laneTabs {
     width: 100%;
-    min-height: 36px;
-    padding: 2px 10px;
+    min-height: 32px;
+    padding: 0 8px;
     gap: 6px;
     justify-content: space-between;
   }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -763,6 +763,12 @@
   to { transform: rotate(360deg); }
 }
 @media (max-width: 900px) {
+  .topbar,
+  .laneTabs {
+    border-bottom: 0;
+    box-shadow: none;
+    background: var(--app-bg);
+  }
   .layout {
     grid-template-columns: 1fr;
     padding: 0;

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,4 +1,5 @@
 .app {
+  --topbar-height: 48px;
   position: fixed;
   top: var(--app-top, 0px);
   left: 0;
@@ -12,7 +13,7 @@
 }
 .topbar {
   flex-shrink: 0;
-  height: calc(48px + env(safe-area-inset-top, 0px));
+  height: calc(var(--topbar-height) + env(safe-area-inset-top, 0px));
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -727,7 +728,7 @@
 .noticeToast {
   position: fixed;
   left: 50%;
-  top: calc(48px + env(safe-area-inset-top, 0px) + 12px);
+  top: calc(var(--topbar-height) + env(safe-area-inset-top, 0px) + 12px);
   transform: translateX(-50%);
   display: inline-flex;
   align-items: center;
@@ -763,6 +764,9 @@
   to { transform: rotate(360deg); }
 }
 @media (max-width: 900px) {
+  .app {
+    --topbar-height: 40px;
+  }
   .topbar,
   .laneTabs {
     border-bottom: 0;
@@ -789,7 +793,7 @@
     display: grid;
     place-items: center;
     width: 44px;
-    height: 44px;
+    height: var(--topbar-height);
     padding: 0;
     flex: 0 0 auto;
     border: none;
@@ -880,7 +884,7 @@
   }
   .left.mobileDrawer {
     position: fixed;
-    top: calc(48px + env(safe-area-inset-top, 0px));
+    top: calc(var(--topbar-height) + env(safe-area-inset-top, 0px));
     bottom: 0;
     left: 0;
     z-index: 110;
@@ -982,7 +986,7 @@
   }
   .mobileDrawerBackdrop {
     position: fixed;
-    inset: calc(48px + env(safe-area-inset-top, 0px)) 0 0;
+    inset: calc(var(--topbar-height) + env(safe-area-inset-top, 0px)) 0 0;
     z-index: 100;
     background: rgba(15, 23, 42, 0.34);
     backdrop-filter: blur(2px);
@@ -1101,7 +1105,8 @@
   }
   .laneTabs {
     width: 100%;
-    padding: 4px 10px;
+    min-height: 36px;
+    padding: 2px 10px;
     gap: 6px;
     justify-content: space-between;
   }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,6 +1,6 @@
 .app {
   position: fixed;
-  top: 0;
+  top: var(--app-top, 0px);
   left: 0;
   right: 0;
   height: var(--ads-visual-viewport-height, 100dvh);

--- a/client/src/__tests__/chat-bubble-style-regression.test.ts
+++ b/client/src/__tests__/chat-bubble-style-regression.test.ts
@@ -1,16 +1,53 @@
 import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import MainChatMessageList from "../components/MainChatMessageList.vue";
 import { readSfc } from "./readSfc";
 
 describe("chat bubble and popover style regressions", () => {
-  it("renders user bubbles with light blue background and bottom clearance for actions", async () => {
+  it("keeps user bubbles full width with actions in the normal flow", async () => {
     const css = await readSfc("../components/MainChatMessageList.vue", import.meta.url);
+    const userBubble = css.match(/\.msg\[data-role="user"\]\s+\.bubble\s*\{[^}]*\}/)?.[0];
+    const userActions = css.match(/\.msg\[data-role="user"\]\s+\.msgActions\s*\{[^}]*\}/)?.[0];
 
-    // User bubbles must use light blue background
-    expect(css).toMatch(/\.msg\[data-role="user"\]\s+\.bubble\s*\{[\s\S]*?background:\s*rgba\(221,\s*244,\s*255,\s*0\.88\)/);
-    expect(css).toMatch(/\.msg\[data-role="user"\]\s+\.bubble\s*\{[\s\S]*?padding:\s*10px 16px 28px/);
+    expect(userBubble).toMatch(/\n\s+width:\s*100%\s*;/);
+    expect(userBubble).toMatch(/max-width:\s*100%\s*;/);
+    expect(userBubble).toMatch(/background:\s*rgba\(221,\s*244,\s*255,\s*0\.88\)/);
+    expect(userBubble).toMatch(/padding:\s*10px 16px 8px\s*;/);
+    expect(userActions).toMatch(/position:\s*static\s*;/);
+    expect(userActions).toMatch(/display:\s*flex\s*;/);
+    expect(userActions).toMatch(/flex-wrap:\s*wrap\s*;/);
+    expect(userActions).toMatch(/justify-content:\s*flex-end\s*;/);
+    expect(userActions).not.toMatch(/(?:left|right|bottom):/);
 
     // Assistant bubbles must not stack unnecessary horizontal padding
     expect(css).toMatch(/\.bubble\s*\{[\s\S]*?padding:\s*4px 0 24px/);
+  });
+
+  it.each([
+    { label: "short text", content: "a" },
+    { label: "wrapped text", content: "A longer user message ".repeat(20) },
+  ])("keeps copy and timestamp inside the user bubble for $label", async ({ content }) => {
+    const wrapper = mount(MainChatMessageList, {
+      props: {
+        messages: [{ id: "user-message", role: "user", kind: "text", content, ts: 1 }],
+        copiedMessageId: null,
+        formatMessageTs: () => "09:15",
+        liveStepExpanded: false,
+        liveStepHasOverflow: false,
+        liveStepCanToggleExpanded: false,
+        liveStepOutlineItems: [],
+        liveStepOutlineHiddenCount: 0,
+        liveStepCollapsedTrivialOutline: false,
+      },
+      global: { stubs: { MarkdownContent: true, ChatFilePreviewModal: true } },
+    });
+    const actions = wrapper.get('.msg[data-role="user"] .bubble > .msgActions');
+
+    expect(actions.get(".msgTime").text()).toBe("09:15");
+    await actions.get(".msgCopyBtn").trigger("click");
+    expect(wrapper.emitted("copyMessage")?.[0]?.[0]).toMatchObject({ id: "user-message", role: "user", content });
+    wrapper.unmount();
   });
 
   it("renders reasoning effort options as a vertical list instead of horizontal wrap", async () => {

--- a/client/src/__tests__/chat-bubble-style-regression.test.ts
+++ b/client/src/__tests__/chat-bubble-style-regression.test.ts
@@ -5,15 +5,17 @@ import MainChatMessageList from "../components/MainChatMessageList.vue";
 import { readSfc } from "./readSfc";
 
 describe("chat bubble and popover style regressions", () => {
-  it("keeps user bubbles full width with actions in the normal flow", async () => {
+  it("keeps user messages full width without a visual bubble", async () => {
     const css = await readSfc("../components/MainChatMessageList.vue", import.meta.url);
     const userBubble = css.match(/\.msg\[data-role="user"\]\s+\.bubble\s*\{[^}]*\}/)?.[0];
     const userActions = css.match(/\.msg\[data-role="user"\]\s+\.msgActions\s*\{[^}]*\}/)?.[0];
 
     expect(userBubble).toMatch(/\n\s+width:\s*100%\s*;/);
     expect(userBubble).toMatch(/max-width:\s*100%\s*;/);
-    expect(userBubble).toMatch(/background:\s*rgba\(221,\s*244,\s*255,\s*0\.88\)/);
-    expect(userBubble).toMatch(/padding:\s*10px 16px 8px\s*;/);
+    expect(userBubble).toMatch(/background:\s*transparent\s*;/);
+    expect(userBubble).toMatch(/border:\s*none\s*;/);
+    expect(userBubble).toMatch(/border-radius:\s*0\s*;/);
+    expect(userBubble).toMatch(/padding:\s*4px 0 8px\s*;/);
     expect(userActions).toMatch(/position:\s*static\s*;/);
     expect(userActions).toMatch(/display:\s*flex\s*;/);
     expect(userActions).toMatch(/flex-wrap:\s*wrap\s*;/);

--- a/client/src/__tests__/execute-stacking-and-command-collapse.test.ts
+++ b/client/src/__tests__/execute-stacking-and-command-collapse.test.ts
@@ -119,7 +119,8 @@ describe("chat execute stacking and command collapse", () => {
     wrapper.unmount();
   });
 
-  it("expands replayed execute blocks with retained full output", async () => {
+  it("keeps replayed execute output at three lines while preserving full output for copying", async () => {
+    const fullOutput = Array.from({ length: 2500 }, (_, index) => `line ${index + 1}`).join("\n");
     const wrapper = mount(MainChatMessageList, {
       props: {
         messages: [
@@ -128,9 +129,9 @@ describe("chat execute stacking and command collapse", () => {
             role: "system",
             kind: "execute",
             content: "line 1\nline 2\nline 3",
-            fullContent: "line 1\nline 2\nline 3\nline 4\nline 5",
+            fullContent: fullOutput,
             command: "npm test",
-            hiddenLineCount: 2,
+            hiddenLineCount: 2497,
           },
         ],
         copiedMessageId: null,
@@ -154,20 +155,21 @@ describe("chat execute stacking and command collapse", () => {
     await settleUi(wrapper);
 
     expect(wrapper.find(".execute-output").text()).not.toContain("line 5");
-    const toggle = wrapper.find(".execute-more--button");
-    expect(toggle.exists()).toBe(true);
-    expect(toggle.text()).toContain("还有 2 行");
+    expect(wrapper.find(".execute-output").text().split("\n")).toHaveLength(3);
+    expect(wrapper.find(".execute-more--button").exists()).toBe(false);
+    expect(wrapper.find(".execute-more").text()).toContain("2497");
+    await wrapper.get(".execute-more").trigger("click");
+    expect(wrapper.find(".execute-output").text()).not.toContain("line 4");
+    expect(wrapper.find(".execute-output--expanded").exists()).toBe(false);
 
-    await toggle.trigger("click");
-
-    expect(wrapper.find(".execute-output").text()).toContain("line 5");
-    expect(wrapper.find(".execute-more--button").text()).toContain("收起输出");
+    await wrapper.get(".executeCopyBtn").trigger("click");
+    expect(wrapper.emitted("copyMessage")?.[0]?.[0]).toMatchObject({ fullContent: fullOutput });
 
     wrapper.unmount();
   });
 
   it("truncates multi-line execute content to at most 3 lines even without fullContent", async () => {
-    const longOutput = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join("\n");
+    const longOutput = Array.from({ length: 1500 }, (_, i) => `line ${i + 1}`).join("\n");
     const wrapper = mount(MainChatMessageList, {
       props: {
         messages: [
@@ -177,6 +179,7 @@ describe("chat execute stacking and command collapse", () => {
             kind: "execute",
             content: longOutput,
             command: "git log",
+            streaming: true,
           },
         ],
         copiedMessageId: null,
@@ -206,18 +209,16 @@ describe("chat execute stacking and command collapse", () => {
     expect(outputText).toContain("line 3");
     expect(outputText).not.toContain("line 4");
 
-    const toggle = wrapper.find(".execute-more--button");
-    expect(toggle.exists()).toBe(true);
-    expect(toggle.text()).toContain("还有 47 行");
-
-    await toggle.trigger("click");
-
-    expect(wrapper.find(".execute-output").text()).toContain("line 50");
-    expect(wrapper.find(".execute-more--button").text()).toContain("收起输出");
-
-    await toggle.trigger("click");
+    expect(wrapper.find(".execute-more--button").exists()).toBe(false);
+    expect(wrapper.find(".execute-more").text()).toContain("1497");
+    await wrapper.get(".execute-more").trigger("click");
     expect(wrapper.find(".execute-output").text()).not.toContain("line 4");
-    expect(wrapper.find(".execute-more--button").text()).toContain("还有 47 行");
+
+    await wrapper.setProps({ messages: [{ id: "e-long", role: "system", kind: "execute", content: `${longOutput}\nlast line`, command: "git log", streaming: false }] });
+    await settleUi(wrapper);
+    expect(wrapper.find(".execute-output").text().split("\n")).toHaveLength(3);
+    expect(wrapper.find(".execute-output").text()).not.toContain("last line");
+    expect(wrapper.find(".execute-more").text()).toContain("1498");
 
     wrapper.unmount();
   });

--- a/client/src/__tests__/mainchat-composer-layout.test.ts
+++ b/client/src/__tests__/mainchat-composer-layout.test.ts
@@ -196,8 +196,9 @@ describe("MainChat compact composer layout", () => {
   it("puts multiline text across the full row with actions underneath", async () => {
     const composer = await readSfc("../components/MainChatComposerPanel.vue", import.meta.url);
 
-    expect(composer).toMatch(/\.composerMainRow--expanded\s*\{[^}]*flex-wrap:\s*wrap\s*;/);
-    expect(composer).toMatch(/\.composerMainRow--expanded\s+\.composer-input\s*\{[^}]*order:\s*-1\s*;[^}]*flex-basis:\s*100%\s*;/);
-    expect(composer).toMatch(/\.composerMainRow--expanded\s+\.composerMainRowRight\s*\{[^}]*margin-left:\s*auto\s*;/);
+    expect(composer).toMatch(/\.composerMainRow\s*\{[^}]*display:\s*grid\s*;[^}]*grid-template-columns:\s*auto minmax\(0,\s*1fr\) auto\s*;[^}]*grid-template-areas:\s*"left input right"\s*;/);
+    expect(composer).toMatch(/\.composerMainRow--expanded\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\) auto\s*;[^}]*grid-template-areas:\s*[\s\S]*"input input"[\s\S]*"left right"/);
+    expect(composer).toMatch(/\.composerMainRow--expanded\s+\.composer-input\s*\{[^}]*width:\s*100%\s*;/);
+    expect(composer).not.toMatch(/\.composerMainRow--expanded\s*\{[^}]*flex-wrap:\s*wrap\s*;/);
   });
 });

--- a/client/src/__tests__/mainchat-composer-layout.test.ts
+++ b/client/src/__tests__/mainchat-composer-layout.test.ts
@@ -182,11 +182,14 @@ describe("MainChat compact composer layout", () => {
     expect(chat).toMatch(/\.chat\s*\{[^}]*flex:\s*1 1 auto\s*;/);
   });
 
-  it("leaves only the device safe area below the visible input border", async () => {
+  it("keeps the visible input border at the viewport bottom with the safe area inside", async () => {
     const composer = await readSfc("../components/MainChatComposerPanel.vue", import.meta.url);
-    const rule = composer.match(/\.composer\s*\{[^}]*\}/)?.[0];
+    const composerRule = composer.match(/\.composer\s*\{[^}]*\}/)?.[0];
+    const inputWrapRule = composer.match(/\.inputWrap\s*\{[^}]*\}/)?.[0];
 
-    expect(rule).toContain("padding: 8px 16px calc(env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1));");
+    expect(composerRule).toContain("padding: 8px 16px 0;");
+    expect(composerRule).not.toContain("safe-area-inset-bottom");
+    expect(inputWrapRule).toContain("padding-bottom: calc(env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1));");
     expect(composer).not.toMatch(/padding-bottom:\s*calc\(12px\s*\+/);
   });
 

--- a/client/src/__tests__/mainchat-composer-layout.test.ts
+++ b/client/src/__tests__/mainchat-composer-layout.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { defineComponent, nextTick, ref } from "vue";
+
+import MainChatComposerPanel from "../components/MainChatComposerPanel.vue";
+import { readSfc } from "./readSfc";
+
+const ComposerHost = defineComponent({
+  components: { MainChatComposerPanel },
+  setup() {
+    const draft = ref("");
+    return { draft };
+  },
+  template: `
+    <MainChatComposerPanel
+      v-model:draft="draft"
+      :queued-prompts="[]"
+      :pending-images="[]"
+      :connected="true"
+      :busy="false"
+    />
+  `,
+});
+
+describe("MainChat compact composer layout", () => {
+  beforeEach(() => {
+    vi.spyOn(window, "getComputedStyle").mockReturnValue({
+      boxSizing: "border-box",
+      lineHeight: "24px",
+      fontSize: "16px",
+      paddingTop: "5px",
+      paddingBottom: "5px",
+      borderTopWidth: "0px",
+      borderBottomWidth: "0px",
+    } as CSSStyleDeclaration);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("places the single-line input between the action and send controls", () => {
+    const wrapper = mount(ComposerHost);
+    const row = wrapper.get(".composerMainRow");
+    const textarea = row.get("textarea.composer-input");
+
+    expect((textarea.element as HTMLTextAreaElement).rows).toBe(1);
+    expect(Array.from(row.element.children).map((element) => element.className)).toEqual([
+      "composerMainRowLeft",
+      "composer-input",
+      "composerMainRowRight",
+    ]);
+    expect(row.get('[data-testid="composer-actions-toggle"]').exists()).toBe(true);
+    expect(row.get(".micIcon").exists()).toBe(true);
+    expect(row.get(".sendIcon").exists()).toBe(true);
+    expect(textarea.attributes("title")).toContain("Shift+Enter");
+    wrapper.unmount();
+  });
+
+  it("grows with content and returns to one line after sending or clearing", async () => {
+    vi.spyOn(HTMLTextAreaElement.prototype, "scrollHeight", "get").mockImplementation(function (this: HTMLTextAreaElement) {
+      return this.value.split("\n").length * 24 + 10;
+    });
+
+    const wrapper = mount(ComposerHost);
+    const textarea = wrapper.get("textarea.composer-input");
+    const element = textarea.element as HTMLTextAreaElement;
+    const longDraft = Array.from({ length: 12 }, (_, index) => `Line ${index}`).join("\n");
+
+    expect(element.style.height).toBe("34px");
+    await textarea.setValue("First line\nSecond line");
+    expect(element.style.height).toBe("58px");
+    expect(element.style.overflowY).toBe("hidden");
+
+    await textarea.setValue(longDraft);
+    expect(element.style.height).toBe("202px");
+    expect(element.style.overflowY).toBe("auto");
+
+    await wrapper.get(".sendIcon").trigger("click");
+    expect(wrapper.getComponent(MainChatComposerPanel).emitted("send")).toEqual([[longDraft]]);
+    expect(element.value).toBe("");
+    expect(element.style.height).toBe("34px");
+    expect(element.style.overflowY).toBe("hidden");
+
+    await textarea.setValue(longDraft);
+    await textarea.setValue("");
+    expect(element.style.height).toBe("34px");
+    wrapper.unmount();
+  });
+
+  it("resizes wrapped drafts when a hidden lane becomes visible without a height feedback loop", async () => {
+    const scrollHeight = vi.spyOn(HTMLTextAreaElement.prototype, "scrollHeight", "get").mockReturnValue(34);
+    const observers: Array<{ callback: ResizeObserverCallback; observer: ResizeObserver }> = [];
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    const animationFrames: FrameRequestCallback[] = [];
+    let nextFrameId = 0;
+    vi.stubGlobal("requestAnimationFrame", vi.fn((callback: FrameRequestCallback) => {
+      animationFrames.push(callback);
+      return ++nextFrameId;
+    }));
+    const cancelFrame = vi.fn();
+    vi.stubGlobal("cancelAnimationFrame", cancelFrame);
+    vi.stubGlobal("ResizeObserver", class {
+      observe = observe;
+      disconnect = disconnect;
+      unobserve = vi.fn();
+
+      constructor(callback: ResizeObserverCallback) {
+        observers.push({ callback, observer: this });
+      }
+    });
+
+    const wrapper = mount(ComposerHost);
+    const textarea = wrapper.get("textarea.composer-input");
+    const element = textarea.element as HTMLTextAreaElement;
+    const notifyWidth = (width: number, flushFrames = true): void => {
+      const { callback, observer } = observers[0]!;
+      callback([{ target: element, contentRect: { width } } as ResizeObserverEntry], observer);
+      if (flushFrames) {
+        for (const frame of animationFrames.splice(0)) frame(0);
+      }
+    };
+    await nextTick();
+    expect(observe).toHaveBeenCalledWith(element);
+    notifyWidth(240);
+    scrollHeight.mockReturnValue(298);
+    await textarea.setValue("Wrapped draft content ".repeat(150));
+    expect(element.style.height).toBe("202px");
+
+    notifyWidth(0);
+    scrollHeight.mockReturnValue(0);
+    window.dispatchEvent(new Event("resize"));
+    scrollHeight.mockReturnValue(298);
+    notifyWidth(240);
+    expect(element.style.height).toBe("202px");
+    expect(element.style.overflowY).toBe("auto");
+
+    scrollHeight.mockClear();
+    notifyWidth(240);
+    expect(scrollHeight).not.toHaveBeenCalled();
+    notifyWidth(320, false);
+    wrapper.unmount();
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(cancelFrame).toHaveBeenLastCalledWith(nextFrameId);
+  });
+
+  it("keeps controls compact and the composer in the bottom flex flow", async () => {
+    const composer = await readSfc("../components/MainChatComposerPanel.vue", import.meta.url);
+    const chat = await readSfc("../components/MainChat.vue", import.meta.url);
+
+    expect(composer).toMatch(/\.composerMainRow\s*\{[^}]*align-items:\s*flex-end\s*;/);
+    expect(composer).toMatch(/\.composerMainRowLeft,\s*\.composerMainRowRight\s*\{[^}]*flex:\s*0 0 auto\s*;/);
+    expect(composer).toMatch(/\.composer-input\s*\{[^}]*flex:\s*1 1 auto\s*;[^}]*min-width:\s*0\s*;/);
+    expect(composer).toMatch(/\.composer\s*\{[^}]*flex-shrink:\s*0\s*;/);
+    expect(composer).not.toMatch(/\.composer\s*\{[^}]*position:\s*(absolute|fixed)\s*;/);
+    expect(chat).toMatch(/\.detail\s*\{[^}]*display:\s*flex\s*;[^}]*flex-direction:\s*column\s*;/);
+    expect(chat).toMatch(/\.chat\s*\{[^}]*flex:\s*1 1 auto\s*;/);
+  });
+});

--- a/client/src/__tests__/mainchat-composer-layout.test.ts
+++ b/client/src/__tests__/mainchat-composer-layout.test.ts
@@ -158,4 +158,12 @@ describe("MainChat compact composer layout", () => {
     expect(chat).toMatch(/\.detail\s*\{[^}]*display:\s*flex\s*;[^}]*flex-direction:\s*column\s*;/);
     expect(chat).toMatch(/\.chat\s*\{[^}]*flex:\s*1 1 auto\s*;/);
   });
+
+  it("leaves only the device safe area below the visible input border", async () => {
+    const composer = await readSfc("../components/MainChatComposerPanel.vue", import.meta.url);
+    const rule = composer.match(/\.composer\s*\{[^}]*\}/)?.[0];
+
+    expect(rule).toContain("padding: 8px 16px calc(env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1));");
+    expect(composer).not.toMatch(/padding-bottom:\s*calc\(12px\s*\+/);
+  });
 });

--- a/client/src/__tests__/mainchat-composer-layout.test.ts
+++ b/client/src/__tests__/mainchat-composer-layout.test.ts
@@ -69,9 +69,11 @@ describe("MainChat compact composer layout", () => {
     const longDraft = Array.from({ length: 12 }, (_, index) => `Line ${index}`).join("\n");
 
     expect(element.style.height).toBe("34px");
+    expect(wrapper.get(".composerMainRow").classes()).not.toContain("composerMainRow--expanded");
     await textarea.setValue("First line\nSecond line");
     expect(element.style.height).toBe("58px");
     expect(element.style.overflowY).toBe("hidden");
+    expect(wrapper.get(".composerMainRow").classes()).toContain("composerMainRow--expanded");
 
     await textarea.setValue(longDraft);
     expect(element.style.height).toBe("202px");
@@ -82,10 +84,31 @@ describe("MainChat compact composer layout", () => {
     expect(element.value).toBe("");
     expect(element.style.height).toBe("34px");
     expect(element.style.overflowY).toBe("hidden");
+    expect(wrapper.get(".composerMainRow").classes()).not.toContain("composerMainRow--expanded");
 
     await textarea.setValue(longDraft);
     await textarea.setValue("");
     expect(element.style.height).toBe("34px");
+    expect(wrapper.get(".composerMainRow").classes()).not.toContain("composerMainRow--expanded");
+    wrapper.unmount();
+  });
+
+  it("keeps a wrapped draft full width when the wider layout reduces its line count", async () => {
+    const scrollHeight = vi.spyOn(HTMLTextAreaElement.prototype, "scrollHeight", "get").mockReturnValue(34);
+    const wrapper = mount(ComposerHost);
+    const textarea = wrapper.get("textarea.composer-input");
+
+    scrollHeight.mockReturnValue(58);
+    await textarea.setValue("A draft that wraps beside the action buttons");
+    expect(wrapper.get(".composerMainRow").classes()).toContain("composerMainRow--expanded");
+
+    scrollHeight.mockReturnValue(34);
+    window.dispatchEvent(new Event("resize"));
+    await nextTick();
+    expect(wrapper.get(".composerMainRow").classes()).toContain("composerMainRow--expanded");
+
+    await textarea.setValue("");
+    expect(wrapper.get(".composerMainRow").classes()).not.toContain("composerMainRow--expanded");
     wrapper.unmount();
   });
 
@@ -165,5 +188,13 @@ describe("MainChat compact composer layout", () => {
 
     expect(rule).toContain("padding: 8px 16px calc(env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1));");
     expect(composer).not.toMatch(/padding-bottom:\s*calc\(12px\s*\+/);
+  });
+
+  it("puts multiline text across the full row with actions underneath", async () => {
+    const composer = await readSfc("../components/MainChatComposerPanel.vue", import.meta.url);
+
+    expect(composer).toMatch(/\.composerMainRow--expanded\s*\{[^}]*flex-wrap:\s*wrap\s*;/);
+    expect(composer).toMatch(/\.composerMainRow--expanded\s+\.composer-input\s*\{[^}]*order:\s*-1\s*;[^}]*flex-basis:\s*100%\s*;/);
+    expect(composer).toMatch(/\.composerMainRow--expanded\s+\.composerMainRowRight\s*\{[^}]*margin-left:\s*auto\s*;/);
   });
 });

--- a/client/src/__tests__/mainchat-header-ui.test.ts
+++ b/client/src/__tests__/mainchat-header-ui.test.ts
@@ -13,6 +13,17 @@ function readUtf8(relFromThisFile: string): string {
 }
 
 describe("MainChat header UI", () => {
+  it("blends mobile navigation into the chat background without horizontal separators", () => {
+    const css = readUtf8("../App.css");
+    const mobileCss = css.slice(css.indexOf("@media (max-width: 900px)"));
+    const navigation = mobileCss.match(/\.topbar,\s*\.laneTabs\s*\{[^}]*\}/)?.[0];
+
+    expect(navigation).toBeDefined();
+    expect(navigation).toMatch(/border-bottom:\s*0\s*;/);
+    expect(navigation).toMatch(/box-shadow:\s*none\s*;/);
+    expect(navigation).toMatch(/background:\s*var\(--app-bg\)\s*;/);
+  });
+
   it("does not render a busy label in the header", () => {
     const wrapper = mount(MainChat, {
       props: {

--- a/client/src/__tests__/mainchat-header-ui.test.ts
+++ b/client/src/__tests__/mainchat-header-ui.test.ts
@@ -13,6 +13,28 @@ function readUtf8(relFromThisFile: string): string {
 }
 
 describe("MainChat header UI", () => {
+  it("compacts mobile navigation without shrinking the desktop header", () => {
+    const css = readUtf8("../App.css");
+    const mobileCss = css.slice(css.indexOf("@media (max-width: 900px)"));
+    const app = css.match(/\.app\s*\{[^}]*\}/)?.[0];
+    const mobileApp = mobileCss.match(/\.app\s*\{[^}]*\}/)?.[0];
+
+    expect(app).toMatch(/--topbar-height:\s*48px\s*;/);
+    expect(mobileApp).toMatch(/--topbar-height:\s*40px\s*;/);
+    expect(mobileCss).toMatch(/\.laneTabs\s*\{[^}]*min-height:\s*36px\s*;[^}]*padding:\s*2px 10px\s*;/);
+    expect(mobileCss).toMatch(/\.mobileMenuBtn\s*\{[^}]*height:\s*var\(--topbar-height\)\s*;/);
+  });
+
+  it("shares the header height with safe-area drawer and overlay positioning", () => {
+    const css = readUtf8("../App.css");
+
+    expect(css).toMatch(/\.topbar\s*\{[^}]*height:\s*calc\(var\(--topbar-height\) \+ env\(safe-area-inset-top/);
+    expect(css).toMatch(/\.left\.mobileDrawer\s*\{[^}]*top:\s*calc\(var\(--topbar-height\) \+ env\(safe-area-inset-top/);
+    expect(css).toMatch(/\.mobileDrawerBackdrop\s*\{[^}]*inset:\s*calc\(var\(--topbar-height\) \+ env\(safe-area-inset-top/);
+    expect(css).toMatch(/\.noticeToast\s*\{[^}]*top:\s*calc\(var\(--topbar-height\) \+ env\(safe-area-inset-top/);
+    expect(css).not.toMatch(/(?:height|top|inset):\s*calc\(48px \+/);
+  });
+
   it("blends mobile navigation into the chat background without horizontal separators", () => {
     const css = readUtf8("../App.css");
     const mobileCss = css.slice(css.indexOf("@media (max-width: 900px)"));

--- a/client/src/__tests__/mainchat-header-ui.test.ts
+++ b/client/src/__tests__/mainchat-header-ui.test.ts
@@ -13,15 +13,15 @@ function readUtf8(relFromThisFile: string): string {
 }
 
 describe("MainChat header UI", () => {
-  it("compacts mobile navigation without shrinking the desktop header", () => {
+  it("compacts both desktop and mobile navigation", () => {
     const css = readUtf8("../App.css");
     const mobileCss = css.slice(css.indexOf("@media (max-width: 900px)"));
     const app = css.match(/\.app\s*\{[^}]*\}/)?.[0];
     const mobileApp = mobileCss.match(/\.app\s*\{[^}]*\}/)?.[0];
 
-    expect(app).toMatch(/--topbar-height:\s*48px\s*;/);
-    expect(mobileApp).toMatch(/--topbar-height:\s*40px\s*;/);
-    expect(mobileCss).toMatch(/\.laneTabs\s*\{[^}]*min-height:\s*36px\s*;[^}]*padding:\s*2px 10px\s*;/);
+    expect(app).toMatch(/--topbar-height:\s*40px\s*;/);
+    expect(mobileApp).toMatch(/--topbar-height:\s*36px\s*;/);
+    expect(mobileCss).toMatch(/\.laneTabs\s*\{[^}]*min-height:\s*32px\s*;[^}]*padding:\s*0 8px\s*;/);
     expect(mobileCss).toMatch(/\.mobileMenuBtn\s*\{[^}]*height:\s*var\(--topbar-height\)\s*;/);
   });
 

--- a/client/src/components/MainChatComposerPanel.vue
+++ b/client/src/components/MainChatComposerPanel.vue
@@ -625,7 +625,9 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
 }
 
 .composerMainRow {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-areas: "left input right";
   align-items: flex-end;
   padding: 8px;
   flex-shrink: 0;
@@ -641,17 +643,27 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
   align-items: center;
 }
 
+.composerMainRowLeft {
+  grid-area: left;
+}
+
+.composerMainRowRight {
+  grid-area: right;
+}
+
 .composerMainRow--expanded {
-  flex-wrap: wrap;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas:
+    "input input"
+    "left right";
 }
 
 .composerMainRow--expanded .composer-input {
-  order: -1;
-  flex-basis: 100%;
+  width: 100%;
 }
 
 .composerMainRow--expanded .composerMainRowRight {
-  margin-left: auto;
+  margin-left: 0;
 }
 
 .attachIcon {
@@ -916,6 +928,7 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
 }
 
 .composer-input {
+  grid-area: input;
   flex: 1 1 auto;
   min-width: 0;
   resize: none;

--- a/client/src/components/MainChatComposerPanel.vue
+++ b/client/src/components/MainChatComposerPanel.vue
@@ -315,21 +315,6 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
         :disabled="inputLocked"
         @change="onFileInputChange"
       />
-      <textarea
-        ref="inputEl"
-        v-model="input"
-        :disabled="inputLocked"
-        rows="5"
-        class="composer-input"
-        placeholder="输入…（Enter 发送，Shift+Enter 换行，粘贴图片）"
-        @keydown="onInputKeydown"
-        @paste="onPaste"
-        @select="updateTextSelection"
-        @keyup="updateTextSelection"
-        @mouseup="updateTextSelection"
-        @focus="updateTextSelection"
-        @blur="clearTextSelectionState"
-      />
       <div class="composerMainRow">
         <div class="composerMainRowLeft">
           <button
@@ -349,6 +334,23 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
             </svg>
           </button>
         </div>
+        <textarea
+          ref="inputEl"
+          v-model="input"
+          :disabled="inputLocked"
+          rows="1"
+          class="composer-input"
+          aria-label="Message"
+          placeholder="Message..."
+          title="Enter to send, Shift+Enter for a new line. Paste images to attach."
+          @keydown="onInputKeydown"
+          @paste="onPaste"
+          @select="updateTextSelection"
+          @keyup="updateTextSelection"
+          @mouseup="updateTextSelection"
+          @focus="updateTextSelection"
+          @blur="clearTextSelectionState"
+        />
         <div class="composerMainRowRight">
           <div v-if="recording" class="voiceIndicator recording" aria-hidden="true">
             <div class="voiceBars">
@@ -622,9 +624,8 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
 
 .composerMainRow {
   display: flex;
-  align-items: center;
-  min-height: 40px;
-  padding: 2px 8px 8px;
+  align-items: flex-end;
+  padding: 8px;
   flex-shrink: 0;
   gap: 6px;
 }
@@ -632,18 +633,10 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
 .composerMainRowLeft,
 .composerMainRowRight {
   display: flex;
+  flex: 0 0 auto;
+  min-height: 34px;
   gap: 6px;
   align-items: center;
-}
-
-.composerMainRowLeft {
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
-.composerMainRowRight {
-  flex: 0 0 auto;
-  margin-left: auto;
 }
 
 .attachIcon {
@@ -908,15 +901,16 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
 }
 
 .composer-input {
-  width: 100%;
+  flex: 1 1 auto;
+  min-width: 0;
   resize: none;
   overflow-y: hidden;
-  min-height: 30px;
-  border-radius: 23px 23px 0 0;
+  min-height: 34px;
+  border-radius: 0;
   border: none;
-  padding: 13px 16px 8px;
+  padding: 5px 6px;
   font-size: 16px;
-  line-height: 1.45;
+  line-height: 1.5;
   background: transparent;
   color: #0f172a;
   box-sizing: border-box;

--- a/client/src/components/MainChatComposerPanel.vue
+++ b/client/src/components/MainChatComposerPanel.vue
@@ -120,6 +120,7 @@ watch(
 const {
   input,
   inputEl,
+  inputExpanded,
   fileInputEl,
   send,
   onInputKeydown,
@@ -315,7 +316,7 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
         :disabled="inputLocked"
         @change="onFileInputChange"
       />
-      <div class="composerMainRow">
+      <div class="composerMainRow" :class="{ 'composerMainRow--expanded': inputExpanded }">
         <div class="composerMainRowLeft">
           <button
             class="attachIcon composerActionToggle"
@@ -637,6 +638,19 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
   min-height: 34px;
   gap: 6px;
   align-items: center;
+}
+
+.composerMainRow--expanded {
+  flex-wrap: wrap;
+}
+
+.composerMainRow--expanded .composer-input {
+  order: -1;
+  flex-basis: 100%;
+}
+
+.composerMainRow--expanded .composerMainRowRight {
+  margin-left: auto;
 }
 
 .attachIcon {

--- a/client/src/components/MainChatComposerPanel.vue
+++ b/client/src/components/MainChatComposerPanel.vue
@@ -482,7 +482,7 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 8px 16px calc(env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1));
+  padding: 8px 16px 0;
   background: var(--app-bg, #ffffff);
   position: relative;
   z-index: 20;
@@ -600,6 +600,7 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
   width: 100%;
   box-sizing: border-box;
   position: relative;
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1));
   border-radius: 24px;
   border: 1px solid rgba(148, 163, 184, 0.38);
   background: rgba(255, 255, 255, 0.97);

--- a/client/src/components/MainChatComposerPanel.vue
+++ b/client/src/components/MainChatComposerPanel.vue
@@ -481,7 +481,7 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 8px 16px calc(12px + env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1));
+  padding: 8px 16px calc(env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1));
   background: var(--app-bg, #ffffff);
   position: relative;
   z-index: 20;
@@ -1018,7 +1018,6 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
   .composer {
     padding-left: 12px;
     padding-right: 12px;
-    padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1));
   }
 
   .actionSheet {

--- a/client/src/components/MainChatMessageList.vue
+++ b/client/src/components/MainChatMessageList.vue
@@ -1173,11 +1173,11 @@ function closeFilePreview(): void {
 }
 
 .msg[data-role="user"] .bubble {
-  width: auto;
-  max-width: min(90%, 960px);
+  width: 100%;
+  max-width: 100%;
   min-width: 0;
   box-sizing: border-box;
-  padding: 10px 16px 28px 16px;
+  padding: 10px 16px 8px;
   border: 1px solid rgba(9, 105, 218, 0.16);
   border-radius: 18px 18px 4px 18px;
   background: rgba(221, 244, 255, 0.88);
@@ -1214,9 +1214,11 @@ function closeFilePreview(): void {
 }
 
 .msg[data-role="user"] .msgActions {
-  left: auto;
-  right: 10px;
-  bottom: 4px;
+  position: static;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  margin-top: 4px;
 }
 
 .thoughtCard {

--- a/client/src/components/MainChatMessageList.vue
+++ b/client/src/components/MainChatMessageList.vue
@@ -1177,10 +1177,10 @@ function closeFilePreview(): void {
   max-width: 100%;
   min-width: 0;
   box-sizing: border-box;
-  padding: 10px 16px 8px;
-  border: 1px solid rgba(9, 105, 218, 0.16);
-  border-radius: 18px 18px 4px 18px;
-  background: rgba(221, 244, 255, 0.88);
+  padding: 4px 0 8px;
+  border: none;
+  border-radius: 0;
+  background: transparent;
   color: #0f172a;
   overflow: visible;
 }

--- a/client/src/components/MainChatMessageList.vue
+++ b/client/src/components/MainChatMessageList.vue
@@ -30,7 +30,6 @@ const emit = defineEmits<{
 }>();
 
 const openCommandTrees = ref<Set<string>>(new Set());
-const expandedExecuteIds = ref<Set<string>>(new Set());
 const expandedPatchKeys = ref<Set<string>>(new Set());
 const filePreviewTarget = ref<MarkdownFilePreviewLink | null>(null);
 const messageListEl = ref<HTMLElement | null>(null);
@@ -474,23 +473,8 @@ function executeAllLines(m: RenderMessage): string[] {
   return raw.replace(/\r\n/g, "\n").split("\n");
 }
 
-function hasExpandableExecuteOutput(m: RenderMessage): boolean {
-  if (m.kind !== "execute") return false;
-  const lines = executeAllLines(m);
-  return lines.length > 3 || (m.hiddenLineCount !== undefined && m.hiddenLineCount > 0);
-}
-
-function isExecuteExpanded(id: string): boolean {
-  return expandedExecuteIds.value.has(id);
-}
-
 function getExecuteOutput(m: RenderMessage): string {
-  const lines = executeAllLines(m);
-  if (lines.length === 0) return "";
-  if (isExecuteExpanded(m.id)) {
-    return lines.join("\n");
-  }
-  return lines.slice(0, 3).join("\n");
+  return executeAllLines(m).slice(0, 3).join("\n");
 }
 
 function getExecuteHiddenCount(m: RenderMessage): number {
@@ -500,13 +484,6 @@ function getExecuteHiddenCount(m: RenderMessage): number {
     return localHidden + m.hiddenLineCount;
   }
   return localHidden;
-}
-
-function toggleExecuteExpanded(id: string): void {
-  const next = new Set(expandedExecuteIds.value);
-  if (next.has(id)) next.delete(id);
-  else next.add(id);
-  expandedExecuteIds.value = next;
 }
 
 function caretPath(open: boolean): string {
@@ -641,17 +618,11 @@ function closeFilePreview(): void {
         </div>
         <pre
           v-if="getExecuteOutput(m).trim()"
-          :class="['execute-output', { 'execute-output--expanded': isExecuteExpanded(m.id) }]"
+          class="execute-output"
         >{{ getExecuteOutput(m) }}</pre>
-        <button
-          v-if="hasExpandableExecuteOutput(m)"
-          class="execute-more execute-more--button"
-          type="button"
-          :aria-expanded="isExecuteExpanded(m.id)"
-          @click="toggleExecuteExpanded(m.id)"
-        >
-          {{ isExecuteExpanded(m.id) ? "收起输出" : `… 还有 ${getExecuteHiddenCount(m)} 行` }}
-        </button>
+        <div v-if="getExecuteHiddenCount(m) > 0" class="execute-more">
+          {{ `… ${getExecuteHiddenCount(m)} more lines` }}
+        </div>
       </div>
       <div v-else-if="m.kind === 'divider'" class="sessionBoundaryDivider" data-testid="session-boundary-divider">
         <div class="sessionBoundaryLine">
@@ -899,31 +870,11 @@ function closeFilePreview(): void {
   flex: 0 0 auto;
 }
 
-.execute-output--expanded {
-  display: block;
-  -webkit-line-clamp: unset;
-  max-height: 300px;
-  overflow: auto;
-}
-
 .execute-more {
   margin-top: 4px;
   font-size: 12px;
   color: #94a3b8;
   flex: 0 0 auto;
-}
-
-.execute-more--button {
-  align-self: flex-start;
-  border: none;
-  background: transparent;
-  padding: 0;
-  cursor: pointer;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-}
-
-.execute-more--button:hover {
-  color: #0f172a;
 }
 
 .patchCard {

--- a/client/src/components/mainChat/useComposer.ts
+++ b/client/src/components/mainChat/useComposer.ts
@@ -91,11 +91,15 @@ export function useMainChatComposer(params: {
     },
   });
   const inputEl = ref<HTMLTextAreaElement | null>(null);
+  const inputExpanded = ref(false);
 
   const resizeComposer = (): void => {
     const el = inputEl.value;
     if (!el) return;
-    autosizeTextarea(el, { minRows: 1, maxRows: 8 });
+    const multiline = autosizeTextarea(el, { minRows: 1, maxRows: 8 });
+    // Keep a nonempty draft wide once it wraps, avoiding a wrap/unwrap feedback
+    // loop when moving the controls below the text gives it more space.
+    inputExpanded.value = el.value.length > 0 && (inputExpanded.value || multiline);
   };
 
   // Resize after Vue commits DOM updates (v-model, conditional UI that affects wrapping, etc).
@@ -574,6 +578,7 @@ export function useMainChatComposer(params: {
   return {
     input,
     inputEl,
+    inputExpanded,
     fileInputEl,
     send,
     onInputKeydown,

--- a/client/src/components/mainChat/useComposer.ts
+++ b/client/src/components/mainChat/useComposer.ts
@@ -104,11 +104,19 @@ export function useMainChatComposer(params: {
   // Some environments/layout changes won't trigger reactive updates (e.g. viewport resize affects wrapping).
   // Attach lightweight native listeners so the composer reliably grows up to maxRows.
   let attachedEl: HTMLTextAreaElement | null = null;
+  let composerResizeObserver: ResizeObserver | null = null;
+  let composerResizeFrame: number | null = null;
   const onNativeInput = (): void => {
     resizeComposer();
   };
 
   const attachNativeListeners = (el: HTMLTextAreaElement | null): void => {
+    composerResizeObserver?.disconnect();
+    composerResizeObserver = null;
+    if (composerResizeFrame !== null) {
+      window.cancelAnimationFrame(composerResizeFrame);
+      composerResizeFrame = null;
+    }
     if (attachedEl) {
       attachedEl.removeEventListener("input", onNativeInput);
       attachedEl = null;
@@ -116,6 +124,21 @@ export function useMainChatComposer(params: {
     if (!el) return;
     attachedEl = el;
     el.addEventListener("input", onNativeInput, { passive: true });
+    if (typeof ResizeObserver !== "undefined") {
+      let observedWidth = -1;
+      composerResizeObserver = new ResizeObserver((entries) => {
+        const width = entries.find((entry) => entry.target === el)?.contentRect.width;
+        if (width === undefined || width === observedWidth) return;
+        observedWidth = width;
+        if (width <= 0) return;
+        if (composerResizeFrame !== null) window.cancelAnimationFrame(composerResizeFrame);
+        composerResizeFrame = window.requestAnimationFrame(() => {
+          composerResizeFrame = null;
+          resizeComposer();
+        });
+      });
+      composerResizeObserver.observe(el);
+    }
   };
 
   watch(

--- a/client/src/lib/textarea_autosize.test.ts
+++ b/client/src/lib/textarea_autosize.test.ts
@@ -16,6 +16,40 @@ function makeStyle(overrides: Partial<CSSStyleDeclaration>): CSSStyleDeclaration
 }
 
 describe("autosizeTextarea", () => {
+  it("measures content without inheriting the native rows height", () => {
+    const element = document.createElement("textarea");
+    element.rows = 5;
+    document.body.appendChild(element);
+
+    const measuredHeights: string[] = [];
+    Object.defineProperty(element, "scrollHeight", {
+      configurable: true,
+      get: () => {
+        measuredHeights.push(element.style.height);
+        const contentRows = element.value.split("\n").length;
+        const nativeRows = element.style.height === "auto" ? element.rows : 1;
+        return Math.max(contentRows, nativeRows) * 20 + 20;
+      },
+    });
+    vi.spyOn(window, "getComputedStyle").mockReturnValue(makeStyle({}));
+
+    autosizeTextarea(element, { minRows: 1, maxRows: 8 });
+    expect(element.style.height).toBe("42px");
+
+    element.value = Array.from({ length: 12 }, (_, index) => `Line ${index}`).join("\n");
+    autosizeTextarea(element, { minRows: 1, maxRows: 8 });
+    expect(element.style.height).toBe("182px");
+    expect(element.style.overflowY).toBe("auto");
+
+    element.value = "";
+    autosizeTextarea(element, { minRows: 1, maxRows: 8 });
+    expect(element.style.height).toBe("42px");
+    expect(element.style.overflowY).toBe("hidden");
+    expect(measuredHeights).toEqual(["0px", "0px", "0px"]);
+
+    element.remove();
+  });
+
   it("clamps height between minRows/maxRows and toggles overflow", () => {
     const el = document.createElement("textarea");
     document.body.appendChild(el);
@@ -108,4 +142,3 @@ describe("autosizeTextarea", () => {
     el.remove();
   });
 });
-

--- a/client/src/lib/textarea_autosize.test.ts
+++ b/client/src/lib/textarea_autosize.test.ts
@@ -33,16 +33,16 @@ describe("autosizeTextarea", () => {
     });
     vi.spyOn(window, "getComputedStyle").mockReturnValue(makeStyle({}));
 
-    autosizeTextarea(element, { minRows: 1, maxRows: 8 });
+    expect(autosizeTextarea(element, { minRows: 1, maxRows: 8 })).toBe(false);
     expect(element.style.height).toBe("42px");
 
     element.value = Array.from({ length: 12 }, (_, index) => `Line ${index}`).join("\n");
-    autosizeTextarea(element, { minRows: 1, maxRows: 8 });
+    expect(autosizeTextarea(element, { minRows: 1, maxRows: 8 })).toBe(true);
     expect(element.style.height).toBe("182px");
     expect(element.style.overflowY).toBe("auto");
 
     element.value = "";
-    autosizeTextarea(element, { minRows: 1, maxRows: 8 });
+    expect(autosizeTextarea(element, { minRows: 1, maxRows: 8 })).toBe(false);
     expect(element.style.height).toBe("42px");
     expect(element.style.overflowY).toBe("hidden");
     expect(measuredHeights).toEqual(["0px", "0px", "0px"]);

--- a/client/src/lib/textarea_autosize.ts
+++ b/client/src/lib/textarea_autosize.ts
@@ -46,7 +46,7 @@ export function autosizeTextarea(el: HTMLTextAreaElement, opts: AutosizeTextarea
   const maxHeight = lineHeightPx * maxRows + extraHeight;
 
   // Reset height so scrollHeight reflects the full content and the textarea can shrink.
-  el.style.height = "auto";
+  el.style.height = "0px";
 
   // scrollHeight includes padding but excludes border; adjust for border-box sizing.
   const contentHeight = el.scrollHeight + borderHeight;
@@ -55,4 +55,3 @@ export function autosizeTextarea(el: HTMLTextAreaElement, opts: AutosizeTextarea
   el.style.height = `${Math.ceil(nextHeight)}px`;
   el.style.overflowY = contentHeight > maxHeight ? "auto" : "hidden";
 }
-

--- a/client/src/lib/textarea_autosize.ts
+++ b/client/src/lib/textarea_autosize.ts
@@ -22,9 +22,10 @@ function resolveLineHeightPx(style: CSSStyleDeclaration): number {
   return 20;
 }
 
-export function autosizeTextarea(el: HTMLTextAreaElement, opts: AutosizeTextareaOptions = {}): void {
-  if (!el) return;
-  if (typeof window === "undefined" || typeof window.getComputedStyle !== "function") return;
+// Returns whether the measured content occupies more than one line.
+export function autosizeTextarea(el: HTMLTextAreaElement, opts: AutosizeTextareaOptions = {}): boolean {
+  if (!el) return false;
+  if (typeof window === "undefined" || typeof window.getComputedStyle !== "function") return false;
 
   const minRows = Math.max(1, Math.floor(opts.minRows ?? 1));
   const maxRows = Math.max(minRows, Math.floor(opts.maxRows ?? minRows));
@@ -54,4 +55,5 @@ export function autosizeTextarea(el: HTMLTextAreaElement, opts: AutosizeTextarea
 
   el.style.height = `${Math.ceil(nextHeight)}px`;
   el.style.overflowY = contentHeight > maxHeight ? "auto" : "hidden";
+  return contentHeight > lineHeightPx + extraHeight + 1;
 }

--- a/client/src/lib/viewport.test.ts
+++ b/client/src/lib/viewport.test.ts
@@ -41,6 +41,7 @@ describe("chat visual viewport anchoring", () => {
     viewport = Object.assign(new EventTarget(), { height: 844, offsetTop: 0 });
     vi.stubGlobal("visualViewport", viewport);
     vi.stubGlobal("innerHeight", 844);
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
     trackListeners(window);
     trackListeners(document);
     input = document.createElement("textarea");
@@ -91,6 +92,7 @@ describe("chat visual viewport anchoring", () => {
 
     expect(cssVariable("--app-top")).toBe("120px");
     expect(cssVariable("--ads-visual-viewport-height")).toBe("440px");
+    expect(cssVariable("--safe-bottom-multiplier")).toBe("0");
 
     updateViewport(844, 0);
     expect(cssVariable("--app-top")).toBe("0px");
@@ -110,6 +112,72 @@ describe("chat visual viewport anchoring", () => {
     vi.advanceTimersByTime(250);
     expect(cssVariable("--app-top")).toBe("0px");
     expect(cssVariable("--ads-visual-viewport-height")).toBe("844px");
+  });
+
+  it("recovers after blur when the keyboard closes after the event burst without a resize event", async () => {
+    const { installViewportCssVars } = await import("./viewport");
+    installViewportCssVars();
+    input.focus();
+    updateViewport(440, 120);
+    input.blur();
+    vi.advanceTimersByTime(2500);
+
+    viewport.height = 844;
+    viewport.offsetTop = 0;
+    vi.advanceTimersByTime(250);
+
+    expect(document.activeElement).not.toBe(input);
+    expect(cssVariable("--app-top")).toBe("0px");
+    expect(cssVariable("--app-bottom")).toBe("0px");
+    expect(cssVariable("--ads-visual-viewport-height")).toBe("844px");
+    expect(cssVariable("--safe-bottom-multiplier")).toBe("1");
+  });
+
+  it("tracks silent browser viewport changes when no input is focused", async () => {
+    const { installViewportCssVars } = await import("./viewport");
+    installViewportCssVars();
+
+    viewport.height = 780;
+    vi.advanceTimersByTime(250);
+    expect(cssVariable("--ads-visual-viewport-height")).toBe("780px");
+
+    viewport.height = 844;
+    vi.advanceTimersByTime(250);
+    expect(cssVariable("--ads-visual-viewport-height")).toBe("844px");
+  });
+
+  it("does not rewrite layout styles when fallback polling reads unchanged metrics", async () => {
+    const { installViewportCssVars } = await import("./viewport");
+    installViewportCssVars();
+    const setProperty = vi.spyOn(document.documentElement.style, "setProperty");
+
+    vi.advanceTimersByTime(1000);
+    expect(setProperty).not.toHaveBeenCalled();
+  });
+
+  it("suspends fallback polling in the background and refreshes when the page becomes visible", async () => {
+    const visibility = vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+    const { installViewportCssVars } = await import("./viewport");
+    installViewportCssVars();
+
+    viewport.height = 780;
+    vi.advanceTimersByTime(1000);
+    expect(cssVariable("--ads-visual-viewport-height")).toBe("844px");
+
+    visibility.mockReturnValue("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    vi.advanceTimersByTime(32);
+    expect(cssVariable("--ads-visual-viewport-height")).toBe("780px");
+  });
+
+  it("refreshes immediately when a page is restored from the back-forward cache", async () => {
+    const { installViewportCssVars } = await import("./viewport");
+    installViewportCssVars();
+
+    viewport.height = 780;
+    window.dispatchEvent(new Event("pageshow"));
+    vi.advanceTimersByTime(32);
+    expect(cssVariable("--ads-visual-viewport-height")).toBe("780px");
   });
 
   it("uses the layout viewport when the visual viewport API is unavailable", async () => {

--- a/client/src/lib/viewport.test.ts
+++ b/client/src/lib/viewport.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { readSfc } from "../__tests__/readSfc";
+
+type ListenerRegistration = {
+  target: EventTarget;
+  type: string;
+  listener: EventListenerOrEventListenerObject;
+  options?: boolean | AddEventListenerOptions;
+};
+
+describe("chat visual viewport anchoring", () => {
+  let viewport: EventTarget & { height: number; offsetTop: number };
+  let input: HTMLTextAreaElement;
+  let originalRootStyle: string | null;
+  const listeners: ListenerRegistration[] = [];
+
+  function trackListeners(target: EventTarget): void {
+    const addEventListener = target.addEventListener.bind(target);
+    vi.spyOn(target, "addEventListener").mockImplementation((type, listener, options) => {
+      if (listener) listeners.push({ target, type, listener, options });
+      addEventListener(type, listener, options);
+    });
+  }
+
+  function cssVariable(name: string): string {
+    return document.documentElement.style.getPropertyValue(name);
+  }
+
+  function updateViewport(height: number, offsetTop: number, eventType = "resize"): void {
+    viewport.height = height;
+    viewport.offsetTop = offsetTop;
+    viewport.dispatchEvent(new Event(eventType));
+    vi.advanceTimersByTime(32);
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    originalRootStyle = document.documentElement.getAttribute("style");
+    viewport = Object.assign(new EventTarget(), { height: 844, offsetTop: 0 });
+    vi.stubGlobal("visualViewport", viewport);
+    vi.stubGlobal("innerHeight", 844);
+    trackListeners(window);
+    trackListeners(document);
+    input = document.createElement("textarea");
+    document.body.appendChild(input);
+  });
+
+  afterEach(() => {
+    for (const { target, type, listener, options } of listeners.splice(0)) {
+      target.removeEventListener(type, listener, options);
+    }
+    input.remove();
+    if (originalRootStyle === null) document.documentElement.removeAttribute("style");
+    else document.documentElement.setAttribute("style", originalRootStyle);
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("anchors the fixed chat page to the reported visual viewport top and height", async () => {
+    const app = await readSfc("../App.vue", import.meta.url);
+    const rule = app.match(/\.app\s*\{[^}]*\}/)?.[0];
+    expect(rule).toBeDefined();
+    expect(rule).toMatch(/position:\s*fixed\s*;/);
+    expect(rule).toMatch(/top:\s*var\(--app-top,\s*0px\)\s*;/);
+    expect(rule).toMatch(/height:\s*var\(--ads-visual-viewport-height,\s*100dvh\)\s*;/);
+  });
+
+  it("tracks keyboard panning even when only a viewport scroll event fires", async () => {
+    const { installViewportCssVars } = await import("./viewport");
+    installViewportCssVars();
+    input.focus();
+    updateViewport(440, 0);
+    updateViewport(440, 120, "scroll");
+
+    expect(cssVariable("--app-top")).toBe("120px");
+    expect(cssVariable("--ads-visual-viewport-height")).toBe("440px");
+    expect(cssVariable("--safe-bottom-multiplier")).toBe("0");
+  });
+
+  it("preserves the viewport offset after blur until the keyboard finishes closing", async () => {
+    const { installViewportCssVars } = await import("./viewport");
+    installViewportCssVars();
+    input.focus();
+    updateViewport(440, 120);
+    input.blur();
+    vi.advanceTimersByTime(32);
+
+    expect(cssVariable("--app-top")).toBe("120px");
+    expect(cssVariable("--ads-visual-viewport-height")).toBe("440px");
+
+    updateViewport(844, 0);
+    expect(cssVariable("--app-top")).toBe("0px");
+    expect(cssVariable("--ads-visual-viewport-height")).toBe("844px");
+    expect(cssVariable("--safe-bottom-multiplier")).toBe("1");
+  });
+
+  it("recovers after keyboard dismissal without a resize event while input remains focused", async () => {
+    const { installViewportCssVars } = await import("./viewport");
+    installViewportCssVars();
+    input.focus();
+    updateViewport(440, 120);
+    vi.advanceTimersByTime(2000);
+
+    viewport.height = 844;
+    viewport.offsetTop = 0;
+    vi.advanceTimersByTime(250);
+    expect(cssVariable("--app-top")).toBe("0px");
+    expect(cssVariable("--ads-visual-viewport-height")).toBe("844px");
+  });
+
+  it("uses the layout viewport when the visual viewport API is unavailable", async () => {
+    vi.stubGlobal("visualViewport", undefined);
+    const { installViewportCssVars } = await import("./viewport");
+    installViewportCssVars();
+    expect(cssVariable("--app-top")).toBe("0px");
+    expect(cssVariable("--ads-visual-viewport-height")).toBe("844px");
+
+    vi.stubGlobal("innerHeight", 440);
+    window.dispatchEvent(new Event("resize"));
+    vi.advanceTimersByTime(32);
+    expect(cssVariable("--ads-visual-viewport-height")).toBe("440px");
+  });
+});

--- a/client/src/lib/viewport.ts
+++ b/client/src/lib/viewport.ts
@@ -26,10 +26,7 @@ function applyViewportVars(): void {
   const next = readViewportMetrics();
   const keyboardOpen = isTextInputElement(document.activeElement) && next.bottomPx > 0;
   const heightPx = next.heightPx;
-  // Only shrink the fixed app container when the on-screen keyboard is open.
-  // Some browsers report a non-zero visualViewport bottom inset even when the keyboard is closed,
-  // which created a persistent blank area under the composer.
-  const appTopPx = keyboardOpen ? next.topPx : 0;
+  const appTopPx = next.topPx;
   const appBottomPx = keyboardOpen ? next.bottomPx : 0;
   if (
     appTopPx === lastMetrics.topPx &&

--- a/client/src/lib/viewport.ts
+++ b/client/src/lib/viewport.ts
@@ -24,10 +24,12 @@ let lastMetrics: MetricsState = {
 };
 function applyViewportVars(): void {
   const next = readViewportMetrics();
-  const keyboardOpen = isTextInputElement(document.activeElement) && next.bottomPx > 0;
+  // Blur can precede the keyboard closing animation. Keep safe-area padding
+  // suppressed until the visual viewport actually reaches the layout bottom.
+  const keyboardOpen = next.bottomPx > 0;
   const heightPx = next.heightPx;
   const appTopPx = next.topPx;
-  const appBottomPx = keyboardOpen ? next.bottomPx : 0;
+  const appBottomPx = next.bottomPx;
   if (
     appTopPx === lastMetrics.topPx &&
     appBottomPx === lastMetrics.bottomPx &&
@@ -87,11 +89,19 @@ export function installViewportCssVars(): void {
   installed = true;
 
   applyViewportVars();
+  window.addEventListener("pageshow", scheduleBurst, { passive: true });
   window.addEventListener("resize", scheduleBurst, { passive: true });
   window.addEventListener("orientationchange", scheduleBurst, { passive: true });
   window.addEventListener("scroll", scheduleBurst, { passive: true });
   window.visualViewport?.addEventListener("resize", scheduleBurst, { passive: true });
   window.visualViewport?.addEventListener("scroll", scheduleBurst, { passive: true });
+  document.addEventListener(
+    "visibilitychange",
+    () => {
+      if (document.visibilityState === "visible") scheduleBurst();
+    },
+    { passive: true },
+  );
   document.addEventListener(
     "focusin",
     (ev) => {
@@ -107,11 +117,10 @@ export function installViewportCssVars(): void {
     { passive: true },
   );
 
-  // Some mobile browsers don't reliably fire resize events when the keyboard is dismissed
-  // (e.g. Android back gesture). Poll while a text field is focused to keep the viewport height in sync.
+  // Mobile browsers can omit the final resize after blur or browser toolbar
+  // animations. Poll visible pages even after the text field loses focus.
   window.setInterval(() => {
-    const active = document.activeElement;
-    if (!isTextInputElement(active)) return;
+    if (document.visibilityState !== "visible") return;
     applyViewportVars();
   }, 250);
 }


### PR DESCRIPTION
## Summary

- remove the user-message bubble treatment while keeping timestamps and copy controls in-flow
- compact desktop and mobile navigation heights
- give multiline composer input its own full-width grid row so side controls cannot cover text

## Verification

- npm run lint
- npm run build
- npm run test:web
- CODEX_HOME=/tmp/ads-empty-codex-home-5WHFU4 npm test

No GitHub Issue was supplied for this focused UI fix.