### PR TITLE
fix(web): stabilize lane conversation switching

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -614,7 +614,9 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
+  width: 100%;
   min-width: 0;
+  overflow: hidden;
 }
 
 .laneSessionActions {

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
 declare const __APP_VERSION__: string | undefined;
 const appVersion = typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "0.0.1";
@@ -134,10 +134,10 @@ const chatLanes: Array<{ id: ChatLane; label: string }> = [
   { id: "worker", label: "Worker" },
 ];
 const workspaceTabs = computed<Array<{ id: ChatLane; label: string }>>(() => chatLanes);
-const activeWorkspaceTab = computed<ChatLane>(() => activeChatLane.value);
 
 const {
   activeChatLane,
+  setActiveChatLane,
   plannerMessages,
   plannerQueuedPrompts,
   plannerPendingImages,
@@ -193,6 +193,15 @@ const {
   resumeTaskThread,
   listResumableSessions,
 });
+
+const activeWorkspaceTab = computed<ChatLane>(() => activeChatLane.value);
+
+type MainChatHandle = {
+  refreshAfterVisibility?: () => void | Promise<void>;
+};
+
+const plannerChatRef = ref<MainChatHandle | null>(null);
+const workerChatRef = ref<MainChatHandle | null>(null);
 
 const activeLaneConnected = computed(() =>
   activeWorkspaceTab.value === "planner" ? Boolean(plannerConnected.value) : Boolean(connected.value),
@@ -336,7 +345,7 @@ function toggleMobileDrawer(): void {
 }
 
 function selectWorkspaceTab(tab: ChatLane): void {
-  activeChatLane.value = tab;
+  setActiveChatLane(tab);
   if (isMobile.value) writeMobileWorkspaceTab(activeProjectId.value, tab);
   closeMobileContextMenu();
 }
@@ -344,7 +353,14 @@ function selectWorkspaceTab(tab: ChatLane): void {
 function restoreMobileWorkspaceTab(): void {
   const projectId = activeProjectId.value.trim();
   const tab = readMobileWorkspaceTab(projectId);
-  activeChatLane.value = tab;
+  setActiveChatLane(tab);
+}
+
+async function refreshVisibleLaneChat(lane: ChatLane): Promise<void> {
+  await nextTick();
+  if (activeWorkspaceTab.value !== lane) return;
+  const chat = lane === "planner" ? plannerChatRef.value : workerChatRef.value;
+  await chat?.refreshAfterVisibility?.();
 }
 
 function selectMobileDrawerSection(section: MobileDrawerSection): void {
@@ -408,16 +424,24 @@ function onMobileKeydown(ev: KeyboardEvent): void {
 
 watch(isMobile, (mobile) => {
   if (mobile) {
-    restoreMobileWorkspaceTab();
+    if (activeProjectId.value.trim()) restoreMobileWorkspaceTab();
     return;
   }
   closeMobileDrawer();
 });
 
 watch(activeProjectId, (projectId, previousProjectId) => {
-  if (!isMobile.value || !projectId.trim() || projectId === previousProjectId) return;
-  restoreMobileWorkspaceTab();
+  if (!projectId.trim() || projectId === previousProjectId) return;
+  if (isMobile.value) {
+    restoreMobileWorkspaceTab();
+    return;
+  }
+  if (previousProjectId?.trim()) setActiveChatLane("worker");
 });
+
+watch(activeWorkspaceTab, (lane) => {
+  void refreshVisibleLaneChat(lane);
+}, { flush: "post" });
 
 onMounted(() => {
   window.addEventListener("keydown", onMobileKeydown);
@@ -797,6 +821,7 @@ const plannerConnectionStatus = computed(() => {
             data-testid="lane-panel-planner"
           >
             <MainChatView
+              ref="plannerChatRef"
               :key="plannerChatKey"
               class="chatHost chatHost--planner"
               :messages="plannerMessages"
@@ -829,6 +854,7 @@ const plannerConnectionStatus = computed(() => {
             data-testid="lane-panel-worker"
           >
             <MainChatView
+              ref="workerChatRef"
               :key="workerChatKey"
               class="chatHost"
               :messages="messages"

--- a/client/src/__tests__/issue-198-lane-switching.test.ts
+++ b/client/src/__tests__/issue-198-lane-switching.test.ts
@@ -1,0 +1,191 @@
+import { defineComponent, nextTick, type PropType } from "vue";
+import { shallowMount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ModelConfig } from "../api/types";
+
+type GetImpl = (url: string) => Promise<unknown>;
+type StubMessage = { id: string; content: string };
+
+let getImpl: GetImpl | null = null;
+const refreshAfterVisibility = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("../api/client", () => {
+  class ApiClient {
+    constructor(_: { baseUrl: string }) {}
+
+    async get<T>(url: string): Promise<T> {
+      if (!getImpl) throw new Error("getImpl not set");
+      return (await getImpl(url)) as T;
+    }
+
+    async post<T>(): Promise<T> {
+      return {} as T;
+    }
+
+    async patch<T>(): Promise<T> {
+      return {} as T;
+    }
+
+    async delete<T>(): Promise<T> {
+      return {} as T;
+    }
+  }
+
+  return { ApiClient };
+});
+
+vi.mock("../api/ws", () => {
+  class AdsWebSocket {
+    onOpen?: () => void;
+    onClose?: (event: { code: number; reason?: string }) => void;
+    onError?: () => void;
+    onMessage?: (message: unknown) => void;
+
+    constructor(_: { sessionId: string; chatSessionId?: string }) {}
+
+    connect(): void {
+      queueMicrotask(() => this.onOpen?.());
+    }
+
+    close(): void {}
+    send(): void {}
+    sendPrompt(): void {}
+    interrupt(): void {}
+    clearHistory(): void {}
+  }
+
+  return { AdsWebSocket };
+});
+
+vi.mock("../components/LoginGate.vue", () => ({
+  default: defineComponent({
+    name: "LoginGate",
+    emits: ["logged-in"],
+    mounted() {
+      queueMicrotask(() => this.$emit("logged-in", { id: "u-1", username: "admin" }));
+    },
+    template: "<div />",
+  }),
+}));
+
+const MainChatViewStub = defineComponent({
+  name: "MainChatView",
+  props: {
+    messages: { type: Array as PropType<StubMessage[]>, default: () => [] },
+  },
+  setup(_, { expose }) {
+    expose({ refreshAfterVisibility });
+    return {};
+  },
+  template: `
+    <div class="main-chat-stub">
+      <span
+        v-for="message in messages"
+        :key="message.id"
+        class="stub-message"
+        :data-message-id="message.id"
+      >{{ message.content }}</span>
+    </div>
+  `,
+});
+
+async function settleUi(wrapper: { vm: { $nextTick: () => Promise<void> } }): Promise<void> {
+  for (let index = 0; index < 6; index += 1) {
+    await wrapper.vm.$nextTick();
+    await nextTick();
+    await Promise.resolve();
+  }
+}
+
+function message(id: string, content: string) {
+  return { id, role: "assistant", kind: "text", content };
+}
+
+function isPanelDisplayed(panel: { attributes: (name: string) => string | undefined }): boolean {
+  return !String(panel.attributes("style") ?? "").includes("display: none");
+}
+
+describe("Issue #198 lane conversation switching", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    getImpl = async (url: string) => {
+      if (url === "/api/models") return [] satisfies ModelConfig[];
+      if (url === "/api/projects") {
+        return {
+          projects: [],
+          activeProjectId: null,
+        };
+      }
+      if (url.startsWith("/api/paths/subdirs")) return { dirs: [], allowedDirs: [] };
+      if (url.startsWith("/api/paths/validate")) return { ok: false };
+      return {};
+    };
+  });
+
+  afterEach(() => {
+    getImpl = null;
+    refreshAfterVisibility.mockClear();
+    localStorage.clear();
+  });
+
+  it("switches the visible conversation and refreshes only the selected lane", async () => {
+    const App = (await import("../App.vue")).default;
+    const wrapper = shallowMount(App, {
+      global: {
+        stubs: {
+          LoginGate: false,
+          MainChatView: MainChatViewStub,
+          ModelManager: true,
+          DraggableModal: true,
+          SessionResumePicker: true,
+        },
+      },
+    });
+
+    await settleUi(wrapper);
+
+    const plannerRuntime = (wrapper.vm as any).activePlannerRuntime;
+    const workerRuntime = (wrapper.vm as any).activeRuntime;
+    plannerRuntime.messages.value = [message("planner-1", "Advisor response")];
+    workerRuntime.messages.value = [message("worker-1", "Worker response")];
+    await settleUi(wrapper);
+
+    const plannerPanel = wrapper.find('[data-testid="lane-panel-planner"]');
+    const workerPanel = wrapper.find('[data-testid="lane-panel-worker"]');
+    expect(isPanelDisplayed(plannerPanel)).toBe(true);
+    expect(isPanelDisplayed(workerPanel)).toBe(false);
+    expect(plannerPanel.text()).toContain("Advisor response");
+    expect(plannerPanel.text()).not.toContain("Worker response");
+
+    await wrapper.find('[data-testid="lane-tab-worker"]').trigger("click");
+    await settleUi(wrapper);
+
+    expect(isPanelDisplayed(workerPanel)).toBe(true);
+    expect(isPanelDisplayed(plannerPanel)).toBe(false);
+    expect(workerPanel.text()).toContain("Worker response");
+    expect(workerPanel.text()).not.toContain("Advisor response");
+    expect(refreshAfterVisibility).toHaveBeenCalledTimes(1);
+
+    await wrapper.find('[data-testid="lane-tab-planner"]').trigger("click");
+    await settleUi(wrapper);
+
+    expect(isPanelDisplayed(plannerPanel)).toBe(true);
+    expect(isPanelDisplayed(workerPanel)).toBe(false);
+    expect(plannerPanel.text()).toContain("Advisor response");
+    expect(plannerPanel.text()).not.toContain("Worker response");
+    expect(refreshAfterVisibility).toHaveBeenCalledTimes(2);
+
+    await wrapper.find('[data-testid="lane-tab-worker"]').trigger("click");
+    await wrapper.find('[data-testid="lane-tab-planner"]').trigger("click");
+    await wrapper.find('[data-testid="lane-tab-worker"]').trigger("click");
+    await settleUi(wrapper);
+
+    expect((wrapper.vm as any).activeChatLane).toBe("worker");
+    expect(isPanelDisplayed(workerPanel)).toBe(true);
+    expect(isPanelDisplayed(plannerPanel)).toBe(false);
+    expect(workerPanel.text()).toContain("Worker response");
+
+    wrapper.unmount();
+  });
+});

--- a/client/src/__tests__/mainchat-autoscroll-on-mount.test.ts
+++ b/client/src/__tests__/mainchat-autoscroll-on-mount.test.ts
@@ -145,4 +145,35 @@ describe("MainChat auto-scroll on mount", () => {
 
     wrapper.unmount();
   });
+
+  it("refreshes a visible pane without moving a user away from an earlier scroll position", async () => {
+    const messages = Array.from({ length: 65 }, (_, index) => msg(`m-${index}`, "assistant", `line ${index}`));
+    const wrapper = mount(MainChat, {
+      props: {
+        messages,
+        queuedPrompts: [],
+        pendingImages: [],
+        connected: true,
+        busy: false,
+      },
+      global: {
+        stubs: {
+          MarkdownContent: MarkdownContentStub,
+        },
+      },
+      attachTo: document.body,
+    });
+
+    const chat = wrapper.find(".chat").element as HTMLElement;
+    Object.defineProperty(chat, "clientHeight", { configurable: true, get: () => 100 });
+    Object.defineProperty(chat, "scrollHeight", { configurable: true, get: () => 1000 });
+    await settleUi(wrapper);
+
+    chat.scrollTop = 100;
+    await wrapper.find(".chat").trigger("scroll");
+    await (wrapper.vm as any).refreshAfterVisibility();
+
+    expect(chat.scrollTop).toBe(100);
+    wrapper.unmount();
+  });
 });

--- a/client/src/components/MainChat.vue
+++ b/client/src/components/MainChat.vue
@@ -36,7 +36,12 @@ const emit = defineEmits<{
 }>();
 
 const listRef = ref<HTMLElement | null>(null);
-const messageListRef = ref<{ showLatestMessages?: () => void } | null>(null);
+type MessageListHandle = {
+  showLatestMessages?: () => void;
+  refreshAfterVisibility?: () => void;
+};
+
+const messageListRef = ref<MessageListHandle | null>(null);
 const autoScroll = ref(true);
 const showScrollToBottom = ref(false);
 
@@ -93,6 +98,17 @@ async function scrollChatToBottom(): Promise<void> {
   autoScroll.value = true;
   showScrollToBottom.value = false;
 }
+
+async function refreshAfterVisibility(): Promise<void> {
+  await nextTick();
+  messageListRef.value?.refreshAfterVisibility?.();
+  await nextTick();
+  if (!listRef.value || !autoScroll.value) return;
+  listRef.value.scrollTop = listRef.value.scrollHeight;
+  showScrollToBottom.value = false;
+}
+
+defineExpose({ refreshAfterVisibility });
 
 const scrollToBottom = scrollChatToBottom;
 

--- a/client/src/components/MainChatMessageList.vue
+++ b/client/src/components/MainChatMessageList.vue
@@ -274,6 +274,14 @@ function resolveMessageScrollRoot(): HTMLElement | null {
   return (list.closest(".chat") as HTMLElement | null) ?? list.parentElement;
 }
 
+function attachMessageScrollRoot(): void {
+  const nextRoot = resolveMessageScrollRoot();
+  if (nextRoot === messageScrollRoot) return;
+  messageScrollRoot?.removeEventListener("scroll", handleMessageScroll);
+  messageScrollRoot = nextRoot;
+  messageScrollRoot?.addEventListener("scroll", handleMessageScroll, { passive: true });
+}
+
 function isMessageScrollRootNearBottom(): boolean {
   const root = messageScrollRoot ?? resolveMessageScrollRoot();
   if (!root) return true;
@@ -289,7 +297,15 @@ function showLatestMessages(): void {
   windowEnd.value = total;
 }
 
-defineExpose({ showLatestMessages });
+function refreshAfterVisibility(): void {
+  attachMessageScrollRoot();
+  const total = renderMessages.value.length;
+  const hasWindow = windowEnd.value > windowStart.value && windowStart.value < total;
+  if (total > 0 && !hasWindow) showLatestMessages();
+  void nextTick().then(observeEarlierMessagesSentinel);
+}
+
+defineExpose({ showLatestMessages, refreshAfterVisibility });
 
 function handleMessageScroll(): void {
   if (isMessageScrollRootNearBottom()) showLatestMessages();
@@ -382,8 +398,7 @@ watch(windowStart, () => {
 });
 
 onMounted(() => {
-  messageScrollRoot = resolveMessageScrollRoot();
-  messageScrollRoot?.addEventListener("scroll", handleMessageScroll, { passive: true });
+  attachMessageScrollRoot();
   observeEarlierMessagesSentinel();
 });
 

--- a/client/src/components/MainChatModelSelectors.vue
+++ b/client/src/components/MainChatModelSelectors.vue
@@ -271,10 +271,10 @@ function selectReasoningEffort(effort: string): void {
 <style scoped>
 .modelSelectors {
   display: grid;
-  grid-template-columns: minmax(0, 112px) 60px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 60px);
   align-items: center;
   gap: 4px;
-  width: fit-content;
+  width: 100%;
   max-width: 100%;
   min-width: 0;
 }
@@ -284,6 +284,7 @@ function selectReasoningEffort(effort: string): void {
   display: flex;
   align-items: center;
   min-width: 0;
+  overflow: hidden;
   height: 26px;
   box-sizing: border-box;
   padding: 3px 18px 3px 6px;
@@ -323,6 +324,7 @@ function selectReasoningEffort(effort: string): void {
   position: absolute;
   inset: 0;
   width: 100%;
+  max-width: 100%;
   min-width: 0;
   height: 100%;
   opacity: 0;

--- a/client/src/composables/app/useLaneRuntimeBridge.test.ts
+++ b/client/src/composables/app/useLaneRuntimeBridge.test.ts
@@ -65,7 +65,7 @@ describe("useLaneRuntimeBridge", () => {
     expect(bridge.workerLatestPromptKey.value).toBe("p1:worker");
   });
 
-  it("returns planner lane to worker when the active project changes", async () => {
+  it("does not change the selected lane when the active project changes", async () => {
     const plannerRuntime = createRuntime();
     const activeProjectId = ref("p1");
 
@@ -86,7 +86,7 @@ describe("useLaneRuntimeBridge", () => {
     bridge.activeChatLane.value = "planner";
     activeProjectId.value = "p3";
     await nextTick();
-    expect(bridge.activeChatLane.value).toBe("worker");
+    expect(bridge.activeChatLane.value).toBe("planner");
   });
 
   it("blocks disconnected planner lane resets but keeps worker new-session available", () => {

--- a/client/src/composables/app/useLaneRuntimeBridge.ts
+++ b/client/src/composables/app/useLaneRuntimeBridge.ts
@@ -1,4 +1,4 @@
-import { computed, ref, watch, type Ref } from "vue";
+import { computed, ref, type Ref } from "vue";
 
 export type ChatLane = "planner" | "worker";
 
@@ -65,15 +65,11 @@ export function useLaneRuntimeBridge(params: {
   ) => void;
 }) {
   const activeChatLane = ref<ChatLane>("planner");
-  watch(
-    () => params.activeProjectId.value,
-    (nextProjectId, prevProjectId) => {
-      if (!prevProjectId || nextProjectId === prevProjectId) return;
-      if (activeChatLane.value === "planner") {
-        activeChatLane.value = "worker";
-      }
-    },
-  );
+
+  function setActiveChatLane(lane: ChatLane): void {
+    activeChatLane.value = lane;
+  }
+
   const plannerRuntime = computed(() => asPlannerRuntimeShape(params.activePlannerRuntime.value));
   const workerRuntime = computed(() => asRuntimeShape(params.activeRuntime.value));
 
@@ -207,6 +203,7 @@ export function useLaneRuntimeBridge(params: {
 
   return {
     activeChatLane,
+    setActiveChatLane,
     plannerMessages,
     plannerQueuedPrompts,
     plannerPendingImages,


### PR DESCRIPTION
Closes #198\n\n## Summary\n- unify Advisor and Worker lane selection behind the runtime bridge\n- refresh hidden chat panes after visibility changes without overriding historical scroll positions\n- constrain mobile model selectors and add lane-switching regression coverage\n\n## Verification\n- npm run lint\n- npm run build\n- npm run test:web (513 tests)\n- env CODEX_HOME=/tmp ADS_MEMORY_INJECTION_ENABLED=false npm test (730 tests)\n- git diff --check