### PR TITLE
fix(web): clear composer after sending

### DIFF
--- a/client/src/__tests__/chat-composer-draft-preservation.test.ts
+++ b/client/src/__tests__/chat-composer-draft-preservation.test.ts
@@ -84,6 +84,49 @@ describe("composer draft preservation on session reset", () => {
     expect(plannerRt.composerDraft.value).toBe("Planner reset draft");
   });
 
+  it("clears worker and planner drafts after their prompts are queued", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const tasks = createLaneActions({ ...ctx, ...chat } as AppContext & ReturnType<typeof createChatActions>, {
+      connectWs: vi.fn(async () => {}),
+      connectPlannerWs: vi.fn(async () => {}),
+    });
+
+    const workerRt = ctx.activeRuntime.value;
+    const plannerRt = ctx.activePlannerRuntime.value;
+    workerRt.composerDraft.value = "Worker prompt";
+    plannerRt.composerDraft.value = "Planner prompt";
+
+    tasks.sendMainPrompt("Worker prompt");
+    tasks.sendPlannerPrompt("Planner prompt");
+
+    expect(workerRt.composerDraft.value).toBe("");
+    expect(plannerRt.composerDraft.value).toBe("");
+    expect(workerRt.queuedPrompts.value[0]?.text).toBe("Worker prompt");
+    expect(plannerRt.queuedPrompts.value[0]?.text).toBe("Planner prompt");
+  });
+
+  it("preserves drafts when prompt enqueue fails before dispatch", () => {
+    const ctx = createAppContext();
+    const chat = createChatActions(ctx as AppContext);
+    const enqueueMainPrompt = vi.fn(() => {
+      throw new Error("dispatch unavailable");
+    });
+    const tasks = createLaneActions(
+      { ...ctx, ...chat, enqueueMainPrompt } as AppContext & ReturnType<typeof createChatActions>,
+      {
+        connectWs: vi.fn(async () => {}),
+        connectPlannerWs: vi.fn(async () => {}),
+      },
+    );
+
+    const workerRt = ctx.activeRuntime.value;
+    workerRt.composerDraft.value = "Retry this prompt";
+
+    expect(() => tasks.sendMainPrompt("Retry this prompt")).toThrow("dispatch unavailable");
+    expect(workerRt.composerDraft.value).toBe("Retry this prompt");
+  });
+
   it("scopes worker and planner backend clears to their originating lanes", () => {
     const ctx = createAppContext();
     const chat = createChatActions(ctx as AppContext);

--- a/client/src/__tests__/mainchat-composer-layout.test.ts
+++ b/client/src/__tests__/mainchat-composer-layout.test.ts
@@ -23,6 +23,34 @@ const ComposerHost = defineComponent({
   `,
 });
 
+const DelayedDraftHost = defineComponent({
+  components: { MainChatComposerPanel },
+  setup() {
+    const draft = ref("");
+    const sent = ref<string[]>([]);
+    const pendingDraftUpdates: string[] = [];
+    const onDraftUpdate = (value: string): void => {
+      if (value) draft.value = value;
+      else pendingDraftUpdates.push(value);
+    };
+    const flushDraftUpdate = (): void => {
+      draft.value = pendingDraftUpdates.shift() ?? draft.value;
+    };
+    return { draft, sent, onDraftUpdate, flushDraftUpdate };
+  },
+  template: `
+    <MainChatComposerPanel
+      :draft="draft"
+      :queued-prompts="[]"
+      :pending-images="[]"
+      :connected="true"
+      :busy="false"
+      @update:draft="onDraftUpdate"
+      @send="sent.push($event)"
+    />
+  `,
+});
+
 describe("MainChat compact composer layout", () => {
   beforeEach(() => {
     vi.spyOn(window, "getComputedStyle").mockReturnValue({
@@ -82,6 +110,7 @@ describe("MainChat compact composer layout", () => {
 
     await wrapper.get(".sendIcon").trigger("click");
     expect(wrapper.getComponent(MainChatComposerPanel).emitted("send")).toEqual([[longDraft]]);
+    expect((wrapper.vm as { draft: string }).draft).toBe("");
     expect(element.value).toBe("");
     expect(element.style.height).toBe("34px");
     expect(element.style.overflowY).toBe("hidden");
@@ -91,6 +120,37 @@ describe("MainChat compact composer layout", () => {
     await textarea.setValue("");
     expect(element.style.height).toBe("34px");
     expect(wrapper.get(".composerMainRow").classes()).not.toContain("composerMainRow--expanded");
+    wrapper.unmount();
+  });
+
+  it("clears the textarea and draft when Enter sends a prompt", async () => {
+    const wrapper = mount(ComposerHost);
+    const textarea = wrapper.get("textarea.composer-input");
+    await textarea.setValue("Prompt sent with Enter");
+
+    await textarea.trigger("keydown", { key: "Enter" });
+
+    expect(wrapper.getComponent(MainChatComposerPanel).emitted("send")).toEqual([["Prompt sent with Enter"]]);
+    expect((wrapper.vm as { draft: string }).draft).toBe("");
+    expect((textarea.element as HTMLTextAreaElement).value).toBe("");
+    wrapper.unmount();
+  });
+
+  it("clears the physical textarea before a delayed parent draft update", async () => {
+    const wrapper = mount(DelayedDraftHost);
+    const textarea = wrapper.get("textarea.composer-input");
+    await textarea.setValue("Prompt with delayed draft synchronization");
+
+    await wrapper.get(".sendIcon").trigger("click");
+
+    expect((wrapper.vm as { draft: string }).draft).toBe("Prompt with delayed draft synchronization");
+    expect((textarea.element as HTMLTextAreaElement).value).toBe("");
+    expect((wrapper.vm as { sent: string[] }).sent).toEqual(["Prompt with delayed draft synchronization"]);
+
+    (wrapper.vm as { flushDraftUpdate: () => void }).flushDraftUpdate();
+    await nextTick();
+    expect((wrapper.vm as { draft: string }).draft).toBe("");
+    expect((textarea.element as HTMLTextAreaElement).value).toBe("");
     wrapper.unmount();
   });
 

--- a/client/src/__tests__/mainchat-prompt-tools.test.ts
+++ b/client/src/__tests__/mainchat-prompt-tools.test.ts
@@ -83,6 +83,22 @@ describe("MainChat prompt tools", () => {
     wrapper.unmount();
   });
 
+  it("still dispatches and clears the composer when latest-prompt storage fails", async () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+    const wrapper = mountPromptTools();
+    const textarea = wrapper.get("textarea.composer-input");
+
+    await textarea.setValue("Prompt without storage");
+    await textarea.trigger("keydown", { key: "Enter" });
+    await nextTick();
+
+    expect((wrapper.vm as { sent: string[] }).sent).toEqual(["Prompt without storage"]);
+    expect((textarea.element as HTMLTextAreaElement).value).toBe("");
+    wrapper.unmount();
+  });
+
   it("keeps latest prompts isolated by project and lane and does not overwrite a draft", async () => {
     localStorage.setItem(STORAGE_KEY, "Worker prompt");
     localStorage.setItem("ADS_WEB_LATEST_PROMPT:project-1:planner", "Planner prompt");

--- a/client/src/app/laneActions.ts
+++ b/client/src/app/laneActions.ts
@@ -125,14 +125,17 @@ function clearRuntimeNoticeTimer(rt: Pick<ProjectRuntime, "noticeTimer">): void 
 
    const sendMainPrompt = (content: string): void => {
      apiError.value = null;
+     const worker = activeRuntime.value;
      const text = String(content ?? "");
      const images = pendingImages.value.slice();
      pendingImages.value = [];
      if (text.trim().toLowerCase() === "/clear") {
        clearActiveChat();
+       worker.composerDraft.value = "";
        return;
      }
      enqueueMainPrompt(text, images);
+     worker.composerDraft.value = "";
    };
 
    const sendPlannerPrompt = (content: string): void => {
@@ -143,9 +146,11 @@ function clearRuntimeNoticeTimer(rt: Pick<ProjectRuntime, "noticeTimer">): void 
      planner.pendingImages.value = [];
      if (text.trim().toLowerCase() === "/clear") {
        clearPlannerChat();
+       planner.composerDraft.value = "";
        return;
      }
      enqueuePrompt(text, images, planner);
+     planner.composerDraft.value = "";
    };
 
    const persistReasoningEffort = (rt: ProjectRuntime): void => {

--- a/client/src/components/MainChatComposerPanel.vue
+++ b/client/src/components/MainChatComposerPanel.vue
@@ -149,7 +149,11 @@ const {
   isInputLocked: () => Boolean(props.inputLocked),
   getApiToken: () => String(props.apiToken ?? ""),
   onSend: (content) => {
-    persistLatestPrompt(content);
+    try {
+      persistLatestPrompt(content);
+    } catch {
+      // Browser storage must not prevent the prompt from being dispatched.
+    }
     emit("send", content);
   },
   onAddImages: (images) => emit("addImages", images),

--- a/client/src/components/mainChat/useComposer.ts
+++ b/client/src/components/mainChat/useComposer.ts
@@ -438,6 +438,10 @@ export function useMainChatComposer(params: {
       const accepted = params.onSend(text);
       if (accepted !== false) {
         input.value = "";
+        const el = inputEl.value;
+        if (el) el.value = "";
+        composerExpanded.value = false;
+        resizeComposer();
       }
     } catch {
       // Keep the draft when dispatch fails so the user can retry it.


### PR DESCRIPTION
Closes #197

## Summary
- clear both the reactive draft and the native textarea after an accepted send
- keep prompt dispatch independent from latest-prompt storage failures
- clear the correct Advisor or Worker runtime draft only after enqueue succeeds
- add click, Enter, delayed-sync, storage-failure, and enqueue-failure regression coverage

## Verification
- npm run lint
- npm run build
- npm run test:web (518 tests)
- env CODEX_HOME=/tmp ADS_MEMORY_INJECTION_ENABLED=false npm test (730 tests)
- npm run test:composer-browser (54 cases)
- git diff --check