### PR TITLE
feat(ui): move brand badge to drawer footer

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -227,17 +227,23 @@
 .btnDanger:hover {
   background: var(--danger-2);
 }
-.brand {
+.drawerFooter {
   display: flex;
   align-items: baseline;
   gap: 6px;
-  font-weight: 700;
-  font-size: 14px;
-  color: var(--accent);
-  white-space: nowrap;
-  flex-shrink: 0;
+  flex: 0 0 auto;
+  margin-top: auto;
+  padding: 8px 2px 4px;
+  border-top: 1px solid var(--border);
 }
-.brandVersion {
+.drawerBrandTitle {
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 800;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+.drawerBrandVersion {
   font-size: 11px;
   font-weight: 500;
   color: var(--muted);
@@ -300,11 +306,12 @@
 .projectTree {
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
   gap: 10px;
   background: rgba(248, 250, 252, 0.95);
   border-radius: 16px;
   padding: 10px;
-  height: 80vh;
+  height: auto;
   min-height: 0;
   overflow: auto;
 }
@@ -1000,6 +1007,9 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+  .left.mobileDrawer .drawerFooter {
+    padding-bottom: calc(4px + env(safe-area-inset-bottom, 0px));
+  }
   .mobileDrawerBackdrop {
     position: fixed;
     inset: calc(var(--topbar-height) + env(safe-area-inset-top, 0px)) 0 0;
@@ -1141,7 +1151,7 @@
 }
 
 @media (max-width: 768px) {
-  .brandVersion,
+  .drawerBrandVersion,
   .projectBranch,
   .mobileContextMenuTitle,
   .mobileContextActionHint,

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -543,10 +543,6 @@ const plannerConnectionStatus = computed(() => {
           <rect x="2" y="12.3" width="10" height="2.2" rx="1.1" />
         </svg>
       </button>
-      <div class="brand">
-        <span>ADS</span>
-        <span class="brandVersion">v{{ appVersion }}</span>
-      </div>
       <div class="topbarMain">
         <div v-if="isMobile" class="mobileContextTitle" :title="mobileContextTitle">
           {{ mobileContextTitle }}
@@ -746,6 +742,10 @@ const plannerConnectionStatus = computed(() => {
             </button>
             </div>
         </div>
+        <footer class="drawerFooter" data-testid="drawer-footer">
+          <span class="drawerBrandTitle">ADS</span>
+          <span class="drawerBrandVersion">v{{ appVersion }}</span>
+        </footer>
       </aside>
 
       <section v-if="isMobile && mobileDrawerSection !== 'projects'" class="mobileMainPanel">

--- a/client/src/__tests__/app-brand-version.test.ts
+++ b/client/src/__tests__/app-brand-version.test.ts
@@ -2,12 +2,27 @@ import { describe, expect, it } from "vitest";
 import { readSfc } from "./readSfc";
 
 describe("App brand version display", () => {
-  it("includes brand title and version badge in App.vue template and style", async () => {
+  it("renders the brand version in the drawer footer instead of the topbar", async () => {
+    const content = await readSfc("../App.vue", import.meta.url);
+    const topbar = content.match(/<header class="topbar">([\s\S]*?)<\/header>/)?.[1] ?? "";
+    const drawer = content.match(/<aside[\s\S]*?data-testid="mobile-drawer"[\s\S]*?<\/aside>/)?.[0] ?? "";
+
+    expect(topbar).not.toMatch(/class="brand"/);
+    expect(topbar).not.toMatch(/brandVersion/);
+    expect(drawer).toMatch(/<footer class="drawerFooter" data-testid="drawer-footer">/);
+    expect(drawer).toMatch(/<span class="drawerBrandTitle">ADS<\/span>/);
+    expect(drawer).toMatch(/<span class="drawerBrandVersion">v\{\{ appVersion \}\}<\/span>/);
+    expect(content).toMatch(/\.drawerFooter\s*\{[\s\S]*?flex:\s*0 0 auto;[\s\S]*?margin-top:\s*auto;/);
+    expect(content).toMatch(/\.drawerBrandVersion\s*\{/);
+    expect(content).not.toMatch(/\.brandVersion\s*\{/);
+  });
+
+  it("lets the project tree fill the sidebar space above the footer", async () => {
     const content = await readSfc("../App.vue", import.meta.url);
 
-    expect(content).toMatch(/class="brand"/);
-    expect(content).toMatch(/class="brandVersion"/);
-    expect(content).toContain("v{{ appVersion }}");
-    expect(content).toMatch(/\.brandVersion\s*\{/);
+    expect(content).toMatch(/\.projectTree\s*\{[\s\S]*?flex:\s*1 1 auto;[\s\S]*?height:\s*auto;/);
+    expect(content).toMatch(
+      /\.left\.mobileDrawer \.drawerFooter\s*\{[\s\S]*?padding-bottom:\s*calc\(4px \+ env\(safe-area-inset-bottom, 0px\)\);/,
+    );
   });
 });

--- a/client/src/__tests__/mobile-typography.test.ts
+++ b/client/src/__tests__/mobile-typography.test.ts
@@ -43,7 +43,7 @@ describe("mobile typography", () => {
   it("raises mobile App chrome microcopy to the minimum readable size", () => {
     const css = readUtf8("../App.css");
 
-    expect(css).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.brandVersion,[\s\S]*?font-size:\s*12px\s*;/);
+    expect(css).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.drawerBrandVersion,[\s\S]*?font-size:\s*12px\s*;/);
     expect(css).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.projectBranch,[\s\S]*?font-size:\s*12px\s*;/);
     expect(css).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.mobileContextActionHint[\s\S]*?font-size:\s*12px\s*;/);
   });

--- a/client/src/lib/composer_inspection.test.ts
+++ b/client/src/lib/composer_inspection.test.ts
@@ -15,7 +15,7 @@ describe("temporary composer inspection", () => {
     vi.useFakeTimers();
     vi.stubGlobal("matchMedia", () => ({ matches: false }));
     vi.stubGlobal("fetch", vi.fn());
-    document.body.innerHTML = '<div class="app"><span class="brandVersion">v0.2.5</span><div class="detail"><div class="composer"><div class="inputWrap"><div class="composerMainRow"><textarea class="composer-input"></textarea><button data-testid="composer-actions-toggle" aria-expanded="false">+</button></div></div></div></div></div>';
+    document.body.innerHTML = '<div class="app"><span class="drawerBrandVersion">v0.2.5</span><div class="detail"><div class="composer"><div class="inputWrap"><div class="composerMainRow"><textarea class="composer-input"></textarea><button data-testid="composer-actions-toggle" aria-expanded="false">+</button></div></div></div></div></div>';
     vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue(new DOMRect(20, 200, 260, 34));
     document.elementFromPoint = vi.fn(() => document.querySelector("button"));
   });


### PR DESCRIPTION
Closes #196

## Summary
- remove the ADS brand and version badge from the topbar
- render the brand and version in a footer shared by the desktop sidebar and mobile drawer
- keep the project tree flexible and respect the mobile bottom safe area
- update brand, typography, and inspection regression coverage

## Verification
- npm run lint
- npm run build
- npm run test:web (519 tests)
- env CODEX_HOME=/tmp ADS_MEMORY_INJECTION_ENABLED=false npm test (730 tests)
- git diff --check