### PR TITLE
fix(web): restore compact chat layout

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -605,7 +605,7 @@
 
 .laneTabGroup {
   display: grid;
-  grid-template-columns: minmax(76px, 1fr) minmax(0, 320px) minmax(76px, 1fr);
+  grid-template-columns: minmax(88px, 1fr) minmax(0, 176px) minmax(88px, 1fr);
   align-items: center;
   gap: 8px;
   width: 100%;
@@ -654,10 +654,12 @@
 
 .laneTab {
   justify-self: start;
+  min-height: 32px;
   border: none;
   background: transparent;
   color: #64748b;
-  font-size: 13px;
+  font-size: 14px;
+  line-height: 20px;
   font-weight: 800;
   padding: 4px 12px;
   border-radius: 999px;
@@ -1135,7 +1137,7 @@
     white-space: nowrap;
     padding: 4px;
     gap: 4px;
-    font-size: 12px;
+    font-size: 14px;
   }
 }
 

--- a/client/src/__tests__/chat-bubble-style-regression.test.ts
+++ b/client/src/__tests__/chat-bubble-style-regression.test.ts
@@ -5,21 +5,24 @@ import MainChatMessageList from "../components/MainChatMessageList.vue";
 import { readSfc } from "./readSfc";
 
 describe("chat bubble and popover style regressions", () => {
-  it("keeps user messages full width without a visual bubble", async () => {
+  it("right-aligns bounded user messages with compact metadata spacing", async () => {
     const css = await readSfc("../components/MainChatMessageList.vue", import.meta.url);
     const userBubble = css.match(/\.msg\[data-role="user"\]\s+\.bubble\s*\{[^}]*\}/)?.[0];
     const userActions = css.match(/\.msg\[data-role="user"\]\s+\.msgActions\s*\{[^}]*\}/)?.[0];
 
-    expect(userBubble).toMatch(/\n\s+width:\s*100%\s*;/);
-    expect(userBubble).toMatch(/max-width:\s*100%\s*;/);
+    expect(userBubble).toMatch(/\n\s+width:\s*fit-content\s*;/);
+    expect(userBubble).toMatch(/max-width:\s*90%\s*;/);
     expect(userBubble).toMatch(/background:\s*transparent\s*;/);
     expect(userBubble).toMatch(/border:\s*none\s*;/);
     expect(userBubble).toMatch(/border-radius:\s*0\s*;/);
-    expect(userBubble).toMatch(/padding:\s*4px 0 8px\s*;/);
+    expect(userBubble).toMatch(/padding:\s*2px 0\s*;/);
     expect(userActions).toMatch(/position:\s*static\s*;/);
     expect(userActions).toMatch(/display:\s*flex\s*;/);
     expect(userActions).toMatch(/flex-wrap:\s*wrap\s*;/);
     expect(userActions).toMatch(/justify-content:\s*flex-end\s*;/);
+    expect(userActions).toMatch(/margin-top:\s*2px\s*;/);
+    expect(css).toMatch(/\.msg\[data-role="user"\]\s*\{[^}]*justify-content:\s*flex-end\s*;[^}]*margin-bottom:\s*8px\s*;/);
+    expect(css).toMatch(/\.msg\[data-role="user"\]\s+\.msgCopyBtn\s*\{[^}]*width:\s*24px\s*;[^}]*height:\s*24px\s*;/);
     expect(userActions).not.toMatch(/(?:left|right|bottom):/);
 
     // Assistant bubbles must not stack unnecessary horizontal padding

--- a/client/src/__tests__/mainchat-composer-layout.test.ts
+++ b/client/src/__tests__/mainchat-composer-layout.test.ts
@@ -74,7 +74,7 @@ describe("MainChat compact composer layout", () => {
     await textarea.setValue("First line\nSecond line");
     expect(element.style.height).toBe("58px");
     expect(element.style.overflowY).toBe("hidden");
-    expect(wrapper.get(".composerMainRow").classes()).not.toContain("composerMainRow--expanded");
+    expect(wrapper.get(".composerMainRow").classes()).toContain("composerMainRow--expanded");
 
     await textarea.setValue(longDraft);
     expect(element.style.height).toBe("202px");
@@ -107,7 +107,7 @@ describe("MainChat compact composer layout", () => {
     wrapper.unmount();
   });
 
-  it("shrinks wrapped content without reserving a separate controls row", async () => {
+  it("expands wrapped content above the controls and collapses when shortened", async () => {
     const scrollHeight = vi.spyOn(HTMLTextAreaElement.prototype, "scrollHeight", "get").mockReturnValue(34);
     const wrapper = mount(ComposerHost);
     const textarea = wrapper.get("textarea.composer-input");
@@ -115,7 +115,7 @@ describe("MainChat compact composer layout", () => {
     scrollHeight.mockReturnValue(58);
     await textarea.setValue("A draft that wraps beside the action buttons");
     expect((textarea.element as HTMLTextAreaElement).style.height).toBe("58px");
-    expect(wrapper.get(".composerMainRow").classes()).toEqual(["composerMainRow"]);
+    expect(wrapper.get(".composerMainRow").classes()).toContain("composerMainRow--expanded");
 
     scrollHeight.mockReturnValue(34);
     await textarea.setValue("Short draft");
@@ -126,11 +126,37 @@ describe("MainChat compact composer layout", () => {
     window.dispatchEvent(new Event("resize"));
     await nextTick();
     expect((textarea.element as HTMLTextAreaElement).style.height).toBe("58px");
-    expect(wrapper.get(".composerMainRow").classes()).toEqual(["composerMainRow"]);
+    expect(wrapper.get(".composerMainRow").classes()).toContain("composerMainRow--expanded");
 
-    scrollHeight.mockReturnValue(34);
     await textarea.setValue("");
     expect((textarea.element as HTMLTextAreaElement).style.height).toBe("34px");
+    expect(wrapper.get(".composerMainRow").classes()).toEqual(["composerMainRow"]);
+    wrapper.unmount();
+  });
+
+  it("keeps a stable expanded layout when text fits only at the expanded width", async () => {
+    const wrapper = mount(ComposerHost);
+    const row = wrapper.get(".composerMainRow");
+    const textarea = wrapper.get("textarea.composer-input");
+    const el = textarea.element as HTMLTextAreaElement;
+    vi.spyOn(row.element, "clientWidth", "get").mockReturnValue(300);
+    vi.spyOn(row.get(".composerMainRowLeft").element, "offsetWidth", "get").mockReturnValue(32);
+    vi.spyOn(row.get(".composerMainRowRight").element, "offsetWidth", "get").mockReturnValue(74);
+    vi.spyOn(el, "scrollHeight", "get").mockImplementation(() => el.style.width === "194px" ? 58 : 34);
+
+    await textarea.setValue("A draft that needs more than the compact input width");
+    expect(row.classes()).toContain("composerMainRow--expanded");
+    expect(el.style.height).toBe("34px");
+    expect(el.style.width).toBe("");
+    for (let index = 0; index < 3; index++) {
+      window.dispatchEvent(new Event("resize"));
+      await nextTick();
+      expect(row.classes()).toContain("composerMainRow--expanded");
+    }
+
+    await textarea.setValue("");
+    expect(row.classes()).toEqual(["composerMainRow"]);
+    expect(el.style.height).toBe("34px");
     wrapper.unmount();
   });
 
@@ -215,11 +241,11 @@ describe("MainChat compact composer layout", () => {
     expect(composer).not.toMatch(/padding-bottom:\s*calc\(12px\s*\+/);
   });
 
-  it("keeps the textarea and actions in one grid row as content grows", async () => {
+  it("spans expanded text across the full row above the actions", async () => {
     const composer = await readSfc("../components/MainChatComposerPanel.vue", import.meta.url);
 
     expect(composer).toMatch(/\.composerMainRow\s*\{[^}]*display:\s*grid\s*;[^}]*grid-template-columns:\s*auto minmax\(0,\s*1fr\) auto\s*;[^}]*grid-template-areas:\s*"left input right"\s*;/);
     expect(composer).toMatch(/\.composer-input\s*\{[^}]*width:\s*100%\s*;/);
-    expect(composer).not.toContain("composerMainRow--expanded");
+    expect(composer).toMatch(/\.composerMainRow--expanded\s*\{[^}]*grid-template-areas:\s*"input input input"\s*"left \. right"\s*;/);
   });
 });

--- a/client/src/__tests__/mainchat-header-ui.test.ts
+++ b/client/src/__tests__/mainchat-header-ui.test.ts
@@ -18,7 +18,7 @@ describe("MainChat header UI", () => {
     const group = css.match(/\.laneTabGroup\s*\{[^}]*\}/)?.[0];
     const controls = css.match(/\.laneModelControls\s*\{[^}]*\}/)?.[0];
     expect(group).toMatch(/display:\s*grid\s*;/);
-    expect(group).toMatch(/grid-template-columns:\s*minmax\(76px,\s*1fr\) minmax\(0,\s*320px\) minmax\(76px,\s*1fr\)\s*;/);
+    expect(group).toMatch(/grid-template-columns:\s*minmax\(88px,\s*1fr\) minmax\(0,\s*176px\) minmax\(88px,\s*1fr\)\s*;/);
     expect(group).toMatch(/width:\s*100%\s*;/);
     expect(controls).toMatch(/min-width:\s*0\s*;/);
     expect(controls).toMatch(/justify-content:\s*center\s*;/);
@@ -28,6 +28,9 @@ describe("MainChat header UI", () => {
     const selectors = readUtf8("../components/MainChatModelSelectors.vue");
     expect(selectors.match(/<select\s/g)).toHaveLength(2);
     expect(selectors).toMatch(/\.modelSelect\s*\{[^}]*width:\s*100%\s*;[^}]*min-width:\s*0\s*;/);
+    expect(selectors).toMatch(/\.modelField\s*\{[^}]*height:\s*26px\s*;[^}]*font-size:\s*12px\s*;/);
+    expect(selectors).toMatch(/\.modelSelect\s*\{[^}]*font-size:\s*16px\s*;/);
+    expect(css).toMatch(/\.laneTab\s*\{[^}]*font-size:\s*14px\s*;/);
     expect(selectors).not.toContain('role="dialog"');
     const app = readUtf8("../App.vue");
     const header = app.match(/<header class="topbar">([\s\S]*?)<\/header>/)?.[1];

--- a/client/src/components/MainChatComposerPanel.vue
+++ b/client/src/components/MainChatComposerPanel.vue
@@ -120,6 +120,10 @@ watch(
 const {
   input,
   inputEl,
+  composerRowEl,
+  leftActionsEl,
+  rightActionsEl,
+  composerExpanded,
   fileInputEl,
   send,
   onInputKeydown,
@@ -315,8 +319,8 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
         :disabled="inputLocked"
         @change="onFileInputChange"
       />
-      <div class="composerMainRow">
-        <div class="composerMainRowLeft">
+      <div ref="composerRowEl" class="composerMainRow" :class="{ 'composerMainRow--expanded': composerExpanded }">
+        <div ref="leftActionsEl" class="composerMainRowLeft">
           <button
             class="attachIcon composerActionToggle"
             type="button"
@@ -351,7 +355,7 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
           @focus="updateTextSelection"
           @blur="clearTextSelectionState"
         />
-        <div class="composerMainRowRight">
+        <div ref="rightActionsEl" class="composerMainRowRight">
           <div v-if="recording" class="voiceIndicator recording" aria-hidden="true">
             <div class="voiceBars">
               <span class="bar" />
@@ -630,6 +634,13 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
   padding: 8px;
   flex-shrink: 0;
   gap: 6px;
+}
+
+.composerMainRow--expanded {
+  grid-template-areas:
+    "input input input"
+    "left . right";
+  row-gap: 2px;
 }
 
 .composerMainRowLeft,

--- a/client/src/components/MainChatMessageList.vue
+++ b/client/src/components/MainChatMessageList.vue
@@ -694,6 +694,7 @@ function closeFilePreview(): void {
 
 .msg[data-role="user"] {
   justify-content: flex-end;
+  margin-bottom: 8px;
 }
 
 .messageHistorySentinel {
@@ -1079,11 +1080,11 @@ function closeFilePreview(): void {
 }
 
 .msg[data-role="user"] .bubble {
-  width: 100%;
-  max-width: 100%;
+  width: fit-content;
+  max-width: 90%;
   min-width: 0;
   box-sizing: border-box;
-  padding: 4px 0 8px;
+  padding: 2px 0;
   border: none;
   border-radius: 0;
   background: transparent;
@@ -1124,7 +1125,17 @@ function closeFilePreview(): void {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
-  margin-top: 4px;
+  margin-top: 2px;
+  gap: 6px;
+}
+
+.msg[data-role="user"] .msgCopyBtn {
+  width: 24px;
+  height: 24px;
+}
+
+.msg[data-role="user"] .bubble :deep(.md > :last-child) {
+  margin-bottom: 0;
 }
 
 .thoughtCard {

--- a/client/src/components/MainChatModelSelectors.vue
+++ b/client/src/components/MainChatModelSelectors.vue
@@ -218,61 +218,75 @@ function selectReasoningEffort(effort: string): void {
 
 <template>
   <div class="modelSelectors" role="group" aria-label="Model settings">
-    <select
-      class="modelSelect"
-      aria-label="Model"
-      :title="selectedModelLabel"
-      data-testid="chat-model-select"
-      :value="effectiveModelId"
-      :disabled="!canChange || !compatibleModelOptions.length"
-      @change="selectModel(($event.target as HTMLSelectElement).value)"
-    >
-      <option v-if="!compatibleModelOptions.length" value="" disabled>No models</option>
-      <option v-else-if="!selectedModel && effectiveModelId" :value="effectiveModelId" disabled>{{ effectiveModelId }}</option>
-      <option
-        v-for="model in compatibleModelOptions"
-        :key="modelKey(model)"
-        :value="modelKey(model)"
-        data-testid="chat-model-option"
-        :data-model-id="modelKey(model)"
-      >{{ formatModelLabel(model) }}</option>
-    </select>
-    <select
-      class="modelSelect"
-      aria-label="Reasoning effort"
-      :title="REASONING_EFFORT_LABELS[reasoningEffortValue] || 'Reasoning effort'"
-      data-testid="chat-reasoning-effort"
-      :value="reasoningEffortValue"
-      :disabled="!canChange || !reasoningEffortOptions.length"
-      @change="selectReasoningEffort(($event.target as HTMLSelectElement).value)"
-    >
-      <option v-if="!reasoningEffortOptions.length" value="" disabled>Effort</option>
-      <option
-        v-for="effort in reasoningEffortOptions"
-        :key="effort"
-        :value="effort"
-        :aria-label="REASONING_EFFORT_LABELS[effort]"
-        :data-reasoning-effort="effort"
-      >{{ REASONING_EFFORT_SHORT_LABELS[effort] ?? REASONING_EFFORT_LABELS[effort] ?? effort }}</option>
-    </select>
+    <label class="modelField" :class="{ 'modelField--disabled': !canChange || !compatibleModelOptions.length }">
+      <span class="modelFieldValue" aria-hidden="true" data-testid="chat-model-value">
+        {{ compatibleModelOptions.length ? selectedModelLabel : "No models" }}
+      </span>
+      <select
+        class="modelSelect"
+        aria-label="Model"
+        :title="selectedModelLabel"
+        data-testid="chat-model-select"
+        :value="effectiveModelId"
+        :disabled="!canChange || !compatibleModelOptions.length"
+        @change="selectModel(($event.target as HTMLSelectElement).value)"
+      >
+        <option v-if="!compatibleModelOptions.length" value="" disabled>No models</option>
+        <option v-else-if="!selectedModel && effectiveModelId" :value="effectiveModelId" disabled>{{ effectiveModelId }}</option>
+        <option
+          v-for="model in compatibleModelOptions"
+          :key="modelKey(model)"
+          :value="modelKey(model)"
+          data-testid="chat-model-option"
+          :data-model-id="modelKey(model)"
+        >{{ formatModelLabel(model) }}</option>
+      </select>
+    </label>
+    <label class="modelField" :class="{ 'modelField--disabled': !canChange || !reasoningEffortOptions.length }">
+      <span class="modelFieldValue" aria-hidden="true" data-testid="chat-effort-value">
+        {{ REASONING_EFFORT_SHORT_LABELS[reasoningEffortValue] || REASONING_EFFORT_LABELS[reasoningEffortValue] || "Effort" }}
+      </span>
+      <select
+        class="modelSelect"
+        aria-label="Reasoning effort"
+        :title="REASONING_EFFORT_LABELS[reasoningEffortValue] || 'Reasoning effort'"
+        data-testid="chat-reasoning-effort"
+        :value="reasoningEffortValue"
+        :disabled="!canChange || !reasoningEffortOptions.length"
+        @change="selectReasoningEffort(($event.target as HTMLSelectElement).value)"
+      >
+        <option v-if="!reasoningEffortOptions.length" value="" disabled>Effort</option>
+        <option
+          v-for="effort in reasoningEffortOptions"
+          :key="effort"
+          :value="effort"
+          :aria-label="REASONING_EFFORT_LABELS[effort]"
+          :data-reasoning-effort="effort"
+        >{{ REASONING_EFFORT_SHORT_LABELS[effort] ?? REASONING_EFFORT_LABELS[effort] ?? effort }}</option>
+      </select>
+    </label>
   </div>
 </template>
 
 <style scoped>
 .modelSelectors {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 88px;
+  grid-template-columns: minmax(0, 112px) 60px;
   align-items: center;
-  gap: 6px;
-  width: 100%;
+  gap: 4px;
+  width: fit-content;
+  max-width: 100%;
   min-width: 0;
 }
 
-.modelSelect {
-  width: 100%;
+.modelField {
+  position: relative;
+  display: flex;
+  align-items: center;
   min-width: 0;
-  min-height: 32px;
-  padding: 4px 20px 4px 6px;
+  height: 26px;
+  box-sizing: border-box;
+  padding: 3px 18px 3px 6px;
   border: 1px solid rgba(148, 163, 184, 0.28);
   border-radius: 999px;
   background-color: rgba(248, 250, 252, 0.98);
@@ -281,38 +295,43 @@ function selectReasoningEffort(effort: string): void {
   background-repeat: no-repeat;
   color: #334155;
   font-size: 12px;
-  font-weight: 700;
-  line-height: 1.25;
-  appearance: none;
+  font-weight: 500;
+  line-height: 18px;
+}
+
+.modelFieldValue {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  cursor: pointer;
 }
 
-.modelSelect:disabled {
+.modelField--disabled {
   opacity: 0.55;
-  cursor: not-allowed;
 }
 
-.modelSelect:hover:not(:disabled) {
+.modelField:hover:not(.modelField--disabled) {
   border-color: rgba(59, 130, 246, 0.35);
   background-color: rgba(239, 246, 255, 0.98);
 }
 
-.modelSelect:focus-visible {
-  outline: none;
+.modelField:focus-within {
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.14);
 }
 
-@media (max-width: 900px) {
-  .modelSelectors {
-    grid-template-columns: minmax(0, 1fr) 80px;
-    gap: 4px;
-  }
+.modelSelect {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  opacity: 0;
+  /* Retain native keyboard/picker behavior without mobile focus zoom. */
+  font-size: 16px;
+  cursor: pointer;
+}
 
-  .modelSelect {
-    font-size: 16px;
-  }
+.modelSelect:disabled {
+  cursor: not-allowed;
 }
 </style>

--- a/client/src/components/mainChat/useComposer.ts
+++ b/client/src/components/mainChat/useComposer.ts
@@ -91,15 +91,45 @@ export function useMainChatComposer(params: {
     },
   });
   const inputEl = ref<HTMLTextAreaElement | null>(null);
+  const composerRowEl = ref<HTMLElement | null>(null);
+  const leftActionsEl = ref<HTMLElement | null>(null);
+  const rightActionsEl = ref<HTMLElement | null>(null);
+  const composerExpanded = ref(false);
 
   const resizeComposer = (): void => {
     const el = inputEl.value;
     if (!el) return;
+    if (!el.value) {
+      composerExpanded.value = false;
+      autosizeTextarea(el, { minRows: 1, maxRows: 8 });
+      return;
+    }
+
+    const row = composerRowEl.value;
+    const left = leftActionsEl.value;
+    const right = rightActionsEl.value;
+    let compactWidth = 0;
+    if (row && left && right) {
+      const style = window.getComputedStyle(row);
+      const padding = (Number.parseFloat(style.paddingLeft) || 0) + (Number.parseFloat(style.paddingRight) || 0);
+      const gap = Number.parseFloat(style.columnGap) || 0;
+      compactWidth = row.clientWidth - padding - gap * 2 - left.offsetWidth - right.offsetWidth;
+    }
+
+    // Always decide using the compact width; measuring the expanded width would
+    // otherwise alternate between the two layouts near a wrapping boundary.
+    const previousWidth = el.style.width;
+    if (compactWidth > 0) el.style.width = `${compactWidth}px`;
+    try {
+      composerExpanded.value = autosizeTextarea(el, { minRows: 1, maxRows: 8 });
+    } finally {
+      el.style.width = previousWidth;
+    }
     autosizeTextarea(el, { minRows: 1, maxRows: 8 });
   };
 
   // Resize after Vue commits DOM updates (v-model, conditional UI that affects wrapping, etc).
-  watch([input, inputEl], resizeComposer, { flush: "post", immediate: true });
+  watch([input, inputEl, composerExpanded], resizeComposer, { flush: "post", immediate: true });
 
   // Some environments/layout changes won't trigger reactive updates (e.g. viewport resize affects wrapping).
   // Attach lightweight native listeners so the composer reliably grows up to maxRows.
@@ -125,19 +155,25 @@ export function useMainChatComposer(params: {
     attachedEl = el;
     el.addEventListener("input", onNativeInput, { passive: true });
     if (typeof ResizeObserver !== "undefined") {
-      let observedWidth = -1;
+      const observedWidths = new WeakMap<Element, number>();
       composerResizeObserver = new ResizeObserver((entries) => {
-        const width = entries.find((entry) => entry.target === el)?.contentRect.width;
-        if (width === undefined || width === observedWidth) return;
-        observedWidth = width;
-        if (width <= 0) return;
+        let widthChanged = false;
+        for (const entry of entries) {
+          const width = entry.contentRect.width;
+          const previousWidth = observedWidths.get(entry.target);
+          observedWidths.set(entry.target, width);
+          if (width > 0 && width !== previousWidth) widthChanged = true;
+        }
+        if (!widthChanged) return;
         if (composerResizeFrame !== null) window.cancelAnimationFrame(composerResizeFrame);
         composerResizeFrame = window.requestAnimationFrame(() => {
           composerResizeFrame = null;
           resizeComposer();
         });
       });
-      composerResizeObserver.observe(el);
+      for (const target of [el, composerRowEl.value, leftActionsEl.value, rightActionsEl.value]) {
+        if (target) composerResizeObserver.observe(target);
+      }
     }
   };
 
@@ -574,6 +610,10 @@ export function useMainChatComposer(params: {
   return {
     input,
     inputEl,
+    composerRowEl,
+    leftActionsEl,
+    rightActionsEl,
+    composerExpanded,
     fileInputEl,
     send,
     onInputKeydown,

--- a/client/src/lib/textarea_autosize.test.ts
+++ b/client/src/lib/textarea_autosize.test.ts
@@ -45,13 +45,14 @@ describe("autosizeTextarea", () => {
     expect(autosizeTextarea(element, { minRows: 1, maxRows: 8 })).toBe(false);
     expect(element.style.height).toBe("42px");
     expect(element.style.overflowY).toBe("hidden");
-    expect(measuredHeights).toEqual(["0px", "0px", "0px"]);
+    expect(measuredHeights).toEqual(["0px"]);
 
     element.remove();
   });
 
   it("clamps height between minRows/maxRows and toggles overflow", () => {
     const el = document.createElement("textarea");
+    el.value = "Measured content";
     document.body.appendChild(el);
 
     const scroll = { value: 0 };
@@ -85,6 +86,7 @@ describe("autosizeTextarea", () => {
 
   it("shrinks when content is reduced", () => {
     const el = document.createElement("textarea");
+    el.value = "Measured content";
     document.body.appendChild(el);
 
     const scroll = { value: 0 };
@@ -108,6 +110,7 @@ describe("autosizeTextarea", () => {
 
   it("falls back to fontSize when lineHeight is normal", () => {
     const el = document.createElement("textarea");
+    el.value = "Measured content";
     document.body.appendChild(el);
 
     const scroll = { value: 0 };
@@ -140,5 +143,21 @@ describe("autosizeTextarea", () => {
     expect(el.style.overflowY).toBe("auto");
 
     el.remove();
+  });
+
+  it("clears stale height and scrolling without measuring an empty editor", () => {
+    const el = document.createElement("textarea");
+    el.style.height = "182px";
+    el.style.overflowY = "auto";
+    el.scrollTop = 100;
+    const scrollHeight = vi.fn(() => 500);
+    Object.defineProperty(el, "scrollHeight", { get: scrollHeight });
+    vi.spyOn(window, "getComputedStyle").mockReturnValue(makeStyle({}));
+
+    expect(autosizeTextarea(el, { minRows: 1, maxRows: 8 })).toBe(false);
+    expect(el.style.height).toBe("42px");
+    expect(el.style.overflowY).toBe("hidden");
+    expect(el.scrollTop).toBe(0);
+    expect(scrollHeight).not.toHaveBeenCalled();
   });
 });

--- a/client/src/lib/textarea_autosize.ts
+++ b/client/src/lib/textarea_autosize.ts
@@ -46,6 +46,14 @@ export function autosizeTextarea(el: HTMLTextAreaElement, opts: AutosizeTextarea
   const minHeight = lineHeightPx * minRows + extraHeight;
   const maxHeight = lineHeightPx * maxRows + extraHeight;
 
+  // Empty editors must collapse even when a browser reports stale scroll geometry.
+  if (!el.value) {
+    el.style.height = `${Math.ceil(minHeight)}px`;
+    el.style.overflowY = "hidden";
+    el.scrollTop = 0;
+    return false;
+  }
+
   // Reset height so scrollHeight reflects the full content and the textarea can shrink.
   el.style.height = "0px";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ads",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ads",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ads",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "description": "AI agent workspace and task orchestration with optional channel connectors",
   "author": "ADS Contributors",


### PR DESCRIPTION
## Summary

Closes #191

- Make Advisor and Worker the primary header controls: 14px role labels at opposite ends, with centered 12px setting labels in 26px-high fields. Bound the model field to 112px and the complete settings group to 176px. Keep native, accessible dropdowns and their existing model/effort behavior.
- Keep empty and short drafts in one compact row. Expand multiline text across the full inner width above the tools, using the compact width for the expansion decision to avoid wrap-boundary oscillation. Reset empty drafts deterministically, including stale scroll geometry, and resize correctly after lane or viewport changes.
- Restore right-aligned, content-sized user messages with a 90% width limit. Reduce text/footer and inter-message spacing while preserving timestamps and copy controls.
- Add regression coverage for expansion, shrink-back, stale empty-input height, wrap-boundary stability, header hierarchy, and bounded user-message layout.
- Update both package manifests to 0.2.5 for the user-authorized release after this PR is merged.

## Verification

- `npm run lint` — passed.
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json` — passed.
- `npm run build` — passed.
- Full backend suite — 730 passed, 0 failed, 0 skipped.
- `npm run test:web` — 86 files, 500 tests passed.
- `git diff --check` — passed.
- Real Chrome with the complete app and local API/WebSocket fixtures: 320px, 390px, 900px, and 1440px widths, plus a 34px mobile safe area. Verified one-row initial state, wrapped and explicit-newline full-width input, keyboard deletion, successful-send reset, compact-width boundary stability, independent lane drafts and preferences, native dropdown keyboard operation, outgoing model/effort values, busy guards, accessible combobox names, user-message alignment/spacing, and copy behavior.
- Additional browser checks: actual 320–1440px viewport changes, simulated keyboard visual viewport and safe-area handling, and long user text/code blocks without page overflow. No browser runtime exceptions. This is Chrome viewport emulation, not an iOS-device validation.

The backend suite uses a temporary preload to isolate host-installed lane-skill metadata only for `tests/systemPrompt/manager.test.ts`. All other test fixtures are unchanged; no test is skipped and no repository or production configuration is changed.

## Scope

No backend/provider contract changes or production-service deployment. Clear session continues to preserve drafts; this change does not add a clear-text menu action. The user subsequently authorized the complete PR lifecycle and release 0.2.5; the version metadata is included so the automatic dev build uses the new version rather than an existing release asset name.
