### PR TITLE
fix(web): keep composer compact and bottom-anchored

### DIFF
--- a/client/src/__tests__/mainchat-composer-layout.test.ts
+++ b/client/src/__tests__/mainchat-composer-layout.test.ts
@@ -7,8 +7,9 @@ import { readSfc } from "./readSfc";
 
 const ComposerHost = defineComponent({
   components: { MainChatComposerPanel },
-  setup() {
-    const draft = ref("");
+  props: { initialDraft: { type: String, default: "" } },
+  setup(props) {
+    const draft = ref(props.initialDraft);
     return { draft };
   },
   template: `
@@ -73,7 +74,7 @@ describe("MainChat compact composer layout", () => {
     await textarea.setValue("First line\nSecond line");
     expect(element.style.height).toBe("58px");
     expect(element.style.overflowY).toBe("hidden");
-    expect(wrapper.get(".composerMainRow").classes()).toContain("composerMainRow--expanded");
+    expect(wrapper.get(".composerMainRow").classes()).not.toContain("composerMainRow--expanded");
 
     await textarea.setValue(longDraft);
     expect(element.style.height).toBe("202px");
@@ -93,22 +94,43 @@ describe("MainChat compact composer layout", () => {
     wrapper.unmount();
   });
 
-  it("keeps a wrapped draft full width when the wider layout reduces its line count", async () => {
+  it.each(["", "Short draft"])("starts with one input row for draft %j", async (initialDraft) => {
+    vi.spyOn(HTMLTextAreaElement.prototype, "scrollHeight", "get").mockReturnValue(34);
+    const wrapper = mount(ComposerHost, { props: { initialDraft } });
+    await nextTick();
+
+    const textarea = wrapper.get("textarea.composer-input").element as HTMLTextAreaElement;
+    expect(textarea.value).toBe(initialDraft);
+    expect(textarea.rows).toBe(1);
+    expect(textarea.style.height).toBe("34px");
+    expect(wrapper.get(".composerMainRow").classes()).toEqual(["composerMainRow"]);
+    wrapper.unmount();
+  });
+
+  it("shrinks wrapped content without reserving a separate controls row", async () => {
     const scrollHeight = vi.spyOn(HTMLTextAreaElement.prototype, "scrollHeight", "get").mockReturnValue(34);
     const wrapper = mount(ComposerHost);
     const textarea = wrapper.get("textarea.composer-input");
 
     scrollHeight.mockReturnValue(58);
     await textarea.setValue("A draft that wraps beside the action buttons");
-    expect(wrapper.get(".composerMainRow").classes()).toContain("composerMainRow--expanded");
+    expect((textarea.element as HTMLTextAreaElement).style.height).toBe("58px");
+    expect(wrapper.get(".composerMainRow").classes()).toEqual(["composerMainRow"]);
 
     scrollHeight.mockReturnValue(34);
+    await textarea.setValue("Short draft");
+    expect((textarea.element as HTMLTextAreaElement).style.height).toBe("34px");
+    expect(wrapper.get(".composerMainRow").classes()).toEqual(["composerMainRow"]);
+
+    scrollHeight.mockReturnValue(58);
     window.dispatchEvent(new Event("resize"));
     await nextTick();
-    expect(wrapper.get(".composerMainRow").classes()).toContain("composerMainRow--expanded");
+    expect((textarea.element as HTMLTextAreaElement).style.height).toBe("58px");
+    expect(wrapper.get(".composerMainRow").classes()).toEqual(["composerMainRow"]);
 
+    scrollHeight.mockReturnValue(34);
     await textarea.setValue("");
-    expect(wrapper.get(".composerMainRow").classes()).not.toContain("composerMainRow--expanded");
+    expect((textarea.element as HTMLTextAreaElement).style.height).toBe("34px");
     wrapper.unmount();
   });
 
@@ -182,23 +204,22 @@ describe("MainChat compact composer layout", () => {
     expect(chat).toMatch(/\.chat\s*\{[^}]*flex:\s*1 1 auto\s*;/);
   });
 
-  it("keeps the visible input border at the viewport bottom with the safe area inside", async () => {
+  it("keeps safe-area protection in the bottom dock, outside the single-row input", async () => {
     const composer = await readSfc("../components/MainChatComposerPanel.vue", import.meta.url);
     const composerRule = composer.match(/\.composer\s*\{[^}]*\}/)?.[0];
     const inputWrapRule = composer.match(/\.inputWrap\s*\{[^}]*\}/)?.[0];
 
-    expect(composerRule).toContain("padding: 8px 16px 0;");
-    expect(composerRule).not.toContain("safe-area-inset-bottom");
-    expect(inputWrapRule).toContain("padding-bottom: calc(env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1));");
+    expect(composerRule).toContain("padding: 8px 16px calc(env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1));");
+    expect(inputWrapRule).not.toContain("safe-area-inset-bottom");
+    expect(inputWrapRule).not.toContain("padding-bottom");
     expect(composer).not.toMatch(/padding-bottom:\s*calc\(12px\s*\+/);
   });
 
-  it("puts multiline text across the full row with actions underneath", async () => {
+  it("keeps the textarea and actions in one grid row as content grows", async () => {
     const composer = await readSfc("../components/MainChatComposerPanel.vue", import.meta.url);
 
     expect(composer).toMatch(/\.composerMainRow\s*\{[^}]*display:\s*grid\s*;[^}]*grid-template-columns:\s*auto minmax\(0,\s*1fr\) auto\s*;[^}]*grid-template-areas:\s*"left input right"\s*;/);
-    expect(composer).toMatch(/\.composerMainRow--expanded\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\) auto\s*;[^}]*grid-template-areas:\s*[\s\S]*"input input"[\s\S]*"left right"/);
-    expect(composer).toMatch(/\.composerMainRow--expanded\s+\.composer-input\s*\{[^}]*width:\s*100%\s*;/);
-    expect(composer).not.toMatch(/\.composerMainRow--expanded\s*\{[^}]*flex-wrap:\s*wrap\s*;/);
+    expect(composer).toMatch(/\.composer-input\s*\{[^}]*width:\s*100%\s*;/);
+    expect(composer).not.toContain("composerMainRow--expanded");
   });
 });

--- a/client/src/components/MainChatComposerPanel.vue
+++ b/client/src/components/MainChatComposerPanel.vue
@@ -120,7 +120,6 @@ watch(
 const {
   input,
   inputEl,
-  inputExpanded,
   fileInputEl,
   send,
   onInputKeydown,
@@ -316,7 +315,7 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
         :disabled="inputLocked"
         @change="onFileInputChange"
       />
-      <div class="composerMainRow" :class="{ 'composerMainRow--expanded': inputExpanded }">
+      <div class="composerMainRow">
         <div class="composerMainRowLeft">
           <button
             class="attachIcon composerActionToggle"
@@ -482,7 +481,7 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 8px 16px 0;
+  padding: 8px 16px calc(env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1));
   background: var(--app-bg, #ffffff);
   position: relative;
   z-index: 20;
@@ -600,7 +599,6 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
   width: 100%;
   box-sizing: border-box;
   position: relative;
-  padding-bottom: calc(env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1));
   border-radius: 24px;
   border: 1px solid rgba(148, 163, 184, 0.38);
   background: rgba(255, 255, 255, 0.97);
@@ -649,21 +647,6 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
 
 .composerMainRowRight {
   grid-area: right;
-}
-
-.composerMainRow--expanded {
-  grid-template-columns: minmax(0, 1fr) auto;
-  grid-template-areas:
-    "input input"
-    "left right";
-}
-
-.composerMainRow--expanded .composer-input {
-  width: 100%;
-}
-
-.composerMainRow--expanded .composerMainRowRight {
-  margin-left: 0;
 }
 
 .attachIcon {
@@ -931,6 +914,7 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
   grid-area: input;
   flex: 1 1 auto;
   min-width: 0;
+  width: 100%;
   resize: none;
   overflow-y: hidden;
   min-height: 34px;

--- a/client/src/components/mainChat/useComposer.ts
+++ b/client/src/components/mainChat/useComposer.ts
@@ -91,15 +91,11 @@ export function useMainChatComposer(params: {
     },
   });
   const inputEl = ref<HTMLTextAreaElement | null>(null);
-  const inputExpanded = ref(false);
 
   const resizeComposer = (): void => {
     const el = inputEl.value;
     if (!el) return;
-    const multiline = autosizeTextarea(el, { minRows: 1, maxRows: 8 });
-    // Keep a nonempty draft wide once it wraps, avoiding a wrap/unwrap feedback
-    // loop when moving the controls below the text gives it more space.
-    inputExpanded.value = el.value.length > 0 && (inputExpanded.value || multiline);
+    autosizeTextarea(el, { minRows: 1, maxRows: 8 });
   };
 
   // Resize after Vue commits DOM updates (v-model, conditional UI that affects wrapping, etc).
@@ -578,7 +574,6 @@ export function useMainChatComposer(params: {
   return {
     input,
     inputEl,
-    inputExpanded,
     fileInputEl,
     send,
     onInputKeydown,


### PR DESCRIPTION
## Summary

- Keep the textarea and actions in a single stable grid row; grow only the textarea as content wraps.
- Remove the expansion latch so shortened, cleared, and sent drafts return immediately to one line.
- Move bottom safe-area protection to the outer dock, avoiding an empty strip inside the input border.
- Add regression coverage for initial empty/short drafts and wrap, shrink, send, resize, and hidden-lane behavior.

Closes #187

## Verification

- `npm run lint`
- `tsc --noEmit -p tsconfig.json`
- `npm run build`
- Backend suite: 730 passed.
- `npm run test:web`: 86 files, 494 tests passed.
- Full-App Chrome checks at 320px, 390px, and 1440px: initial/shortened input height 52px; long content capped at a 220px wrapper; no extra grid row or horizontal overflow.
- Simulated 34px bottom safe area preserves the 52px input wrapper. Simulated keyboard viewport changes keep the outer dock at the viewport bottom and suppress safe-area padding while the keyboard is open.
- Advisor/Worker switching preserves independent drafts and correct height.

The local backend run isolates installed workflow-skill descriptions only for `tests/systemPrompt/manager.test.ts` via a temporary `ADS_SKILLS_METADATA_PATH` preload. Without this test-only isolation, the unchanged baseline has a false-positive lane-name assertion. No test is skipped and no production skill configuration is modified.

Safe-area and keyboard checks are browser simulations, not a claim of physical iOS device validation. No deployment is included.
