### PR TITLE
fix(ui): remove verbose inline hint text from mobile context menu

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -855,28 +855,23 @@
     right: 8px;
     display: flex;
     flex-direction: column;
-    width: min(250px, calc(100vw - 24px));
-    padding: 7px;
+    width: max-content;
+    min-width: 140px;
+    max-width: calc(100vw - 24px);
+    padding: 6px;
     border: 1px solid var(--border);
     border-radius: 13px;
     background: var(--surface);
     box-shadow: 0 18px 42px rgba(15, 23, 42, 0.18);
     z-index: 140;
   }
-  .mobileContextMenuTitle {
-    padding: 6px 10px 7px;
-    color: var(--muted);
-    font-size: 11px;
-    font-weight: 800;
-  }
   .mobileContextAction {
     display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 10px;
+    align-items: center;
+    justify-content: flex-start;
     width: 100%;
-    min-height: 42px;
-    padding: 10px;
+    min-height: 40px;
+    padding: 8px 10px;
     border: none;
     border-radius: 9px;
     background: transparent;
@@ -884,6 +879,7 @@
     text-align: left;
     font-size: 13px;
     font-weight: 700;
+    white-space: nowrap;
     cursor: pointer;
   }
   .mobileContextAction:hover:not(:disabled) {
@@ -892,15 +888,8 @@
   }
   .mobileContextAction:disabled {
     color: var(--muted-2);
+    opacity: 0.72;
     cursor: not-allowed;
-  }
-  .mobileContextActionHint {
-    max-width: 130px;
-    color: var(--muted-2);
-    font-size: 10px;
-    font-weight: 500;
-    line-height: 1.35;
-    text-align: right;
   }
   .left {
     display: none;
@@ -1153,8 +1142,6 @@
 @media (max-width: 768px) {
   .drawerBrandVersion,
   .projectBranch,
-  .mobileContextMenuTitle,
-  .mobileContextActionHint,
   .mobileDrawerSubitemText small {
     font-size: 12px;
   }

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -284,12 +284,6 @@ const sessionResumeDisabledReason = computed(() => {
   return "";
 });
 
-const newSessionDisabledReason = computed(() => {
-  if (activeLaneBusy.value) return "当前对话正在生成，结束后才能新建会话";
-  if (activeLaneNewSessionBlocked.value) return "当前 Advisor 尚未连接，暂时无法新建会话";
-  return "";
-});
-
 const mobileContextTitle = computed(() => {
   if (mobileDrawerSection.value === "settings") return "系统设置";
   return activeProject.value?.name?.trim() || "项目";
@@ -375,6 +369,11 @@ function toggleMobileContextMenu(): void {
 }
 
 function handleMobileContextAction(actionId: MobileContextActionId): void {
+  const action = mobileContextActions.value.find((item) => item.id === actionId);
+  if (action?.disabled) {
+    closeMobileContextMenu();
+    return;
+  }
   closeMobileContextMenu();
   if (actionId === "resume") {
     closeMobileDrawer();
@@ -613,7 +612,6 @@ const plannerConnectionStatus = computed(() => {
         data-testid="mobile-context-menu"
         @click.stop
       >
-        <div class="mobileContextMenuTitle">{{ mobileContextMenuTitle }}</div>
         <button
           v-for="action in mobileContextActions"
           :key="action.id"
@@ -625,13 +623,6 @@ const plannerConnectionStatus = computed(() => {
           @click="handleMobileContextAction(action.id)"
         >
           <span>{{ action.label }}</span>
-          <span v-if="action.disabled" class="mobileContextActionHint">
-            {{
-              action.id === "resume"
-                ? sessionResumeDisabledReason
-                : newSessionDisabledReason
-            }}
-          </span>
         </button>
       </div>
     </header>

--- a/client/src/__tests__/mobile-navigation-behavior.test.ts
+++ b/client/src/__tests__/mobile-navigation-behavior.test.ts
@@ -185,6 +185,46 @@ describe("mobile navigation behavior", () => {
     wrapper.unmount();
   }, 40_000);
 
+  it("keeps disabled context actions compact and hint-free", async () => {
+    const App = (await import("../App.vue")).default;
+    const wrapper = shallowMount(App, {
+      global: {
+        stubs: {
+          LoginGate: false,
+          MainChatView: false,
+          ModelManager: ModelManagerStub,
+          DraggableModal: true,
+        },
+      },
+    });
+    await settleUi(wrapper);
+
+    const plannerRuntime = (wrapper.vm as any).activePlannerRuntime as {
+      busy: { value: boolean };
+      connected: { value: boolean };
+    };
+    plannerRuntime.busy.value = true;
+    await settleUi(wrapper);
+    await wrapper.find('[data-testid="mobile-context-menu-toggle"]').trigger("click");
+
+    const menu = wrapper.find('[data-testid="mobile-context-menu"]');
+    const actions = menu.findAll("button.mobileContextAction");
+    expect(menu.attributes("aria-label")).toBe("项目操作");
+    expect(menu.find(".mobileContextMenuTitle").exists()).toBe(false);
+    expect(menu.findAll(".mobileContextActionHint")).toHaveLength(0);
+    expect(actions).toHaveLength(2);
+    expect(actions.every((action) => (action.element as HTMLButtonElement).disabled)).toBe(true);
+
+    plannerRuntime.busy.value = false;
+    plannerRuntime.connected.value = false;
+    await settleUi(wrapper);
+    expect((menu.find('[data-testid="mobile-context-action-resume"]').element as HTMLButtonElement).disabled).toBe(false);
+    expect((menu.find('[data-testid="mobile-context-action-new-session"]').element as HTMLButtonElement).disabled).toBe(true);
+    expect(menu.findAll(".mobileContextActionHint")).toHaveLength(0);
+
+    wrapper.unmount();
+  }, 40_000);
+
   it("restores the last tab independently for each project", async () => {
     projectsResponse = {
       projects: [

--- a/client/src/__tests__/mobile-typography.test.ts
+++ b/client/src/__tests__/mobile-typography.test.ts
@@ -45,6 +45,23 @@ describe("mobile typography", () => {
 
     expect(css).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.drawerBrandVersion,[\s\S]*?font-size:\s*12px\s*;/);
     expect(css).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.projectBranch,[\s\S]*?font-size:\s*12px\s*;/);
-    expect(css).toMatch(/@media\s*\(max-width:\s*768px\)[\s\S]*?\.mobileContextActionHint[\s\S]*?font-size:\s*12px\s*;/);
+  });
+
+  it("keeps mobile context actions compact without inline hint text", () => {
+    const css = readUtf8("../App.css");
+    const mobileCss = css.slice(css.indexOf("@media (max-width: 900px)"));
+    const menu = mobileCss.match(/\.mobileContextMenu\s*\{[^}]*\}/)?.[0];
+    const action = mobileCss.match(/\.mobileContextAction\s*\{[^}]*\}/)?.[0];
+    const disabled = mobileCss.match(/\.mobileContextAction:disabled\s*\{[^}]*\}/)?.[0];
+
+    expect(menu).toMatch(/width:\s*max-content\s*;/);
+    expect(menu).toMatch(/min-width:\s*140px\s*;/);
+    expect(menu).toMatch(/max-width:\s*calc\(100vw - 24px\)\s*;/);
+    expect(action).toMatch(/align-items:\s*center\s*;/);
+    expect(action).toMatch(/min-height:\s*40px\s*;/);
+    expect(disabled).toMatch(/opacity:\s*0\.72\s*;/);
+    expect(disabled).toMatch(/cursor:\s*not-allowed\s*;/);
+    expect(css).not.toMatch(/\.mobileContextMenuTitle\s*\{/);
+    expect(css).not.toMatch(/\.mobileContextActionHint\s*\{/);
   });
 });


### PR DESCRIPTION
## Summary
- remove verbose disabled hint paragraphs from the mobile context menu
- keep the detailed resume reason in the session picker and guard disabled actions
- compact and normalize mobile menu styling with regression coverage

## Verification
- npm run lint
- npm run build
- npm run test:web
- npm test

Closes #195