### PR TITLE
fix(pwa): bound composer menus and viewport layout

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -30,9 +30,10 @@
         position: fixed;
         overflow: hidden;
         top: var(--app-top, 0px);
-        bottom: var(--app-bottom, 0px);
+        height: var(--ads-visual-viewport-height, 100dvh);
         left: 0;
         right: 0;
+        --app-safe-bottom: max(0px, calc(env(safe-area-inset-bottom, 0px) - var(--app-bottom, 0px)));
       }
     </style>
   </head>

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,10 +1,7 @@
 .app {
   --topbar-height: 40px;
-  position: fixed;
-  top: var(--app-top, 0px);
-  left: 0;
-  right: 0;
-  height: var(--ads-visual-viewport-height, 100dvh);
+  position: relative;
+  height: 100%;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/client/src/__tests__/mainchat-composer-layout.test.ts
+++ b/client/src/__tests__/mainchat-composer-layout.test.ts
@@ -230,12 +230,60 @@ describe("MainChat compact composer layout", () => {
     expect(chat).toMatch(/\.chat\s*\{[^}]*flex:\s*1 1 auto\s*;/);
   });
 
-  it("keeps safe-area protection in the bottom dock, outside the single-row input", async () => {
+  it("reserves the tool row when only the visual viewport height changes", async () => {
+    const viewport = Object.assign(new EventTarget(), { height: 844, offsetTop: 0, width: 390 });
+    vi.stubGlobal("visualViewport", viewport);
+    vi.stubGlobal("innerHeight", 844);
+    vi.spyOn(HTMLTextAreaElement.prototype, "scrollHeight", "get").mockReturnValue(800);
+    const Host = defineComponent({
+      components: { ComposerHost },
+      template: '<div class="detail"><div class="chat"></div><ComposerHost /></div>',
+    });
+    const wrapper = mount(Host);
+    const row = wrapper.get(".composerMainRow").element;
+    const textarea = wrapper.get("textarea");
+    const element = textarea.element as HTMLTextAreaElement;
+    const composer = wrapper.get(".composer").element;
+    const inputStyle = window.getComputedStyle(element);
+    vi.mocked(window.getComputedStyle).mockImplementation((target) => {
+      if (target.matches(".chat")) return { ...inputStyle, paddingTop: "12px", paddingBottom: "12px" };
+      if (target.matches(".composerMainRow")) return { ...inputStyle, paddingTop: "8px", paddingBottom: "8px", rowGap: "2px" };
+      return inputStyle;
+    });
+    vi.spyOn(wrapper.element, "getBoundingClientRect").mockImplementation(() => new DOMRect(0, 68, 390, viewport.height - 68));
+    vi.spyOn(wrapper.get(".chat").element, "getBoundingClientRect").mockReturnValue(new DOMRect(0, 68, 390, 0));
+    vi.spyOn(row, "clientWidth", "get").mockReturnValue(356);
+    vi.spyOn(row, "offsetHeight", "get").mockImplementation(() => Number.parseFloat(element.style.height) + 46);
+    vi.spyOn(composer, "offsetHeight", "get").mockImplementation(() => Number.parseFloat(element.style.height) + 56);
+    for (const selector of [".composerMainRowLeft", ".composerMainRowRight"]) {
+      vi.spyOn(wrapper.get(selector).element, "offsetHeight", "get").mockReturnValue(34);
+    }
+
+    await textarea.setValue("Long draft\n".repeat(30));
+    expect(element.style.height).toBe("202px");
+    viewport.height = 300;
+    viewport.dispatchEvent(new Event("resize"));
+    await nextTick();
+    expect(element.style.height).toBe("146px");
+    expect(element.style.overflowY).toBe("auto");
+    expect(wrapper.get(".composerMainRow").classes()).toContain("composerMainRow--expanded");
+
+    viewport.height = 430;
+    viewport.dispatchEvent(new Event("resize"));
+    await nextTick();
+    expect(element.style.height).toBe("202px");
+    await textarea.setValue("");
+    expect(element.style.height).toBe("34px");
+    expect(wrapper.get(".composerMainRow").classes()).not.toContain("composerMainRow--expanded");
+    wrapper.unmount();
+  });
+
+  it("consumes only the root's remaining safe area without adding another input inset", async () => {
     const composer = await readSfc("../components/MainChatComposerPanel.vue", import.meta.url);
     const composerRule = composer.match(/\.composer\s*\{[^}]*\}/)?.[0];
     const inputWrapRule = composer.match(/\.inputWrap\s*\{[^}]*\}/)?.[0];
 
-    expect(composerRule).toContain("padding: 8px 16px calc(env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1));");
+    expect(composerRule).toContain("padding: 8px 16px var(--app-safe-bottom, env(safe-area-inset-bottom, 0px));");
     expect(inputWrapRule).not.toContain("safe-area-inset-bottom");
     expect(inputWrapRule).not.toContain("padding-bottom");
     expect(composer).not.toMatch(/padding-bottom:\s*calc\(12px\s*\+/);

--- a/client/src/__tests__/mainchat-prompt-tools.test.ts
+++ b/client/src/__tests__/mainchat-prompt-tools.test.ts
@@ -38,6 +38,10 @@ function action(selector: string): DOMWrapper<Element> {
   return new DOMWrapper(element);
 }
 
+function dispatchCompatibilityClick(element: Element): void {
+  element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, detail: 1 }));
+}
+
 async function openActionSheet(wrapper: ReturnType<typeof mount>): Promise<void> {
   await wrapper.get('[data-testid="composer-actions-toggle"]').trigger("click");
   await nextTick();
@@ -148,15 +152,19 @@ describe("MainChat prompt tools", () => {
     wrapper.unmount();
   });
 
-  it("toggles only on click, dismisses outside and on Escape, and closes when locked", async () => {
+  it("toggles on pointer release or click, dismisses outside and on Escape, and closes when locked", async () => {
     const wrapper = mountPromptTools();
     const toggle = wrapper.get('[data-testid="composer-actions-toggle"]');
     await toggle.trigger("pointerdown", { pointerType: "touch" });
     await toggle.trigger("pointerup", { pointerType: "touch" });
-    expect(toggle.attributes("aria-expanded")).toBe("false");
-    await toggle.trigger("click");
     expect(toggle.attributes("aria-expanded")).toBe("true");
-    await toggle.trigger("click");
+    dispatchCompatibilityClick(toggle.element);
+    await nextTick();
+    expect(toggle.attributes("aria-expanded")).toBe("true");
+    await toggle.trigger("pointerdown", { pointerType: "touch" });
+    await toggle.trigger("pointerup", { pointerType: "touch" });
+    dispatchCompatibilityClick(toggle.element);
+    await nextTick();
     expect(toggle.attributes("aria-expanded")).toBe("false");
 
     await openActionSheet(wrapper);
@@ -170,6 +178,51 @@ describe("MainChat prompt tools", () => {
     await openActionSheet(wrapper);
     await wrapper.setProps({ inputLocked: true });
     expect(toggle.attributes("aria-expanded")).toBe("false");
+    wrapper.unmount();
+  });
+
+  it("opens on a pointer release when no click follows and suppresses the compatibility click", async () => {
+    const wrapper = mountPromptTools();
+    const toggle = wrapper.get('[data-testid="composer-actions-toggle"]');
+
+    await toggle.trigger("pointerdown", { pointerId: 1 });
+    await toggle.trigger("pointerup", { pointerId: 1 });
+    await nextTick();
+    expect(toggle.attributes("aria-expanded")).toBe("true");
+
+    dispatchCompatibilityClick(toggle.element);
+    await nextTick();
+    expect(toggle.attributes("aria-expanded")).toBe("true");
+
+    await toggle.trigger("pointerdown", { pointerId: 2 });
+    await toggle.trigger("pointerup", { pointerId: 2 });
+    dispatchCompatibilityClick(toggle.element);
+    await nextTick();
+    await nextTick();
+    expect(toggle.attributes("aria-expanded")).toBe("false");
+    wrapper.unmount();
+  });
+
+  it("preserves a selected range when touch activation blurs the textarea", async () => {
+    const wrapper = mountPromptTools();
+    const textarea = wrapper.get("textarea.composer-input");
+    const element = textarea.element as HTMLTextAreaElement;
+    await textarea.setValue("alpha beta");
+    element.focus();
+    element.setSelectionRange(6, 10);
+    await textarea.trigger("select");
+
+    const toggle = wrapper.get('[data-testid="composer-actions-toggle"]');
+    await toggle.trigger("pointerdown", { pointerId: 1 });
+    await textarea.trigger("blur");
+    await toggle.trigger("pointerup", { pointerId: 1 });
+    await nextTick();
+
+    const quote = action("[data-testid='wrap-triple-quotes']");
+    expect(quote.attributes("disabled")).toBeUndefined();
+    await quote.trigger("click");
+    await nextTick();
+    expect(element.value).toBe('alpha """beta"""');
     wrapper.unmount();
   });
 

--- a/client/src/__tests__/mainchat-prompt-tools.test.ts
+++ b/client/src/__tests__/mainchat-prompt-tools.test.ts
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { defineComponent, nextTick, ref } from "vue";
-import { mount } from "@vue/test-utils";
+import { DOMWrapper, mount } from "@vue/test-utils";
 
 import MainChatComposerPanel from "../components/MainChatComposerPanel.vue";
 
@@ -9,6 +9,7 @@ const STORAGE_KEY = "ADS_WEB_LATEST_PROMPT:project-1:main";
 function mountPromptTools(options?: { inputLocked?: boolean; latestPromptKey?: string }) {
   const Host = defineComponent({
     components: { MainChatComposerPanel },
+    props: { inputLocked: { type: Boolean, default: options?.inputLocked === true } },
     setup() {
       const draft = ref("");
       const sent = ref<string[]>([]);
@@ -21,14 +22,20 @@ function mountPromptTools(options?: { inputLocked?: boolean; latestPromptKey?: s
         :pending-images="[]"
         :connected="true"
         :busy="false"
-        :input-locked="${options?.inputLocked === true ? "true" : "false"}"
+        :input-locked="inputLocked"
         latest-prompt-key="${options?.latestPromptKey ?? "project-1:main"}"
         @update:draft="draft = $event"
         @send="sent.push($event)"
       />
     `,
   });
-  return mount(Host, { global: { stubs: { MainChatPendingImageViewer: true } } });
+  return mount(Host, { attachTo: document.body, global: { stubs: { MainChatPendingImageViewer: true } } });
+}
+
+function action(selector: string): DOMWrapper<Element> {
+  const element = document.querySelector(selector);
+  if (!element) throw new Error(`Missing action: ${selector}`);
+  return new DOMWrapper(element);
 }
 
 async function openActionSheet(wrapper: ReturnType<typeof mount>): Promise<void> {
@@ -39,6 +46,14 @@ async function openActionSheet(wrapper: ReturnType<typeof mount>): Promise<void>
 describe("MainChat prompt tools", () => {
   beforeEach(() => {
     localStorage.clear();
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue(new DOMRect(16, 240, 32, 32));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    document.body.innerHTML = "";
   });
 
   it("stores the latest sent prompt and restores it into an empty composer", async () => {
@@ -54,7 +69,7 @@ describe("MainChat prompt tools", () => {
     expect((textarea.element as HTMLTextAreaElement).value).toBe("");
 
     await openActionSheet(wrapper);
-    const restore = wrapper.get("[data-testid='restore-latest-prompt']");
+    const restore = action("[data-testid='restore-latest-prompt']");
     expect(restore.attributes("disabled")).toBeUndefined();
     await restore.trigger("click");
     await nextTick();
@@ -72,7 +87,7 @@ describe("MainChat prompt tools", () => {
     const textarea = wrapper.get("textarea.composer-input");
     await textarea.setValue("Current draft");
     await openActionSheet(wrapper);
-    const restore = wrapper.get("[data-testid='restore-latest-prompt']");
+    const restore = action("[data-testid='restore-latest-prompt']");
 
     expect(restore.attributes("disabled")).toBeDefined();
     await textarea.setValue("");
@@ -94,7 +109,7 @@ describe("MainChat prompt tools", () => {
     await textarea.trigger("select");
 
     await openActionSheet(wrapper);
-    const quote = wrapper.get("[data-testid='wrap-triple-quotes']");
+    const quote = action("[data-testid='wrap-triple-quotes']");
     expect(quote.attributes("disabled")).toBeUndefined();
     await quote.trigger("click");
     await nextTick();
@@ -111,6 +126,90 @@ describe("MainChat prompt tools", () => {
     expect(wrapper.find(".inputToolbarRight").exists()).toBe(false);
     expect(wrapper.get('[data-testid="composer-actions-toggle"]').attributes("disabled")).toBeDefined();
     expect(wrapper.find('[data-testid="composer-action-sheet"]').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it("keeps portal actions alive through pointerdown and invokes the file picker synchronously", async () => {
+    const wrapper = mountPromptTools();
+    const fileInput = wrapper.get('input[type="file"]').element as HTMLInputElement;
+    const picker = vi.spyOn(fileInput, "click").mockImplementation(() => {});
+    await openActionSheet(wrapper);
+    const menu = action('[data-testid="composer-action-sheet"]');
+    expect(document.body.contains(menu.element)).toBe(true);
+    expect(wrapper.element.contains(menu.element)).toBe(false);
+
+    const attach = action('[data-testid="action-attach-image"]');
+    await attach.trigger("pointerdown");
+    expect(document.body.contains(attach.element)).toBe(true);
+    attach.element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(picker).toHaveBeenCalledOnce();
+    await nextTick();
+    expect(document.querySelector('[data-testid="composer-action-sheet"]')).toBeNull();
+    wrapper.unmount();
+  });
+
+  it("toggles only on click, dismisses outside and on Escape, and closes when locked", async () => {
+    const wrapper = mountPromptTools();
+    const toggle = wrapper.get('[data-testid="composer-actions-toggle"]');
+    await toggle.trigger("pointerdown", { pointerType: "touch" });
+    await toggle.trigger("pointerup", { pointerType: "touch" });
+    expect(toggle.attributes("aria-expanded")).toBe("false");
+    await toggle.trigger("click");
+    expect(toggle.attributes("aria-expanded")).toBe("true");
+    await toggle.trigger("click");
+    expect(toggle.attributes("aria-expanded")).toBe("false");
+
+    await openActionSheet(wrapper);
+    document.body.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+    await nextTick();
+    expect(toggle.attributes("aria-expanded")).toBe("false");
+    await openActionSheet(wrapper);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await nextTick();
+    expect(toggle.attributes("aria-expanded")).toBe("false");
+    await openActionSheet(wrapper);
+    await wrapper.setProps({ inputLocked: true });
+    expect(toggle.attributes("aria-expanded")).toBe("false");
+    wrapper.unmount();
+  });
+
+  it("anchors the portal to the trigger and bounds its height inside the visual viewport", async () => {
+    vi.stubGlobal("visualViewport", Object.assign(new EventTarget(), { height: 300, offsetTop: 0, width: 320, offsetLeft: 0 }));
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue(new DOMRect(24, 248, 32, 32));
+    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(124);
+    vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(126);
+    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(124);
+    const wrapper = mountPromptTools();
+    await openActionSheet(wrapper);
+    await nextTick();
+    const menu = action('[data-testid="composer-action-sheet"]').element as HTMLElement;
+    expect(menu.style.top).toBe("114px");
+    expect(menu.style.left).toBe("24px");
+    expect(menu.style.maxHeight).toBe("232px");
+    expect(menu.style.visibility).toBe("visible");
+    expect(wrapper.get('[data-testid="composer-actions-toggle"]').attributes("aria-controls")).toBe(menu.id);
+    wrapper.unmount();
+    vi.unstubAllGlobals();
+  });
+
+  it("reduces menu height on viewport-only changes even before the trigger finishes moving", async () => {
+    vi.useFakeTimers();
+    const viewport = Object.assign(new EventTarget(), { height: 300, offsetTop: 0, width: 320, offsetLeft: 0 });
+    vi.stubGlobal("visualViewport", viewport);
+    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(124);
+    vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(126);
+    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(124);
+    const wrapper = mountPromptTools();
+    await openActionSheet(wrapper);
+    await nextTick();
+    const menu = action('[data-testid="composer-action-sheet"]').element as HTMLElement;
+    viewport.height = 110;
+    viewport.dispatchEvent(new Event("resize"));
+    vi.advanceTimersByTime(32);
+    await nextTick();
+    expect(menu.style.top).toBe("8px");
+    expect(menu.style.maxHeight).toBe("94px");
+    expect(menu.style.visibility).toBe("visible");
     wrapper.unmount();
   });
 });

--- a/client/src/components/MainChatComposerPanel.vue
+++ b/client/src/components/MainChatComposerPanel.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, nextTick, ref, useId, watch } from "vue";
 
 import MainChatPendingImageViewer from "./MainChatPendingImageViewer.vue";
 import { resolveComposerImagePreview } from "./mainChat/attachmentPreview";
 import type { IncomingImage, QueuedPrompt } from "./mainChat/types";
 import { useMainChatComposer } from "./mainChat/useComposer";
+import { useComposerActionMenu } from "./mainChat/useComposerActionMenu";
 
 type PendingImagePreview = {
   key: string;
@@ -150,26 +151,15 @@ const {
 });
 
 const composerRoot = ref<HTMLElement | null>(null);
-const actionMenuOpen = ref(false);
-
-function closeActionMenu(): void {
-  actionMenuOpen.value = false;
-}
-
-function toggleActionMenu(): void {
-  if (props.inputLocked) return;
-  actionMenuOpen.value = !actionMenuOpen.value;
-}
-
-function onActionMenuPointerDown(event: Event): void {
-  const target = event.target;
-  if (target instanceof Node && composerRoot.value?.contains(target)) return;
-  closeActionMenu();
-}
-
-function onActionMenuKeydown(event: KeyboardEvent): void {
-  if (event.key === "Escape") closeActionMenu();
-}
+const actionMenuId = useId();
+const {
+  trigger: actionMenuTrigger,
+  menu: actionMenuElement,
+  open: actionMenuOpen,
+  style: actionMenuStyle,
+  toggle: toggleActionMenu,
+  close: closeActionMenu,
+} = useComposerActionMenu(composerRoot, () => Boolean(props.inputLocked));
 
 function attachFromActionMenu(): void {
   closeActionMenu();
@@ -185,16 +175,6 @@ async function quoteFromActionMenu(): Promise<void> {
   closeActionMenu();
   await wrapSelectedTextWithTripleQuotes();
 }
-
-onMounted(() => {
-  document.addEventListener("pointerdown", onActionMenuPointerDown);
-  document.addEventListener("keydown", onActionMenuKeydown);
-});
-
-onBeforeUnmount(() => {
-  document.removeEventListener("pointerdown", onActionMenuPointerDown);
-  document.removeEventListener("keydown", onActionMenuKeydown);
-});
 
 const hasTextSelection = ref(false);
 const canRestoreLatestPrompt = computed(
@@ -322,11 +302,13 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
       <div ref="composerRowEl" class="composerMainRow" :class="{ 'composerMainRow--expanded': composerExpanded }">
         <div ref="leftActionsEl" class="composerMainRowLeft">
           <button
+            ref="actionMenuTrigger"
             class="attachIcon composerActionToggle"
             type="button"
             title="更多输入操作"
             aria-label="更多输入操作"
             :aria-expanded="actionMenuOpen"
+            :aria-controls="actionMenuOpen ? actionMenuId : undefined"
             aria-haspopup="menu"
             data-testid="composer-actions-toggle"
             :disabled="inputLocked"
@@ -405,51 +387,56 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
           </button>
         </div>
       </div>
-      <div
-        v-if="actionMenuOpen"
-        class="actionSheet"
-        role="menu"
-        aria-label="输入操作"
-        data-testid="composer-action-sheet"
-        @click.stop
-      >
-        <button
-          class="actionSheetItem"
-          type="button"
-          role="menuitem"
-          data-testid="action-attach-image"
-          :disabled="inputLocked"
-          @mousedown.prevent
-          @click="attachFromActionMenu"
+      <Teleport to="body">
+        <div
+          v-if="actionMenuOpen"
+          :id="actionMenuId"
+          ref="actionMenuElement"
+          class="actionSheet"
+          :style="actionMenuStyle"
+          role="menu"
+          aria-label="输入操作"
+          data-testid="composer-action-sheet"
+          @click.stop
         >
-          <span class="actionSheetIcon" aria-hidden="true">📎</span>
-          <span>添加图片附件</span>
-        </button>
-        <button
-          class="actionSheetItem"
-          type="button"
-          role="menuitem"
-          data-testid="wrap-triple-quotes"
-          :disabled="inputLocked || !hasTextSelection"
-          @mousedown.prevent
-          @click="quoteFromActionMenu"
-        >
-          <span class="actionSheetIcon actionSheetIcon--mono" aria-hidden="true">&quot;&quot;&quot;</span>
-          <span>快速引用选中文本</span>
-        </button>
-        <button
-          class="actionSheetItem"
-          type="button"
-          role="menuitem"
-          data-testid="restore-latest-prompt"
-          :disabled="!canRestoreLatestPrompt"
-          @mousedown.prevent
-          @click="restoreFromActionMenu"
-        >
-          <span class="actionSheetIcon" aria-hidden="true">↺</span>
-          <span>恢复上一条输入</span>
-        </button>
-      </div>
+          <button
+            class="actionSheetItem"
+            type="button"
+            role="menuitem"
+            data-testid="action-attach-image"
+            :disabled="inputLocked"
+            @mousedown.prevent
+            @click="attachFromActionMenu"
+          >
+            <span class="actionSheetIcon" aria-hidden="true">📎</span>
+            <span>添加图片附件</span>
+          </button>
+          <button
+            class="actionSheetItem"
+            type="button"
+            role="menuitem"
+            data-testid="wrap-triple-quotes"
+            :disabled="inputLocked || !hasTextSelection"
+            @mousedown.prevent
+            @click="quoteFromActionMenu"
+          >
+            <span class="actionSheetIcon actionSheetIcon--mono" aria-hidden="true">&quot;&quot;&quot;</span>
+            <span>快速引用选中文本</span>
+          </button>
+          <button
+            class="actionSheetItem"
+            type="button"
+            role="menuitem"
+            data-testid="restore-latest-prompt"
+            :disabled="!canRestoreLatestPrompt"
+            @mousedown.prevent
+            @click="restoreFromActionMenu"
+          >
+            <span class="actionSheetIcon" aria-hidden="true">↺</span>
+            <span>恢复上一条输入</span>
+          </button>
+        </div>
+      </Teleport>
       <div
         v-if="(voiceStatusKind === 'ok' || voiceStatusKind === 'error') && voiceStatusMessage"
         class="voiceToast"
@@ -485,7 +472,7 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 8px 16px calc(env(safe-area-inset-bottom, 0px) * var(--safe-bottom-multiplier, 1));
+  padding: 8px 16px var(--app-safe-bottom, env(safe-area-inset-bottom, 0px));
   background: var(--app-bg, #ffffff);
   position: relative;
   z-index: 20;
@@ -633,7 +620,8 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
   align-items: flex-end;
   padding: 8px;
   flex-shrink: 0;
-  gap: 6px;
+  column-gap: 6px;
+  row-gap: 2px;
 }
 
 .composerMainRow--expanded {
@@ -693,12 +681,13 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
 }
 
 .actionSheet {
-  position: absolute;
-  left: 8px;
-  bottom: calc(100% + 8px);
-  width: min(270px, calc(100% - 16px));
+  position: fixed;
+  z-index: 200;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 6px;
   display: grid;
+  grid-auto-rows: max-content;
   gap: 2px;
   border: 1px solid rgba(148, 163, 184, 0.3);
   border-radius: 15px;

--- a/client/src/components/MainChatComposerPanel.vue
+++ b/client/src/components/MainChatComposerPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, ref, useId, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, ref, useId, watch } from "vue";
 
 import MainChatPendingImageViewer from "./MainChatPendingImageViewer.vue";
 import { resolveComposerImagePreview } from "./mainChat/attachmentPreview";
@@ -11,6 +11,11 @@ type PendingImagePreview = {
   key: string;
   src: string;
   href: string;
+};
+
+type TextSelectionRange = {
+  start: number;
+  end: number;
 };
 
 const props = defineProps<{
@@ -152,6 +157,8 @@ const {
 
 const composerRoot = ref<HTMLElement | null>(null);
 const actionMenuId = useId();
+const hasTextSelection = ref(false);
+const actionMenuSelection = ref<TextSelectionRange | null>(null);
 const {
   trigger: actionMenuTrigger,
   menu: actionMenuElement,
@@ -161,22 +168,119 @@ const {
   close: closeActionMenu,
 } = useComposerActionMenu(composerRoot, () => Boolean(props.inputLocked));
 
+const ACTION_MENU_POINTER_SLOP_PX = 10;
+const ACTION_MENU_CLICK_SUPPRESS_MS = 700;
+let actionMenuPointerCandidate: { pointerId: number; x: number; y: number } | null = null;
+let actionMenuPointerActivationAt = 0;
+let actionMenuClickSuppressTimer: ReturnType<typeof setTimeout> | null = null;
+
+function clearActionMenuPointerCandidate(): void {
+  actionMenuPointerCandidate = null;
+}
+
+function clearActionMenuClickSuppression(): void {
+  actionMenuPointerActivationAt = 0;
+  if (actionMenuClickSuppressTimer !== null) {
+    clearTimeout(actionMenuClickSuppressTimer);
+    actionMenuClickSuppressTimer = null;
+  }
+}
+
+function rememberActionMenuSelection(): void {
+  const el = inputEl.value;
+  if (!el || props.inputLocked) return;
+  const start = el.selectionStart;
+  const end = el.selectionEnd;
+  if (end <= start) return;
+  actionMenuSelection.value = { start, end };
+  hasTextSelection.value = true;
+}
+
+function releaseActionMenuSelection(): void {
+  actionMenuSelection.value = null;
+}
+
+function toggleActionMenuFromInput(): void {
+  if (actionMenuOpen.value) releaseActionMenuSelection();
+  toggleActionMenu();
+}
+
+function markActionMenuPointerActivation(): void {
+  actionMenuPointerActivationAt = Date.now();
+  if (actionMenuClickSuppressTimer !== null) clearTimeout(actionMenuClickSuppressTimer);
+  actionMenuClickSuppressTimer = setTimeout(() => {
+    actionMenuPointerActivationAt = 0;
+    actionMenuClickSuppressTimer = null;
+  }, ACTION_MENU_CLICK_SUPPRESS_MS);
+}
+
+function onActionMenuPointerDown(event: PointerEvent): void {
+  if (props.inputLocked || event.button > 0) {
+    clearActionMenuPointerCandidate();
+    return;
+  }
+  rememberActionMenuSelection();
+  actionMenuPointerCandidate = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };
+  const target = event.currentTarget;
+  if (target instanceof HTMLElement && target.setPointerCapture) {
+    try {
+      target.setPointerCapture(event.pointerId);
+    } catch {
+      clearActionMenuPointerCandidate();
+    }
+  }
+}
+
+function onActionMenuPointerUp(event: PointerEvent): void {
+  const candidate = actionMenuPointerCandidate;
+  clearActionMenuPointerCandidate();
+  if (!candidate || candidate.pointerId !== event.pointerId || props.inputLocked) return;
+  if (
+    Math.abs(event.clientX - candidate.x) > ACTION_MENU_POINTER_SLOP_PX ||
+    Math.abs(event.clientY - candidate.y) > ACTION_MENU_POINTER_SLOP_PX
+  ) {
+    return;
+  }
+  markActionMenuPointerActivation();
+  toggleActionMenuFromInput();
+}
+
+function onActionMenuPointerCancel(): void {
+  clearActionMenuPointerCandidate();
+}
+
+function onActionMenuClick(event: MouseEvent): void {
+  if (
+    actionMenuPointerActivationAt > 0 &&
+    event.detail > 0 &&
+    Date.now() - actionMenuPointerActivationAt < ACTION_MENU_CLICK_SUPPRESS_MS
+  ) {
+    clearActionMenuClickSuppression();
+    return;
+  }
+  clearActionMenuClickSuppression();
+  toggleActionMenuFromInput();
+}
+
 function attachFromActionMenu(): void {
+  releaseActionMenuSelection();
   closeActionMenu();
   triggerFileInput();
 }
 
 async function restoreFromActionMenu(): Promise<void> {
+  releaseActionMenuSelection();
   closeActionMenu();
   await restoreLatestPrompt();
 }
 
 async function quoteFromActionMenu(): Promise<void> {
+  const selection = actionMenuSelection.value;
+  releaseActionMenuSelection();
   closeActionMenu();
-  await wrapSelectedTextWithTripleQuotes();
+  await wrapSelectedTextWithTripleQuotes(selection);
 }
 
-const hasTextSelection = ref(false);
 const canRestoreLatestPrompt = computed(
   () => !props.inputLocked && !input.value.trim() && Boolean(latestPrompt.value.trim()),
 );
@@ -194,12 +298,20 @@ function updateTextSelection(): void {
   const el = inputEl.value;
   if (!el || props.inputLocked) {
     hasTextSelection.value = false;
+    actionMenuSelection.value = null;
     return;
   }
-  hasTextSelection.value = el.selectionEnd > el.selectionStart;
+  const start = el.selectionStart;
+  const end = el.selectionEnd;
+  hasTextSelection.value = end > start;
+  actionMenuSelection.value = end > start ? { start, end } : null;
 }
 
 function clearTextSelectionState(): void {
+  if (actionMenuSelection.value) {
+    hasTextSelection.value = true;
+    return;
+  }
   hasTextSelection.value = false;
 }
 
@@ -215,12 +327,14 @@ async function restoreLatestPrompt(): Promise<void> {
   updateTextSelection();
 }
 
-async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
+async function wrapSelectedTextWithTripleQuotes(selectionOverride: TextSelectionRange | null = null): Promise<void> {
   const el = inputEl.value;
   if (!el || props.inputLocked) return;
   const current = input.value;
-  const start = el.selectionStart;
-  const end = el.selectionEnd;
+  const currentSelection = { start: el.selectionStart, end: el.selectionEnd };
+  const selection = selectionOverride ?? currentSelection;
+  const start = Math.max(0, Math.min(selection.start, current.length));
+  const end = Math.max(start, Math.min(selection.end, current.length));
   if (end <= start) return;
   const selected = current.slice(start, end);
   input.value = `${current.slice(0, start)}\"\"\"${selected}\"\"\"${current.slice(end)}`;
@@ -229,6 +343,11 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
   el.setSelectionRange(start + 3, end + 3);
   updateTextSelection();
 }
+
+onBeforeUnmount(() => {
+  clearActionMenuPointerCandidate();
+  clearActionMenuClickSuppression();
+});
 </script>
 
 <template>
@@ -312,8 +431,12 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
             aria-haspopup="menu"
             data-testid="composer-actions-toggle"
             :disabled="inputLocked"
-            @mousedown.prevent
-            @click.stop="toggleActionMenu"
+            @pointerdown="onActionMenuPointerDown"
+            @pointerup="onActionMenuPointerUp"
+            @pointercancel="onActionMenuPointerCancel"
+            @touchstart="rememberActionMenuSelection"
+            @mousedown="rememberActionMenuSelection"
+            @click.stop="onActionMenuClick"
           >
             <svg width="18" height="18" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path fill-rule="evenodd" d="M10 3a.75.75 0 0 1 .75.75v5.5h5.5a.75.75 0 0 1 0 1.5h-5.5v5.5a.75.75 0 0 1-1.5 0v-5.5h-5.5a.75.75 0 0 1 0-1.5h5.5v-5.5A.75.75 0 0 1 10 3Z" clip-rule="evenodd" />
@@ -405,7 +528,6 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
             role="menuitem"
             data-testid="action-attach-image"
             :disabled="inputLocked"
-            @mousedown.prevent
             @click="attachFromActionMenu"
           >
             <span class="actionSheetIcon" aria-hidden="true">📎</span>
@@ -417,7 +539,6 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
             role="menuitem"
             data-testid="wrap-triple-quotes"
             :disabled="inputLocked || !hasTextSelection"
-            @mousedown.prevent
             @click="quoteFromActionMenu"
           >
             <span class="actionSheetIcon actionSheetIcon--mono" aria-hidden="true">&quot;&quot;&quot;</span>
@@ -429,7 +550,6 @@ async function wrapSelectedTextWithTripleQuotes(): Promise<void> {
             role="menuitem"
             data-testid="restore-latest-prompt"
             :disabled="!canRestoreLatestPrompt"
-            @mousedown.prevent
             @click="restoreFromActionMenu"
           >
             <span class="actionSheetIcon" aria-hidden="true">↺</span>

--- a/client/src/components/mainChat/useComposer.ts
+++ b/client/src/components/mainChat/useComposer.ts
@@ -2,6 +2,7 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue"
 
 import type { IncomingImage } from "./types";
 import { autosizeTextarea } from "../../lib/textarea_autosize";
+import { readViewportMetrics } from "../../lib/viewport";
 
 type VoiceStatusKind = "idle" | "recording" | "transcribing" | "error" | "ok";
 type TranscriptionResponse = { ok?: boolean; text?: string; error?: string; message?: string };
@@ -96,6 +97,30 @@ export function useMainChatComposer(params: {
   const rightActionsEl = ref<HTMLElement | null>(null);
   const composerExpanded = ref(false);
 
+  const availableTextareaHeight = (): number | undefined => {
+    const row = composerRowEl.value;
+    const composer = row?.closest<HTMLElement>(".composer");
+    const container = composer?.closest<HTMLElement>(".detail");
+    if (!row || !composer || !container) return undefined;
+    const bounds = container.getBoundingClientRect();
+    if (bounds.height <= 0) return undefined;
+    const viewport = readViewportMetrics();
+    const chat = container.querySelector(".chat");
+    const chatTop = chat?.getBoundingClientRect().top ?? bounds.top;
+    const chatStyle = chat ? window.getComputedStyle(chat) : null;
+    const chatInsets = chatStyle
+      ? [chatStyle.paddingTop, chatStyle.paddingBottom, chatStyle.borderTopWidth, chatStyle.borderBottomWidth]
+        .reduce((total, value) => total + (Number.parseFloat(value) || 0), 0)
+      : 0;
+    const availableHeight = Math.min(bounds.bottom, viewport.topPx + viewport.heightPx)
+      - Math.max(bounds.top, chatTop, viewport.topPx) - chatInsets;
+    const style = window.getComputedStyle(row);
+    const padding = (Number.parseFloat(style.paddingTop) || 0) + (Number.parseFloat(style.paddingBottom) || 0);
+    const toolsHeight = Math.max(leftActionsEl.value?.offsetHeight ?? 0, rightActionsEl.value?.offsetHeight ?? 0);
+    const chromeHeight = composer.offsetHeight - row.offsetHeight + padding + toolsHeight + (Number.parseFloat(style.rowGap) || 0);
+    return Math.max(0, availableHeight - chromeHeight);
+  };
+
   const resizeComposer = (): void => {
     const el = inputEl.value;
     if (!el) return;
@@ -106,8 +131,10 @@ export function useMainChatComposer(params: {
     }
 
     const row = composerRowEl.value;
+    if (row?.closest(".detail") && row.clientWidth === 0) return;
     const left = leftActionsEl.value;
     const right = rightActionsEl.value;
+    const options = { minRows: 1, maxRows: 8, maxHeightPx: availableTextareaHeight() };
     let compactWidth = 0;
     if (row && left && right) {
       const style = window.getComputedStyle(row);
@@ -121,11 +148,11 @@ export function useMainChatComposer(params: {
     const previousWidth = el.style.width;
     if (compactWidth > 0) el.style.width = `${compactWidth}px`;
     try {
-      composerExpanded.value = autosizeTextarea(el, { minRows: 1, maxRows: 8 });
+      composerExpanded.value = autosizeTextarea(el, options);
     } finally {
       el.style.width = previousWidth;
     }
-    autosizeTextarea(el, { minRows: 1, maxRows: 8 });
+    autosizeTextarea(el, options);
   };
 
   // Resize after Vue commits DOM updates (v-model, conditional UI that affects wrapping, etc).
@@ -155,23 +182,27 @@ export function useMainChatComposer(params: {
     attachedEl = el;
     el.addEventListener("input", onNativeInput, { passive: true });
     if (typeof ResizeObserver !== "undefined") {
-      const observedWidths = new WeakMap<Element, number>();
+      const composer = composerRowEl.value?.closest<HTMLElement>(".composer");
+      const container = composer?.closest<HTMLElement>(".detail");
+      const heightTargets = new Set([composer, container, leftActionsEl.value, rightActionsEl.value]);
+      const observedSizes = new WeakMap<Element, { width: number; height: number }>();
       composerResizeObserver = new ResizeObserver((entries) => {
-        let widthChanged = false;
+        let sizeChanged = false;
         for (const entry of entries) {
-          const width = entry.contentRect.width;
-          const previousWidth = observedWidths.get(entry.target);
-          observedWidths.set(entry.target, width);
-          if (width > 0 && width !== previousWidth) widthChanged = true;
+          const { width, height } = entry.contentRect;
+          const previousSize = observedSizes.get(entry.target);
+          observedSizes.set(entry.target, { width, height });
+          if (width > 0 && width !== previousSize?.width) sizeChanged = true;
+          if (heightTargets.has(entry.target as HTMLElement) && height > 0 && height !== previousSize?.height) sizeChanged = true;
         }
-        if (!widthChanged) return;
+        if (!sizeChanged) return;
         if (composerResizeFrame !== null) window.cancelAnimationFrame(composerResizeFrame);
         composerResizeFrame = window.requestAnimationFrame(() => {
           composerResizeFrame = null;
           resizeComposer();
         });
       });
-      for (const target of [el, composerRowEl.value, leftActionsEl.value, rightActionsEl.value]) {
+      for (const target of [el, composerRowEl.value, ...heightTargets]) {
         if (target) composerResizeObserver.observe(target);
       }
     }
@@ -189,9 +220,17 @@ export function useMainChatComposer(params: {
   const onWindowResize = (): void => {
     resizeComposer();
   };
+  const viewport = window.visualViewport;
+  const onVisibilityChange = (): void => {
+    if (document.visibilityState === "visible") resizeComposer();
+  };
 
   onMounted(() => {
     window.addEventListener("resize", onWindowResize, { passive: true });
+    window.addEventListener("pageshow", onWindowResize, { passive: true });
+    viewport?.addEventListener("resize", onWindowResize, { passive: true });
+    viewport?.addEventListener("scroll", onWindowResize, { passive: true });
+    document.addEventListener("visibilitychange", onVisibilityChange);
     resizeComposer();
   });
 
@@ -251,6 +290,10 @@ export function useMainChatComposer(params: {
 
   onBeforeUnmount(() => {
     window.removeEventListener("resize", onWindowResize);
+    window.removeEventListener("pageshow", onWindowResize);
+    viewport?.removeEventListener("resize", onWindowResize);
+    viewport?.removeEventListener("scroll", onWindowResize);
+    document.removeEventListener("visibilitychange", onVisibilityChange);
     attachNativeListeners(null);
   });
 

--- a/client/src/components/mainChat/useComposerActionMenu.ts
+++ b/client/src/components/mainChat/useComposerActionMenu.ts
@@ -1,0 +1,119 @@
+import { nextTick, onBeforeUnmount, onMounted, ref, watch, type CSSProperties, type Ref } from "vue";
+
+import { readViewportMetrics } from "../../lib/viewport";
+
+export function useComposerActionMenu(root: Ref<HTMLElement | null>, isLocked: () => boolean) {
+  const trigger = ref<HTMLButtonElement | null>(null);
+  const menu = ref<HTMLElement | null>(null);
+  const open = ref(false);
+  const style = ref<CSSProperties>({ visibility: "hidden" });
+  let frame: number | null = null;
+  let observer: ResizeObserver | null = null;
+  const viewport = window.visualViewport;
+
+  function close(): void {
+    open.value = false;
+    style.value = { visibility: "hidden" };
+  }
+
+  function position(): void {
+    if (!open.value || !trigger.value || !menu.value) return;
+    const anchor = trigger.value.getBoundingClientRect();
+    if (anchor.width <= 0 || anchor.height <= 0) {
+      close();
+      return;
+    }
+    const bounds = readViewportMetrics();
+    const container = root.value?.closest(".detail")?.getBoundingClientRect();
+    const top = Math.max(bounds.topPx, container?.top ?? bounds.topPx) + 8;
+    const bottom = Math.min(bounds.topPx + bounds.heightPx, container?.bottom ?? Infinity) - 8;
+    if (bottom <= top) {
+      close();
+      return;
+    }
+    const left = bounds.leftPx + 8;
+    const width = Math.min(270, Math.max(0, bounds.widthPx - 16));
+    const aboveEdge = Math.min(anchor.top - 8, bottom);
+    const belowEdge = Math.max(anchor.bottom + 8, top);
+    const above = Math.max(0, aboveEdge - top);
+    const below = Math.max(0, bottom - belowEdge);
+    menu.value.style.width = `${width}px`;
+    const naturalHeight = menu.value.scrollHeight + menu.value.offsetHeight - menu.value.clientHeight;
+    const placeAbove = above >= naturalHeight || above >= below;
+    const maxHeight = placeAbove ? above : below;
+    const height = Math.min(naturalHeight, maxHeight);
+    style.value = {
+      visibility: "visible",
+      width: `${width}px`,
+      maxHeight: `${Math.floor(maxHeight)}px`,
+      left: `${Math.max(left, Math.min(anchor.left, bounds.leftPx + bounds.widthPx - 8 - width))}px`,
+      top: `${placeAbove ? Math.max(top, aboveEdge - height) : belowEdge}px`,
+    };
+  }
+
+  function schedulePosition(): void {
+    if (!open.value || frame !== null) return;
+    frame = window.requestAnimationFrame(() => {
+      frame = null;
+      position();
+    });
+  }
+
+  function toggle(): void {
+    if (isLocked()) return;
+    if (open.value) close();
+    else open.value = true;
+  }
+
+  function onPointerDown(event: Event): void {
+    const target = event.target;
+    if (target instanceof Node && (root.value?.contains(target) || menu.value?.contains(target))) return;
+    close();
+  }
+
+  function onKeydown(event: KeyboardEvent): void {
+    if (event.key !== "Escape" || !open.value) return;
+    if (menu.value?.contains(document.activeElement)) trigger.value?.focus({ preventScroll: true });
+    close();
+  }
+
+  function onVisibilityChange(): void {
+    if (document.visibilityState === "hidden") close();
+    else schedulePosition();
+  }
+
+  watch([open, menu], async () => {
+    observer?.disconnect();
+    if (!open.value) return;
+    await nextTick();
+    if (!observer && typeof ResizeObserver !== "undefined") observer = new ResizeObserver(schedulePosition);
+    position();
+    for (const element of [root.value, trigger.value, menu.value, root.value?.closest(".detail")]) {
+      if (element) observer?.observe(element);
+    }
+  }, { flush: "post" });
+
+  onMounted(() => {
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeydown);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener("resize", schedulePosition, { passive: true });
+    window.addEventListener("scroll", schedulePosition, { passive: true, capture: true });
+    viewport?.addEventListener("resize", schedulePosition, { passive: true });
+    viewport?.addEventListener("scroll", schedulePosition, { passive: true });
+  });
+
+  onBeforeUnmount(() => {
+    observer?.disconnect();
+    if (frame !== null) window.cancelAnimationFrame(frame);
+    document.removeEventListener("pointerdown", onPointerDown);
+    document.removeEventListener("keydown", onKeydown);
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+    window.removeEventListener("resize", schedulePosition);
+    window.removeEventListener("scroll", schedulePosition, true);
+    viewport?.removeEventListener("resize", schedulePosition);
+    viewport?.removeEventListener("scroll", schedulePosition);
+  });
+
+  return { trigger, menu, open, style, toggle, close };
+}

--- a/client/src/global.css
+++ b/client/src/global.css
@@ -42,8 +42,7 @@
 }
 
 html,
-body,
-#app {
+body {
   height: 100%;
 }
 

--- a/client/src/lib/composer_inspection.test.ts
+++ b/client/src/lib/composer_inspection.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readSfc } from "../__tests__/readSfc";
+
+type InspectionReport = {
+  initial: { environment: { serviceWorker: string | null; scripts: string[] }; input: { length: number; lines: number } };
+  records: Array<{ type: string; defaultPrevented?: boolean }>;
+};
+
+type Inspection = { report: () => InspectionReport; stop: () => InspectionReport };
+const inspectionWindow = window as unknown as { ADSComposerInspection?: Inspection };
+const originalHitTest = document.elementFromPoint;
+
+describe("temporary composer inspection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("matchMedia", () => ({ matches: false }));
+    vi.stubGlobal("fetch", vi.fn());
+    document.body.innerHTML = '<div class="app"><span class="brandVersion">v0.2.5</span><div class="detail"><div class="composer"><div class="inputWrap"><div class="composerMainRow"><textarea class="composer-input"></textarea><button data-testid="composer-actions-toggle" aria-expanded="false">+</button></div></div></div></div></div>';
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue(new DOMRect(20, 200, 260, 34));
+    document.elementFromPoint = vi.fn(() => document.querySelector("button"));
+  });
+
+  afterEach(() => {
+    inspectionWindow.ADSComposerInspection?.stop();
+    document.body.innerHTML = "";
+    document.querySelector('[data-inspection-fixture="true"]')?.remove();
+    document.elementFromPoint = originalHitTest;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  async function install(): Promise<Inspection> {
+    const source = await readSfc("../../../scripts/inspect-composer.js", import.meta.url);
+    new Function(source)();
+    const inspection = inspectionWindow.ADSComposerInspection;
+    if (!inspection) throw new Error("Inspection was not installed");
+    return inspection;
+  }
+
+  it("exports only draft metrics and sanitized asset paths without reading credentials or using the network", async () => {
+    const input = document.querySelector("textarea")!;
+    input.value = "PRIVATE_DRAFT\nPRIVATE_SECOND_LINE";
+    const script = document.createElement("script");
+    script.src = "/assets/app.js?token=PRIVATE_CREDENTIAL";
+    script.dataset.inspectionFixture = "true";
+    document.head.appendChild(script);
+    vi.spyOn(document, "cookie", "get").mockImplementation(() => { throw new Error("Credential access is forbidden"); });
+    const inspection = await install();
+    const report = inspection.report();
+
+    expect(report.initial.input).toMatchObject({ length: input.value.length, lines: 2 });
+    expect(report.initial.environment.serviceWorker).toBeNull();
+    expect(report.initial.environment.scripts).toContain("/assets/app.js");
+    expect(JSON.stringify(report)).not.toContain("PRIVATE_");
+    expect(fetch).not.toHaveBeenCalled();
+    inspection.stop();
+    expect(input.value).toBe("PRIVATE_DRAFT\nPRIVATE_SECOND_LINE");
+    expect(inspectionWindow.ADSComposerInspection).toBeUndefined();
+  });
+
+  it("captures post-handler cancellation and removes event listeners and pending frames on stop", async () => {
+    const inspection = await install();
+    const toggle = document.querySelector("button")!;
+    toggle.addEventListener("mousedown", event => event.preventDefault());
+    toggle.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    vi.advanceTimersByTime(32);
+    expect(inspection.report().records).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "mousedown", defaultPrevented: false }),
+      expect.objectContaining({ type: "mousedown:rendered", defaultPrevented: true }),
+    ]));
+
+    toggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    const count = inspection.stop().records.length;
+    toggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    vi.advanceTimersByTime(32);
+    expect(inspection.report().records).toHaveLength(count);
+  });
+});

--- a/client/src/lib/textarea_autosize.test.ts
+++ b/client/src/lib/textarea_autosize.test.ts
@@ -16,6 +16,31 @@ function makeStyle(overrides: Partial<CSSStyleDeclaration>): CSSStyleDeclaration
 }
 
 describe("autosizeTextarea", () => {
+  it("caps multiline input by the available height without losing expansion state", () => {
+    const element = document.createElement("textarea");
+    element.value = "First line\nSecond line\nThird line";
+    Object.defineProperty(element, "scrollHeight", { get: () => 300 });
+    vi.spyOn(window, "getComputedStyle").mockReturnValue(makeStyle({}));
+
+    expect(autosizeTextarea(element, { minRows: 1, maxRows: 8, maxHeightPx: 90 })).toBe(true);
+    expect(element.style.height).toBe("90px");
+    expect(element.style.overflowY).toBe("auto");
+    expect(autosizeTextarea(element, { minRows: 1, maxRows: 8, maxHeightPx: 0 })).toBe(true);
+    expect(element.style.height).toBe("42px");
+
+    element.value = "";
+    expect(autosizeTextarea(element, { minRows: 1, maxRows: 8, maxHeightPx: 90 })).toBe(false);
+    expect(element.style.height).toBe("42px");
+    expect(element.style.overflowY).toBe("hidden");
+  });
+
+  it("recognizes explicit newlines even before hidden content can be measured", () => {
+    const element = document.createElement("textarea");
+    element.value = "First line\nSecond line";
+    vi.spyOn(window, "getComputedStyle").mockReturnValue(makeStyle({}));
+    expect(autosizeTextarea(element, { minRows: 1, maxRows: 8 })).toBe(true);
+  });
+
   it("measures content without inheriting the native rows height", () => {
     const element = document.createElement("textarea");
     element.rows = 5;

--- a/client/src/lib/textarea_autosize.ts
+++ b/client/src/lib/textarea_autosize.ts
@@ -1,6 +1,7 @@
 export type AutosizeTextareaOptions = {
   minRows?: number;
   maxRows?: number;
+  maxHeightPx?: number;
 };
 
 function parsePx(value: string): number {
@@ -44,7 +45,10 @@ export function autosizeTextarea(el: HTMLTextAreaElement, opts: AutosizeTextarea
   const extraHeight = paddingTop + paddingBottom + borderHeight;
 
   const minHeight = lineHeightPx * minRows + extraHeight;
-  const maxHeight = lineHeightPx * maxRows + extraHeight;
+  const rowLimit = lineHeightPx * maxRows + extraHeight;
+  const maxHeight = Number.isFinite(opts.maxHeightPx)
+    ? Math.max(minHeight, Math.min(rowLimit, opts.maxHeightPx!))
+    : rowLimit;
 
   // Empty editors must collapse even when a browser reports stale scroll geometry.
   if (!el.value) {
@@ -63,5 +67,5 @@ export function autosizeTextarea(el: HTMLTextAreaElement, opts: AutosizeTextarea
 
   el.style.height = `${Math.ceil(nextHeight)}px`;
   el.style.overflowY = contentHeight > maxHeight ? "auto" : "hidden";
-  return contentHeight > lineHeightPx + extraHeight + 1;
+  return el.value.includes("\n") || contentHeight > lineHeightPx + extraHeight + 1;
 }

--- a/client/src/lib/viewport.test.ts
+++ b/client/src/lib/viewport.test.ts
@@ -61,13 +61,20 @@ describe("chat visual viewport anchoring", () => {
     vi.unstubAllGlobals();
   });
 
-  it("anchors the fixed chat page to the reported visual viewport top and height", async () => {
+  it("gives the root sole ownership of visual viewport geometry and remaining safe area", async () => {
     const app = await readSfc("../App.vue", import.meta.url);
+    const html = await readSfc("../../index.html", import.meta.url);
+    const global = await readSfc("../global.css", import.meta.url);
     const rule = app.match(/\.app\s*\{[^}]*\}/)?.[0];
+    const root = html.match(/#app\s*\{[^}]*\}/)?.[0];
     expect(rule).toBeDefined();
-    expect(rule).toMatch(/position:\s*fixed\s*;/);
-    expect(rule).toMatch(/top:\s*var\(--app-top,\s*0px\)\s*;/);
-    expect(rule).toMatch(/height:\s*var\(--ads-visual-viewport-height,\s*100dvh\)\s*;/);
+    expect(rule).toMatch(/height:\s*100%\s*;/);
+    expect(rule).not.toContain("--app-top");
+    expect(root).toMatch(/position:\s*fixed\s*;/);
+    expect(root).toMatch(/top:\s*var\(--app-top,\s*0px\)\s*;/);
+    expect(root).toMatch(/height:\s*var\(--ads-visual-viewport-height,\s*100dvh\)\s*;/);
+    expect(root).toContain("max(0px, calc(env(safe-area-inset-bottom, 0px) - var(--app-bottom, 0px)))");
+    expect(global).not.toMatch(/#app\s*\{[^}]*height:/);
   });
 
   it("tracks keyboard panning even when only a viewport scroll event fires", async () => {
@@ -79,7 +86,7 @@ describe("chat visual viewport anchoring", () => {
 
     expect(cssVariable("--app-top")).toBe("120px");
     expect(cssVariable("--ads-visual-viewport-height")).toBe("440px");
-    expect(cssVariable("--safe-bottom-multiplier")).toBe("0");
+    expect(cssVariable("--app-bottom")).toBe("284px");
   });
 
   it("preserves the viewport offset after blur until the keyboard finishes closing", async () => {
@@ -92,12 +99,12 @@ describe("chat visual viewport anchoring", () => {
 
     expect(cssVariable("--app-top")).toBe("120px");
     expect(cssVariable("--ads-visual-viewport-height")).toBe("440px");
-    expect(cssVariable("--safe-bottom-multiplier")).toBe("0");
+    expect(cssVariable("--app-bottom")).toBe("284px");
 
     updateViewport(844, 0);
     expect(cssVariable("--app-top")).toBe("0px");
     expect(cssVariable("--ads-visual-viewport-height")).toBe("844px");
-    expect(cssVariable("--safe-bottom-multiplier")).toBe("1");
+    expect(cssVariable("--app-bottom")).toBe("0px");
   });
 
   it("recovers after keyboard dismissal without a resize event while input remains focused", async () => {
@@ -130,7 +137,7 @@ describe("chat visual viewport anchoring", () => {
     expect(cssVariable("--app-top")).toBe("0px");
     expect(cssVariable("--app-bottom")).toBe("0px");
     expect(cssVariable("--ads-visual-viewport-height")).toBe("844px");
-    expect(cssVariable("--safe-bottom-multiplier")).toBe("1");
+    expect(cssVariable("--app-bottom")).toBe("0px");
   });
 
   it("tracks silent browser viewport changes when no input is focused", async () => {

--- a/client/src/lib/viewport.ts
+++ b/client/src/lib/viewport.ts
@@ -1,39 +1,36 @@
 import { isTextInputElement } from "./dom";
 
-type ViewportMetrics = { topPx: number; bottomPx: number; heightPx: number };
+type ViewportMetrics = { topPx: number; bottomPx: number; heightPx: number; leftPx: number; widthPx: number };
 
-function readViewportMetrics(): ViewportMetrics {
+export function readViewportMetrics(): ViewportMetrics {
   const layoutHeightPx = Math.max(1, Math.round(window.innerHeight));
   const viewport = window.visualViewport;
   if (!viewport) {
-    return { topPx: 0, bottomPx: 0, heightPx: layoutHeightPx };
+    return { topPx: 0, bottomPx: 0, heightPx: layoutHeightPx, leftPx: 0, widthPx: window.innerWidth };
   }
   const topPx = Number.isFinite(viewport.offsetTop) ? Math.max(0, Math.round(viewport.offsetTop)) : 0;
   const heightPx = Number.isFinite(viewport.height) ? Math.max(1, Math.round(viewport.height)) : layoutHeightPx;
   const bottomPx = Math.max(0, layoutHeightPx - topPx - heightPx);
-  return { topPx, bottomPx, heightPx };
+  const leftPx = Number.isFinite(viewport.offsetLeft) ? Math.max(0, viewport.offsetLeft) : 0;
+  const widthPx = Number.isFinite(viewport.width) ? Math.max(1, viewport.width) : window.innerWidth;
+  return { topPx, bottomPx, heightPx, leftPx, widthPx };
 }
 
-type MetricsState = { topPx: number; bottomPx: number; keyboardOpen: boolean; heightPx: number };
+type MetricsState = { topPx: number; bottomPx: number; heightPx: number };
 
 let lastMetrics: MetricsState = {
   topPx: Number.NaN,
   bottomPx: Number.NaN,
-  keyboardOpen: false,
   heightPx: Number.NaN,
 };
 function applyViewportVars(): void {
   const next = readViewportMetrics();
-  // Blur can precede the keyboard closing animation. Keep safe-area padding
-  // suppressed until the visual viewport actually reaches the layout bottom.
-  const keyboardOpen = next.bottomPx > 0;
   const heightPx = next.heightPx;
   const appTopPx = next.topPx;
   const appBottomPx = next.bottomPx;
   if (
     appTopPx === lastMetrics.topPx &&
     appBottomPx === lastMetrics.bottomPx &&
-    keyboardOpen === lastMetrics.keyboardOpen &&
     heightPx === lastMetrics.heightPx
   ) {
     return;
@@ -44,13 +41,10 @@ function applyViewportVars(): void {
   if (appBottomPx !== lastMetrics.bottomPx) {
     document.documentElement.style.setProperty("--app-bottom", `${appBottomPx}px`);
   }
-  if (keyboardOpen !== lastMetrics.keyboardOpen) {
-    document.documentElement.style.setProperty("--safe-bottom-multiplier", keyboardOpen ? "0" : "1");
-  }
   if (heightPx !== lastMetrics.heightPx) {
     document.documentElement.style.setProperty("--ads-visual-viewport-height", `${heightPx}px`);
   }
-  lastMetrics = { topPx: appTopPx, bottomPx: appBottomPx, keyboardOpen, heightPx };
+  lastMetrics = { topPx: appTopPx, bottomPx: appBottomPx, heightPx };
 }
 
 let heightRaf = 0;

--- a/docs/web.md
+++ b/docs/web.md
@@ -71,6 +71,26 @@ Web Console 经过专门的移动端交互优化：
 
 ---
 
+## Composer 浏览器与真机验收
+
+修改输入框后，除 Web 单元测试外，还应执行可重复的真实浏览器交互场景：
+
+```sh
+npm run build:web
+npm run test:composer-browser
+```
+
+场景使用本机 Chrome、独立临时用户目录和本地 API/WebSocket fixtures，不连接生产服务。可通过 `CHROME_BIN` 指定浏览器，通过 `ADS_COMPOSER_BUILD_DIR` 指定待验证的客户端构建。检查覆盖移动端触摸、桌面鼠标、320/390px 宽度、300/360/430px 缩小视口、菜单实际命中、多行全宽、清空回缩，以及可见边框与安全区的距离；终端给出元数据和截图的临时目录。模拟视口不等于真实软键盘，更不能替代安装到主屏幕的 iOS PWA。
+
+真机排查必须在受影响页面清缓存或刷新前进行，并单独记录设备型号和 iOS 版本。在 Safari 远程 Web Inspector 中运行 `scripts/inspect-composer.js` 的内容，再使用真实手指操作。该脚本仅临时采集事件、资源路径、视口/安全区、布局、命中测试和文本长度/行数；不读取 Cookie、令牌、会话标识，不导出草稿或对话正文，不发送网络请求，也不随应用加载。取回记录并移除监听：
+
+```js
+const composerReport = window.ADSComposerInspection.stop();
+JSON.stringify(composerReport, null, 2);
+```
+
+按「命中测试 → 事件到达 → expanded 状态 → DOM 更新 → 菜单可见且可操作」定位第一个失败环节。验收应同时覆盖空/短/自动换行/显式换行/高度封顶草稿，键盘开关、后台恢复、方向变化和 Lane 切换；实际测试附件选择器、引用、恢复输入、CJK/IME 编辑与清空回缩。分别记录可见边框到屏幕边缘的原始距离和必要安全区，普通应用间距不超过 8 CSS px。截图与桌面检查通过不构成真机验收通过。
+
 ## Web 相关环境变量
 
 | 变量名 | 默认值 | 说明 |

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build:web": "vite build --config client/vite.config.ts",
     "dev:web": "vite --config client/vite.config.ts",
     "test:web": "vitest --config client/vitest.config.ts run",
+    "test:composer-browser": "node scripts/test-composer-browser.js",
     "postbuild": "node scripts/chmod-bins.js",
     "bundle": "npm run build && node scripts/bundle.js",
     "deploy:local": "node scripts/deploy-local.js",

--- a/scripts/inspect-composer.js
+++ b/scripts/inspect-composer.js
@@ -1,0 +1,128 @@
+(() => {
+  window.ADSComposerInspection?.stop();
+  const records = [];
+  const frames = new Set();
+  const selectors = ["#app", ".app", ".detail", ".composer", ".inputWrap", ".composerMainRow", ".composer-input", ".composerMainRowLeft", ".composerMainRowRight", ".actionSheet"];
+  const actions = ["composer-actions-toggle", "action-attach-image", "wrap-triple-quotes", "restore-latest-prompt"];
+  const probe = document.createElement("div");
+  probe.style.cssText = "position:fixed;visibility:hidden;pointer-events:none;width:0;height:0;padding:env(safe-area-inset-top,0px) env(safe-area-inset-right,0px) env(safe-area-inset-bottom,0px) env(safe-area-inset-left,0px)";
+  document.body.appendChild(probe);
+
+  function label(element) {
+    if (!(element instanceof Element)) return "other";
+    for (const action of actions) {
+      if (element.closest(`[data-testid="${action}"]`)) return action;
+    }
+    return selectors.find(selector => element.matches(selector)) || element.tagName.toLowerCase();
+  }
+
+  function rect(element) {
+    if (!element) return null;
+    const bounds = element.getBoundingClientRect();
+    return { top: bounds.top, right: bounds.right, bottom: bounds.bottom, left: bounds.left, width: bounds.width, height: bounds.height };
+  }
+
+  function visible(selector) {
+    return [...document.querySelectorAll(selector)].find(element => element.getBoundingClientRect().height > 0);
+  }
+
+  function geometry(element) {
+    if (!element) return null;
+    const bounds = rect(element);
+    const style = getComputedStyle(element);
+    const target = document.elementFromPoint(bounds.left + bounds.width / 2, bounds.top + bounds.height / 2);
+    return {
+      ...bounds, display: style.display, visibility: style.visibility,
+      overflowX: style.overflowX, overflowY: style.overflowY, grid: style.gridTemplateAreas,
+      centerTarget: label(target), centerHit: element.contains(target),
+    };
+  }
+
+  function assetPath(value) {
+    if (!value) return null;
+    try { return new URL(value, location.href).pathname; } catch { return null; }
+  }
+
+  function snapshot() {
+    const input = visible(".composer-input");
+    const toggle = visible('[data-testid="composer-actions-toggle"]');
+    const menu = document.querySelector('[data-testid="composer-action-sheet"]');
+    const safeArea = getComputedStyle(probe);
+    const viewport = window.visualViewport;
+    const ancestors = [];
+    for (let ancestor = (menu || toggle)?.parentElement; ancestor; ancestor = ancestor.parentElement) {
+      ancestors.push({ element: label(ancestor), ...geometry(ancestor) });
+    }
+    const inputStyle = input ? getComputedStyle(input) : null;
+    return {
+      atMs: Math.round(performance.now()),
+      environment: {
+        userAgent: navigator.userAgent,
+        standalone: matchMedia("(display-mode: standalone)").matches || navigator.standalone === true,
+        version: document.querySelector(".brandVersion")?.textContent?.match(/v?\d+\.\d+\.\d+/)?.[0] || null,
+        scripts: [...document.scripts].filter(script => script.src).map(script => assetPath(script.src)),
+        stylesheets: [...document.querySelectorAll('link[rel="stylesheet"]')].map(link => assetPath(link.href)),
+        serviceWorker: assetPath(navigator.serviceWorker?.controller?.scriptURL || "") || null,
+        screen: { width: screen.width, height: screen.height, devicePixelRatio },
+      },
+      viewport: {
+        innerHeight, innerWidth, clientHeight: document.documentElement.clientHeight,
+        height: viewport?.height, width: viewport?.width, offsetTop: viewport?.offsetTop,
+        offsetLeft: viewport?.offsetLeft, scale: viewport?.scale,
+        safeArea: { top: safeArea.paddingTop, right: safeArea.paddingRight, bottom: safeArea.paddingBottom, left: safeArea.paddingLeft },
+      },
+      nodes: Object.fromEntries(selectors.map(selector => [selector, geometry(visible(selector))])),
+      input: input ? {
+        length: input.value.length, lines: input.value.split(/\r\n|\r|\n/).length,
+        scrollHeight: input.scrollHeight, scrollTop: input.scrollTop,
+        expanded: input.parentElement.classList.contains("composerMainRow--expanded"),
+        lineHeight: inputStyle.lineHeight, fontSize: inputStyle.fontSize,
+        padding: inputStyle.padding, height: inputStyle.height,
+      } : null,
+      trigger: toggle ? { disabled: toggle.disabled, expanded: toggle.getAttribute("aria-expanded"), ...geometry(toggle) } : null,
+      menu: menu ? { ...geometry(menu), actions: [...menu.querySelectorAll("button")].map(element => ({ action: label(element), disabled: element.disabled, ...geometry(element) })) } : null,
+      ancestors,
+    };
+  }
+
+  function record(value) {
+    records.push(value);
+    if (records.length > 200) records.shift();
+  }
+
+  function onInteraction(event) {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    record({ type: event.type, target: label(target), isTrusted: event.isTrusted, defaultPrevented: event.defaultPrevented, snapshot: snapshot() });
+    if (!["click", "pointerdown", "mousedown"].includes(event.type)) return;
+    const frame = requestAnimationFrame(() => {
+      frames.delete(frame);
+      record({ type: `${event.type}:rendered`, target: label(target), isTrusted: event.isTrusted, defaultPrevented: event.defaultPrevented, snapshot: snapshot() });
+    });
+    frames.add(frame);
+  }
+
+  function onError(event) {
+    record({ type: "error", name: event.error?.name || "Error", source: assetPath(event.filename), line: event.lineno, column: event.colno });
+  }
+
+  const eventTypes = ["touchstart", "touchend", "pointerdown", "pointerup", "pointercancel", "mousedown", "mouseup", "click"];
+  for (const type of eventTypes) document.addEventListener(type, onInteraction, true);
+  window.addEventListener("error", onError);
+  const inspection = {
+    snapshot,
+    report: () => ({ initial, records: records.slice(), current: snapshot() }),
+    stop: () => {
+      const report = inspection.report();
+      for (const type of eventTypes) document.removeEventListener(type, onInteraction, true);
+      window.removeEventListener("error", onError);
+      for (const frame of frames) cancelAnimationFrame(frame);
+      probe.remove();
+      delete window.ADSComposerInspection;
+      return report;
+    },
+  };
+  const initial = snapshot();
+  window.ADSComposerInspection = inspection;
+  return inspection;
+})();

--- a/scripts/test-composer-browser.js
+++ b/scripts/test-composer-browser.js
@@ -1,0 +1,334 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { createServer } from "node:http";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const buildRoot = path.resolve(process.env.ADS_COMPOSER_BUILD_DIR || path.join(repoRoot, "dist/client"));
+const artifacts = await mkdtemp(path.join(tmpdir(), "ads-composer-check-"));
+const profile = path.join(artifacts, "profile");
+const html = await readFile(path.join(buildRoot, "index.html"), "utf8");
+const assetPaths = [...html.matchAll(/(?:src|href)="([^"\s]*\/assets\/[^"\s]+)"/g)].map((match) => match[1]);
+assert.ok(assetPaths.length >= 2, "The browser check requires a built client artifact");
+const heightFilter = process.env.ADS_COMPOSER_VIEWPORT_HEIGHT ? Number(process.env.ADS_COMPOSER_VIEWPORT_HEIGHT) : null;
+assert.ok(heightFilter === null || [844, 430, 360, 300].includes(heightFilter), "Unsupported visual viewport height");
+const stateFilter = process.env.ADS_COMPOSER_DRAFT_STATE || null;
+assert.ok(stateFilter === null || ["empty", "short", "wrapped", "newlines", "capped"].includes(stateFilter), "Unsupported draft state");
+const contentTypes = { ".html": "text/html", ".js": "application/javascript", ".css": "text/css", ".json": "application/json", ".webmanifest": "application/manifest+json", ".png": "image/png", ".svg": "image/svg+xml" };
+const server = createServer(async (request, response) => {
+  try {
+    const pathname = decodeURIComponent(new URL(request.url, "http://localhost").pathname);
+    const file = path.resolve(buildRoot, `.${pathname === "/" ? "/index.html" : pathname}`);
+    if (!file.startsWith(`${buildRoot}${path.sep}`)) throw new Error("Invalid asset path");
+    const body = await readFile(file);
+    response.writeHead(200, { "Content-Type": contentTypes[path.extname(file)] || "application/octet-stream" });
+    response.end(body);
+  } catch {
+    response.writeHead(404);
+    response.end();
+  }
+});
+server.listen(0, "127.0.0.1");
+await once(server, "listening");
+const address = server.address();
+const origin = `http://127.0.0.1:${address.port}`;
+const browser = spawn(process.env.CHROME_BIN || "/usr/bin/google-chrome", [
+  "--headless=new", "--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage",
+  "--remote-debugging-port=0", `--user-data-dir=${profile}`, "about:blank",
+], { stdio: ["ignore", "ignore", "pipe"] });
+
+let socket;
+let captureScreenshot;
+let captureState;
+const report = { environment: "Desktop Chrome with touch and simulated visual viewport; not installed iOS", buildRoot, assetPaths, cases: [] };
+try {
+  const endpoint = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("Browser startup timed out")), 15000);
+    browser.stderr.on("data", (chunk) => {
+      const match = String(chunk).match(/DevTools listening on (ws:\/\/\S+)/);
+      if (!match) return;
+      clearTimeout(timer);
+      resolve(match[1]);
+    });
+    browser.once("error", (error) => { clearTimeout(timer); reject(error); });
+  });
+  socket = new WebSocket(endpoint);
+  await once(socket, "open");
+  let sequence = 0;
+  let sessionId;
+  let fileChoosers = 0;
+  const pending = new Map();
+  socket.addEventListener("message", (event) => {
+    const message = JSON.parse(event.data);
+    if (message.method === "Page.fileChooserOpened") fileChoosers++;
+    const request = pending.get(message.id);
+    if (!request) return;
+    pending.delete(message.id);
+    clearTimeout(request.timer);
+    if (message.error) request.reject(new Error(JSON.stringify(message.error)));
+    else request.resolve(message.result);
+  });
+  const send = (method, params = {}) => new Promise((resolve, reject) => {
+    const id = ++sequence;
+    const timer = setTimeout(() => { pending.delete(id); reject(new Error(`${method} timed out`)); }, 20000);
+    pending.set(id, { resolve, reject, timer });
+    socket.send(JSON.stringify({ id, method, params, sessionId }));
+  });
+  const { targetId } = await send("Target.createTarget", { url: "about:blank" });
+  ({ sessionId } = await send("Target.attachToTarget", { targetId, flatten: true }));
+  await send("Page.enable");
+  await send("Page.setInterceptFileChooserDialog", { enabled: true });
+  await send("Runtime.enable");
+  await send("Network.enable");
+  await send("Network.setBlockedURLs", { urls: ["https://fonts.googleapis.com/*", "https://fonts.gstatic.com/*"] });
+  report.browser = (await send("Browser.getVersion")).product;
+  captureScreenshot = async (name) => writeFile(path.join(artifacts, name), Buffer.from((await send("Page.captureScreenshot", { format: "png" })).data, "base64"));
+  await send("Page.addScriptToEvaluateOnNewDocument", { source: `
+    window.__composerErrors = [];
+    window.__composerEvents = [];
+    localStorage.clear();
+    sessionStorage.clear();
+    window.addEventListener("error", event => window.__composerErrors.push(event.error?.name || "Error"));
+    window.__composerViewport = Object.assign(new EventTarget(), { height: 844, offsetTop: 0, offsetLeft: 0, scale: 1 });
+    Object.defineProperty(window.__composerViewport, "width", { get: () => innerWidth });
+    Object.defineProperty(window, "visualViewport", { value: window.__composerViewport });
+    const originalFetch = window.fetch.bind(window);
+    window.fetch = async (input, options) => {
+      const pathname = new URL(typeof input === "string" ? input : input.url, location.href).pathname;
+      if (!pathname.startsWith("/api/")) return originalFetch(input, options);
+      let result = {};
+      if (pathname === "/api/auth/status") result = { initialized: true };
+      if (pathname === "/api/auth/me") result = { id: "composer-fixture", username: "Fixture" };
+      if (pathname === "/api/models") result = [];
+      if (pathname === "/api/projects") result = { projects: [], activeProjectId: null };
+      return new Response(JSON.stringify(result), { headers: { "Content-Type": "application/json" } });
+    };
+    window.WebSocket = class extends EventTarget {
+      static OPEN = 1;
+      static CONNECTING = 0;
+      static CLOSED = 3;
+      readyState = 0;
+      constructor() {
+        super();
+        setTimeout(() => {
+          this.readyState = 1;
+          this.onopen?.(new Event("open"));
+          this.onmessage?.({ data: JSON.stringify({ type: "agents", activeAgentId: "codex", agents: [{ id: "codex", name: "Codex", ready: true }] }) });
+          this.onmessage?.({ data: JSON.stringify({ type: "history", messages: [] }) });
+        }, 0);
+      }
+      send() {}
+      close() { this.readyState = 3; }
+    };
+    window.__visibleComposerElement = selector => [...document.querySelectorAll(selector)].find(element => element.getBoundingClientRect().height > 0);
+    for (const type of ["pointerdown", "pointerup", "mousedown", "mouseup", "click"]) {
+      document.addEventListener(type, event => {
+        const target = event.target.closest?.("[data-testid]");
+        if (target?.dataset.testid !== "composer-actions-toggle") return;
+        window.__composerEvents.push({ type, trusted: event.isTrusted, prevented: event.defaultPrevented });
+      }, true);
+    }
+  ` });
+  const evaluate = async (expression) => {
+    const result = await send("Runtime.evaluate", { expression, awaitPromise: true, returnByValue: true });
+    if (result.exceptionDetails) throw new Error(JSON.stringify(result.exceptionDetails));
+    return result.result.value;
+  };
+  const settle = () => evaluate("new Promise(resolve => setTimeout(() => requestAnimationFrame(() => requestAnimationFrame(resolve)), 60))");
+  const metrics = () => evaluate(`(() => {
+    const visible = window.__visibleComposerElement;
+    const rect = element => {
+      if (!element) return null;
+      const bounds = element.getBoundingClientRect();
+      return { top: bounds.top, bottom: bounds.bottom, left: bounds.left, right: bounds.right, height: bounds.height, width: bounds.width };
+    };
+    const hit = element => {
+      const bounds = element.getBoundingClientRect();
+      return element.contains(document.elementFromPoint(bounds.left + bounds.width / 2, bounds.top + bounds.height / 2));
+    };
+    const input = visible(".composer-input");
+    const menu = visible(".actionSheet");
+    const toggle = visible('[data-testid="composer-actions-toggle"]');
+    return {
+      viewport: { height: visualViewport.height, top: visualViewport.offsetTop },
+      root: rect(document.querySelector("#app")), app: rect(document.querySelector(".app")),
+      detail: rect(visible(".detail")), wrap: rect(visible(".inputWrap")),
+      row: rect(visible(".composerMainRow")), input: rect(input),
+      expanded: input.parentElement.classList.contains("composerMainRow--expanded"),
+      inputDisabled: input.disabled,
+      selection: { start: input.selectionStart, end: input.selectionEnd, focused: document.activeElement === input },
+      overflow: getComputedStyle(input).overflowY, scrollHeight: input.scrollHeight,
+      toggle: { ...rect(toggle), hit: hit(toggle), open: toggle.getAttribute("aria-expanded") },
+      tools: [...visible(".composerMainRowRight").querySelectorAll("button")].map(element => ({ ...rect(element), hit: hit(element) })),
+      menu: menu ? { ...rect(menu), items: [...menu.querySelectorAll("button")].map(element => ({ ...rect(element), hit: hit(element), disabled: element.disabled })) } : null,
+      errors: window.__composerErrors,
+    };
+  })()`);
+  captureState = metrics;
+  const tap = async (selector, touch) => {
+    const point = await evaluate(`(() => {
+      const element = window.__visibleComposerElement(${JSON.stringify(selector)});
+      const bounds = element.getBoundingClientRect();
+      const pointX = bounds.left + bounds.width / 2, pointY = bounds.top + bounds.height / 2;
+      if (!element.contains(document.elementFromPoint(pointX, pointY))) throw new Error("Target is not hit-testable");
+      return { x: pointX, y: pointY };
+    })()`);
+    if (touch) {
+      await send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ ...point, id: 1, radiusX: 1, radiusY: 1, force: 1 }] });
+      await send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+    } else {
+      await send("Input.dispatchMouseEvent", { type: "mousePressed", ...point, button: "left", clickCount: 1 });
+      await send("Input.dispatchMouseEvent", { type: "mouseReleased", ...point, button: "left", clickCount: 1 });
+    }
+    await settle();
+  };
+  const fill = async (text) => {
+    await evaluate('(() => { const input = window.__visibleComposerElement(".composer-input"); input.focus(); input.select(); })()');
+    if (text) await send("Input.insertText", { text });
+    else {
+      await send("Input.dispatchKeyEvent", { type: "keyDown", key: "Backspace", code: "Backspace", windowsVirtualKeyCode: 8 });
+      await send("Input.dispatchKeyEvent", { type: "keyUp", key: "Backspace", code: "Backspace", windowsVirtualKeyCode: 8 });
+    }
+    await settle();
+  };
+  const toggleSelector = '[data-testid="composer-actions-toggle"]';
+  for (const width of [320, 390, 1440]) {
+    const touch = width < 900;
+    await send("Emulation.setDeviceMetricsOverride", { width, height: 844, mobile: touch, deviceScaleFactor: 1 });
+    await send("Emulation.setTouchEmulationEnabled", { enabled: touch });
+    await send("Emulation.setSafeAreaInsetsOverride", { insets: { top: 0, left: 0, right: 0, bottom: touch ? 34 : 0 } });
+    await send("Page.navigate", { url: origin });
+    await evaluate(`new Promise((resolve, reject) => {
+      const deadline = Date.now() + 15000;
+      const check = () => {
+        const input = window.__visibleComposerElement?.(".composer-input");
+        if (input && !input.disabled) return resolve(true);
+        if (Date.now() > deadline) return reject(new Error("Composer did not become ready"));
+        setTimeout(check, 40);
+      };
+      check();
+    })`);
+    await settle();
+    const initial = await metrics();
+    for (const height of touch ? [844, 430, 360, 300] : [844]) {
+      if (heightFilter !== null && height !== heightFilter) continue;
+      await evaluate(`Object.assign(window.__composerViewport, { height: ${height}, offsetTop: 0 }); window.__composerViewport.dispatchEvent(new Event("resize"));`);
+      await settle();
+      for (const [state, text] of [
+        ["empty", ""], ["short", "Short draft"],
+        ["wrapped", "\u6d4b\u8bd5\u8f93\u5165".repeat(Math.ceil(width / 32))],
+        ["newlines", "First line\nSecond line\nThird line"],
+        ["capped", "Long line of editable text\n".repeat(30)],
+      ]) {
+        if (stateFilter !== null && state !== stateFilter) continue;
+        await fill(text);
+        const before = await metrics();
+        const record = { width, height, state, before };
+        report.cases.push(record);
+        assert.equal(before.errors.length, 0, "No browser runtime errors");
+        assert.equal(before.toggle.hit, true, "The action trigger must remain hit-testable");
+        assert.ok(before.toggle.bottom <= height && before.tools.every(tool => tool.bottom <= height && tool.hit), "All tools must fit the visual viewport");
+        const requiredSafeArea = touch && height === 844 ? 34 : 0;
+        const gap = height - before.wrap.bottom;
+        assert.ok(gap >= requiredSafeArea - 1 && gap <= requiredSafeArea + 8, "The visible border must have only required safe area and <=8px ordinary spacing");
+        if (state === "empty" || state === "short") {
+          assert.equal(before.expanded, false);
+          assert.equal(before.input.height, initial.input.height);
+        } else {
+          assert.equal(before.expanded, true);
+          assert.ok(Math.abs(before.input.width - (before.row.width - 16)) <= 1, "Multiline text must fill the inner row");
+          assert.ok(before.input.bottom <= before.toggle.top, "Tools must not cover text");
+        }
+        if (state === "capped") assert.equal(before.overflow, "auto");
+        if (width === 390 && (height === 844 && ["empty", "newlines"].includes(state) || height === 430 && state === "empty")) {
+          await captureScreenshot(`${state}-${height}.png`);
+        }
+        await tap(toggleSelector, touch);
+        const opened = await metrics();
+        record.opened = opened;
+        assert.equal(opened.toggle.open, "true", "One real activation must open the menu");
+        assert.ok(opened.menu && opened.menu.top >= opened.detail.top && opened.menu.bottom <= height, "The menu must stay within the usable viewport");
+        assert.ok(opened.menu.items.every(item => item.hit && item.top >= opened.menu.top && item.bottom <= opened.menu.bottom), "Every menu item must be hit-testable");
+        if (width === 390 && height === 300 && state === "capped") {
+          await captureScreenshot("reduced-viewport-menu.png");
+        }
+        await tap(toggleSelector, touch);
+        assert.equal((await metrics()).toggle.open, "false", "The next tap must close, not double-toggle");
+      }
+    }
+    await fill("");
+    assert.equal((await metrics()).input.height, initial.input.height, "Delete-all must restore initial height");
+    if (heightFilter === null && stateFilter === null) {
+      await evaluate('Object.assign(window.__composerViewport, { height: 360, offsetTop: 120 }); window.__composerViewport.dispatchEvent(new Event("scroll"));');
+      await settle();
+      await fill("Panned draft\n".repeat(20));
+      const panned = await metrics();
+      assert.equal(panned.root.top, 120);
+      assert.equal(panned.root.bottom, 480);
+      assert.ok(panned.tools.every(tool => tool.bottom <= 480));
+      await tap(toggleSelector, touch);
+      assert.ok((await metrics()).menu.items.every(item => item.hit));
+      await evaluate('Object.assign(window.__composerViewport, { height: 844, offsetTop: 0 }); window.__composerViewport.dispatchEvent(new Event("resize")); window.dispatchEvent(new Event("pageshow"));');
+      await settle();
+      assert.equal((await metrics()).root.bottom, 844);
+      await tap(toggleSelector, touch);
+
+      await fill("alpha beta");
+      for (let index = 0; index < 4; index++) {
+        await send("Input.dispatchKeyEvent", { type: "keyDown", key: "ArrowLeft", code: "ArrowLeft", modifiers: 8, windowsVirtualKeyCode: 37 });
+      }
+      await send("Input.dispatchKeyEvent", { type: "keyUp", key: "ArrowLeft", code: "ArrowLeft", modifiers: 0, windowsVirtualKeyCode: 37 });
+      await settle();
+      const selectionBeforeMenu = (await metrics()).selection;
+      assert.equal(selectionBeforeMenu.start, 6, "Keyboard selection must begin at the last word");
+      assert.equal(selectionBeforeMenu.end, 10);
+      await tap(toggleSelector, touch);
+      report.cases.push({ width, state: "quote-selection", selectionBeforeMenu, opened: await metrics() });
+      await tap('[data-testid="wrap-triple-quotes"]', touch);
+      assert.equal(await evaluate('window.__visibleComposerElement(".composer-input").value'), 'alpha """beta"""');
+      await tap(toggleSelector, touch);
+      const previousChoosers = fileChoosers;
+      await tap('[data-testid="action-attach-image"]', touch);
+      assert.equal(fileChoosers, previousChoosers + 1, "The menu must preserve native file-picker activation");
+      assert.equal((await metrics()).toggle.open, "false");
+
+      await tap(toggleSelector, touch);
+      await tap(".chat", touch);
+      assert.equal((await metrics()).toggle.open, "false", "Outside pointerdown must dismiss the menu");
+      await tap(toggleSelector, touch);
+      await send("Input.dispatchKeyEvent", { type: "keyDown", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27 });
+      await settle();
+      assert.equal((await metrics()).toggle.open, "false");
+      await tap(".laneTab:not(.active)", touch);
+      await tap(".laneTab:not(.active)", touch);
+      assert.equal(await evaluate('window.__visibleComposerElement(".composer-input").value'), 'alpha """beta"""', "Lane switches must preserve the draft");
+      await tap(".sendIcon", touch);
+      assert.equal(await evaluate('window.__visibleComposerElement(".composer-input").value'), "", "Sending must clear the draft");
+      assert.equal((await metrics()).input.height, initial.input.height);
+      await tap(toggleSelector, touch);
+      await tap('[data-testid="restore-latest-prompt"]', touch);
+      assert.equal(await evaluate('window.__visibleComposerElement(".composer-input").value'), 'alpha """beta"""');
+      report.cases.push({ width, state: "interaction-and-resume", panned, filePickerOpened: fileChoosers > previousChoosers });
+    }
+    report.cases.push({ width, events: await evaluate("window.__composerEvents") });
+  }
+  console.log(JSON.stringify({ status: "passed", cases: report.cases.length, artifacts, environment: report.environment }));
+} catch (error) {
+  if (captureState) report.failure = await captureState().catch(() => ({ unavailable: true }));
+  if (captureScreenshot) await captureScreenshot("failure.png").catch(() => {});
+  throw error;
+} finally {
+  await writeFile(path.join(artifacts, "report.json"), JSON.stringify(report, null, 2));
+  socket?.close();
+  browser.kill("SIGTERM");
+  if (browser.exitCode === null) await once(browser, "exit");
+  server.close();
+  await rm(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 }).catch(error => {
+    console.warn(`Temporary browser profile cleanup: ${error.code}`);
+  });
+  console.log(`Composer browser evidence: ${artifacts}`);
+}


### PR DESCRIPTION
## Summary

Closes #193

This PR is deliberately a **draft pending installed-iOS-PWA acceptance**. It fixes the reproduced layout defects and supplies repeatable interaction checks, but does not claim to have identified or resolved the affected phone's all-state activation failure.

- Anchor the action menu to its actual trigger in a viewport-bounded body portal. Include the portal in outside-pointer containment, retain one click-based toggle, preserve synchronous file-picker activation, and scroll the menu when space is limited.
- Budget textarea growth against the remaining chat viewport, including chat padding, composer chrome, and the bottom tool row. Observe height-only viewport/container changes, keep multiline text full-width, and preserve deterministic empty-input reset.
- Give `#app` sole ownership of visual-viewport positioning/height. Remove competing root height rules and apply only the remaining required safe area once, outside the visible input border.
- Add regression coverage, a dependency-free Chrome interaction scenario, and a temporary metadata-only Web Inspector script with privacy/cleanup tests. The inspection script is not imported into the application and performs no network requests.

## Reproduction and browser evidence

Negative controls against the unchanged v0.2.5 artifact (`index-wGwV9UtX.js`, `index-BteDdV_m.css`) fail as expected:

- At 320px width / 430px simulated visual height, the capped-draft menu occupies y=41..167 while the chat starts at y=68; the first action's center is not hit-testable.
- At 320px width / 300px simulated visual height with a capped draft, the trigger is outside its hit-testable viewport.

The corrected artifact is `index-BW4wckls.js` / `index-BExxTe3g.css`:

- At 390px width / 300px simulated visual height, capped text is 146px high and 348px wide, the trigger occupies y=258..290, and the menu occupies y=124..250. All menu item centers are hit-testable.
- With the keyboard closed and an emulated 34px required safe area, the measured border-to-screen gap is 34px: 34px safe area and 0px additional application spacing. Reduced keyboard viewport cases have no extra bottom safe-area gap.
- Actual Chrome mouse/touch dispatch covers menu open/close, outside dismissal, Escape, keyboard text selection and quoting, native file-chooser activation, send/reset/restore, lane draft preservation, and panned viewport recovery.
- This is **desktop Chrome 151.0.7922.75 with simulated keyboard geometry**, not physical iOS validation. The isolated browser uses local API/WebSocket fixtures, never a production session.

Reproduce with `npm run build:web && npm run test:composer-browser`. The script prints its temporary geometry/event report and screenshot directory. `CHROME_BIN` and `ADS_COMPOSER_BUILD_DIR` can select the local browser and artifact; `ADS_COMPOSER_VIEWPORT_HEIGHT=300 ADS_COMPOSER_DRAFT_STATE=capped` isolates the hidden-trigger negative control.

## Verification

- `npm run lint` — passed.
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json` — passed.
- `npm run build` — passed, including the Web build.
- `npm test` with an empty temporary `CODEX_HOME` — 730 passed, 0 failed, 0 skipped. This isolates host-installed skill metadata; repository and production configuration are unchanged.
- `npm run test:web` — 87 files, 509 tests passed.
- `npm run test:composer-browser` — 45 layout states at 320px, 390px, and 1440px widths, plus interaction/resume scenarios at each width, passed.
- `git diff --check` — passed.

## Required before marking ready

- [ ] Record the affected physical device/iOS version, loaded assets, service-worker controller, and the first failed hit-test/event/state/rendering hop before any cache reset.
- [ ] Complete the installed-PWA menu/attachment/quoting/restore matrix with keyboard open and closed, including background/resume, lane switching, and orientation changes.
- [ ] Verify actual CJK/IME caret/selection behavior and capture the three requested layout states plus an operable opened menu, with raw bottom gap and required safe-area measurements separately.

Use the opt-in procedure in `docs/web.md` and `scripts/inspect-composer.js` for on-device metadata. Desktop success does not establish the phone's root cause, and this PR must not close the physical-device acceptance gap by assertion.

## Scope boundaries

No header redesign, message styling changes, provider/backend protocol changes, release/version bump, merge, or production deployment. Clear session still preserves drafts. The supplied untracked user screenshots remain unchanged and are not committed. No architectural transition or ADR was planned for this bounded UI repair.
